### PR TITLE
Fix: Did a bunch of nice to haves for strings

### DIFF
--- a/ts/components/conversation/message/message-content/MessageContextMenu.tsx
+++ b/ts/components/conversation/message/message-content/MessageContextMenu.tsx
@@ -363,7 +363,7 @@ export const MessageContextMenu = (props: Props) => {
           <RetryItem messageId={messageId} />
           {isDeletable ? (
             <ItemWithDataTestId onClick={onSelect}>
-              <Localizer token="messageSelect" />
+              <Localizer token="select" />
             </ItemWithDataTestId>
           ) : null}
           <DeleteItem messageId={messageId} />

--- a/ts/components/dialog/SessionSetPasswordDialog.tsx
+++ b/ts/components/dialog/SessionSetPasswordDialog.tsx
@@ -76,7 +76,7 @@ export class SessionSetPasswordDialog extends Component<Props, State> {
     }
 
     const confirmButtonText =
-      passwordAction === 'remove' ? window.i18n('remove') : window.i18n('done');
+      passwordAction === 'remove' ? window.i18n('remove') : window.i18n('save');
 
     const titleString = () => {
       switch (passwordAction) {
@@ -186,9 +186,12 @@ export class SessionSetPasswordDialog extends Component<Props, State> {
     // if user did not fill the first password field, we can't do anything
     const errorFirstInput = validatePassword(enteredPassword);
     if (errorFirstInput !== null) {
-      this.setState({
-        error: errorFirstInput,
-      });
+      this.setState(
+        {
+          error: errorFirstInput,
+        },
+        () => this.showError()
+      );
       this.showError();
       return false;
     }

--- a/ts/components/leftpane/MessageRequestsBanner.tsx
+++ b/ts/components/leftpane/MessageRequestsBanner.tsx
@@ -62,10 +62,10 @@ const StyledGridContainer = styled.div`
   justify-content: center;
   align-items: center;
   border-radius: 50%;
-  background-color: var(--text-secondary-color);
+  background-color: var(--primary-color);
 `;
 
-export const CirclularIcon = (props: {
+export const CircularIcon = (props: {
   iconType: SessionIconType;
   iconSize: SessionIconSize | number;
 }) => {
@@ -120,7 +120,7 @@ export const MessageRequestsBanner = (props: { handleOnClick: () => any }) => {
         }}
         data-testid="message-request-banner"
       >
-        <CirclularIcon iconType="messageRequest" iconSize={22} />
+        <CircularIcon iconType="messageRequest" iconSize={22} />
         <StyledMessageRequestBannerHeader>
           <Localizer token="sessionMessageRequests" />
         </StyledMessageRequestBannerHeader>

--- a/ts/components/leftpane/overlay/OverlayMessage.tsx
+++ b/ts/components/leftpane/overlay/OverlayMessage.tsx
@@ -193,8 +193,8 @@ export const OverlayMessage = () => {
 
       {!isEmpty(pubkeyOrOns) ? (
         <SessionButton
-          ariaLabel={window.i18n('theContinue')}
-          text={window.i18n('theContinue')}
+          ariaLabel={window.i18n('next')}
+          text={window.i18n('next')}
           disabled={disableNextButton}
           onClick={handleMessageButtonClick}
           dataTestId="next-new-conversation-button"

--- a/ts/components/settings/section/CategoryPrivacy.tsx
+++ b/ts/components/settings/section/CategoryPrivacy.tsx
@@ -130,6 +130,7 @@ export const SettingsCategoryPrivacy = (props: {
             dataTestId="change-password-settings-button"
           />
           <SessionSettingButtonItem
+            title={window.i18n('passwordRemove')}
             description={window.i18n('passwordRemoveDescription')}
             onClick={() => {
               displayPasswordModal('remove', props.onPasswordUpdated);


### PR DESCRIPTION
Fixed:
https://optf.atlassian.net/browse/SES-2758 - 'Continue' button -> 'Next' button
https://optf.atlassian.net/browse/SES-2760 - Change password modal button from Done to Save
https://optf.atlassian.net/browse/SES-2762 - Error message toast only showing up on second click for Set Password modal
https://optf.atlassian.net/browse/SES-2763 - Remove Password as section heading to be added
https://optf.atlassian.net/browse/SES-2765 - Message context menu - 'Select message' to be replaced with 'Select'
https://optf.atlassian.net/browse/SES-2495 - Updated Message Request banner icon to be primary color



