### PR TITLE
fix: catch truncation errors when setting the display name

### DIFF
--- a/ts/components/registration/stages/CreateAccount.tsx
+++ b/ts/components/registration/stages/CreateAccount.tsx
@@ -33,6 +33,7 @@ import { resetRegistration } from '../RegistrationStages';
 import { ContinueButton, OnboardDescription, OnboardHeading } from '../components';
 import { BackButtonWithinContainer } from '../components/BackButton';
 import { displayNameIsValid, sanitizeDisplayNameOrToast } from '../utils';
+import { localize } from '../../../util/i18n/localizedString';
 
 export type AccountDetails = {
   recoveryPassword: string;
@@ -106,9 +107,21 @@ export const CreateAccount = () => {
         `[onboarding] create account: signUpWithDetails failed! Error: ${err.message || String(err)}`
       );
       dispatch(setAccountCreationStep(AccountCreation.DisplayName));
-      // Note: we have to assume here that libsession threw an error because the name was too long.
+
+      switch (err.message) {
+        case 'failed to retrieve display name after setting it':
+          dispatch(setDisplayNameError(localize('displayNameErrorDescription').toString()));
+          return;
+        case 'failed to get truncated displayName after setting it':
+          dispatch(setDisplayNameError(localize('displayNameErrorDescription').toString()));
+          return;
+        default:
+        // we can't guarantee that an error has a message so we handle the final case outside of the switch
+      }
+
+      // Note: we have to assume here that libsession threw an error because the name was too long since we covered the other cases.
       // The error reported by libsession is not localized
-      dispatch(setDisplayNameError(window.i18n('displayNameErrorDescriptionShorter')));
+      dispatch(setDisplayNameError(localize('displayNameErrorDescriptionShorter').toString()));
     }
   };
 

--- a/ts/components/registration/stages/CreateAccount.tsx
+++ b/ts/components/registration/stages/CreateAccount.tsx
@@ -34,6 +34,7 @@ import { ContinueButton, OnboardDescription, OnboardHeading } from '../component
 import { BackButtonWithinContainer } from '../components/BackButton';
 import { displayNameIsValid, sanitizeDisplayNameOrToast } from '../utils';
 import { localize } from '../../../util/i18n/localizedString';
+import { RetrieveDisplayNameError } from '../../../session/utils/errors';
 
 export type AccountDetails = {
   recoveryPassword: string;
@@ -108,15 +109,9 @@ export const CreateAccount = () => {
       );
       dispatch(setAccountCreationStep(AccountCreation.DisplayName));
 
-      switch (err.message) {
-        case 'failed to retrieve display name after setting it':
-          dispatch(setDisplayNameError(localize('displayNameErrorDescription').toString()));
-          return;
-        case 'failed to get truncated displayName after setting it':
-          dispatch(setDisplayNameError(localize('displayNameErrorDescription').toString()));
-          return;
-        default:
-        // we can't guarantee that an error has a message so we handle the final case outside of the switch
+      if (err instanceof RetrieveDisplayNameError) {
+        dispatch(setDisplayNameError(localize('displayNameErrorDescription').toString()));
+        return;
       }
 
       // Note: we have to assume here that libsession threw an error because the name was too long since we covered the other cases.

--- a/ts/components/registration/stages/RestoreAccount.tsx
+++ b/ts/components/registration/stages/RestoreAccount.tsx
@@ -6,7 +6,7 @@ import { InvalidWordsError, NotEnoughWordsError } from '../../../session/crypto/
 import { ProfileManager } from '../../../session/profile_manager/ProfileManager';
 import { PromiseUtils } from '../../../session/utils';
 import { TaskTimedOutError } from '../../../session/utils/Promise';
-import { NotFoundError } from '../../../session/utils/errors';
+import { NotFoundError, RetrieveDisplayNameError } from '../../../session/utils/errors';
 import { trigger } from '../../../shims/events';
 import {
   AccountRestoration,
@@ -198,15 +198,9 @@ export const RestoreAccount = () => {
       );
       dispatch(setAccountRestorationStep(AccountRestoration.DisplayName));
 
-      switch (err.message) {
-        case 'failed to retrieve display name after setting it':
-          dispatch(setDisplayNameError(localize('displayNameErrorDescription').toString()));
-          return;
-        case 'failed to get truncated displayName after setting it':
-          dispatch(setDisplayNameError(localize('displayNameErrorDescription').toString()));
-          return;
-        default:
-        // we can't guarantee that an error has a message so we handle the final case outside of the switch
+      if (err instanceof RetrieveDisplayNameError) {
+        dispatch(setDisplayNameError(localize('displayNameErrorDescription').toString()));
+        return;
       }
 
       // Note: we have to assume here that libsession threw an error because the name was too long since we covered the other cases.

--- a/ts/components/registration/stages/RestoreAccount.tsx
+++ b/ts/components/registration/stages/RestoreAccount.tsx
@@ -43,6 +43,7 @@ import { BackButtonWithinContainer } from '../components/BackButton';
 import { useRecoveryProgressEffect } from '../hooks';
 import { displayNameIsValid, sanitizeDisplayNameOrToast } from '../utils';
 import { AccountDetails } from './CreateAccount';
+import { localize } from '../../../util/i18n/localizedString';
 
 type AccountRestoreDetails = AccountDetails & { dispatch: Dispatch; abortSignal?: AbortSignal };
 
@@ -197,9 +198,20 @@ export const RestoreAccount = () => {
       );
       dispatch(setAccountRestorationStep(AccountRestoration.DisplayName));
 
-      // Note: we have to assume here that libsession threw an error because the name was too long.
+      switch (err.message) {
+        case 'failed to retrieve display name after setting it':
+          dispatch(setDisplayNameError(localize('displayNameErrorDescription').toString()));
+          return;
+        case 'failed to get truncated displayName after setting it':
+          dispatch(setDisplayNameError(localize('displayNameErrorDescription').toString()));
+          return;
+        default:
+        // we can't guarantee that an error has a message so we handle the final case outside of the switch
+      }
+
+      // Note: we have to assume here that libsession threw an error because the name was too long since we covered the other cases.
       // The error reported by libsession is not localized
-      dispatch(setDisplayNameError(window.i18n('displayNameErrorDescriptionShorter')));
+      dispatch(setDisplayNameError(localize('displayNameErrorDescriptionShorter').toString()));
     }
   };
 

--- a/ts/session/profile_manager/ProfileManager.ts
+++ b/ts/session/profile_manager/ProfileManager.ts
@@ -6,6 +6,7 @@ import { SyncUtils, UserUtils } from '../utils';
 import { fromHexToArray, sanitizeSessionUsername, toHex } from '../utils/String';
 import { AvatarDownload } from '../utils/job_runners/jobs/AvatarDownloadJob';
 import { CONVERSATION_PRIORITIES, ConversationTypeEnum } from '../../models/types';
+import { RetrieveDisplayNameError } from '../utils/errors';
 
 export type Profile = {
   displayName: string | undefined;
@@ -115,7 +116,7 @@ async function updateOurProfileDisplayNameOnboarding(newName: string) {
     const appliedName = await UserConfigWrapperActions.getName();
 
     if (isNil(appliedName)) {
-      throw new Error('failed to retrieve display name after setting it');
+      throw new RetrieveDisplayNameError();
     }
 
     return appliedName;
@@ -141,7 +142,7 @@ async function updateOurProfileDisplayName(newName: string) {
   await UserConfigWrapperActions.setNameTruncated(sanitizeSessionUsername(newName).trim());
   const truncatedName = await UserConfigWrapperActions.getName();
   if (isNil(truncatedName)) {
-    throw new Error('failed to get truncated displayName after setting it');
+    throw new RetrieveDisplayNameError();
   }
   await UserConfigWrapperActions.setPriority(dbPriority);
   if (dbProfileUrl && !isEmpty(dbProfileKey)) {

--- a/ts/session/profile_manager/ProfileManager.ts
+++ b/ts/session/profile_manager/ProfileManager.ts
@@ -115,9 +115,7 @@ async function updateOurProfileDisplayNameOnboarding(newName: string) {
     const appliedName = await UserConfigWrapperActions.getName();
 
     if (isNil(appliedName)) {
-      throw new Error(
-        'updateOurProfileDisplayNameOnboarding failed to retrieve name after setting it'
-      );
+      throw new Error('failed to retrieve display name after setting it');
     }
 
     return appliedName;
@@ -143,7 +141,7 @@ async function updateOurProfileDisplayName(newName: string) {
   await UserConfigWrapperActions.setNameTruncated(sanitizeSessionUsername(newName).trim());
   const truncatedName = await UserConfigWrapperActions.getName();
   if (isNil(truncatedName)) {
-    throw new Error('updateOurProfileDisplayName: failed to get truncated displayName back');
+    throw new Error('failed to get truncated displayName after setting it');
   }
   await UserConfigWrapperActions.setPriority(dbPriority);
   if (dbProfileUrl && !isEmpty(dbProfileKey)) {

--- a/ts/session/utils/errors.ts
+++ b/ts/session/utils/errors.ts
@@ -74,3 +74,11 @@ export class SnodeResponseError extends Error {
     Object.setPrototypeOf(this, SnodeResponseError.prototype);
   }
 }
+
+export class RetrieveDisplayNameError extends Error {
+  constructor(message = 'failed to retrieve display name after setting it') {
+    super(message);
+    // restore prototype chain
+    Object.setPrototypeOf(this, SnodeResponseError.prototype);
+  }
+}


### PR DESCRIPTION
Fixes incorrectly showing shorter display name error in integration tests.