### PR TITLE
fix: dont load empty info in the debug about info

### DIFF
--- a/ts/components/dialog/debug/components.tsx
+++ b/ts/components/dialog/debug/components.tsx
@@ -248,18 +248,23 @@ export const AboutInfo = () => {
         alignItems="center"
         flexGap="var(--margins-xs)"
       >
-        {aboutInfo.map((info, index) => (
-          <Flex
-            key={`debug-about-info-${index}`}
-            container={true}
-            width="100%"
-            alignItems="flex-start"
-            flexGap="var(--margins-xs)"
-          >
-            <p style={{ userSelect: 'text', lineHeight: 1.5 }}>{info}</p>
-            <CopyToClipboardIcon iconSize={'medium'} copyContent={info} />
-          </Flex>
-        ))}
+        {aboutInfo.map((info, index) => {
+          if (!info) {
+            return null;
+          }
+          return (
+            <Flex
+              key={`debug-about-info-${index}`}
+              container={true}
+              width="100%"
+              alignItems="flex-start"
+              flexGap="var(--margins-xs)"
+            >
+              <p style={{ userSelect: 'text', lineHeight: 1.5 }}>{info}</p>
+              <CopyToClipboardIcon iconSize={'medium'} copyContent={info} />
+            </Flex>
+          );
+        })}
         <SpacerXS />
       </Flex>
     </Flex>


### PR DESCRIPTION
we dont have an environment when running in production

![image](https://github.com/user-attachments/assets/9c9c929c-fffc-4dc1-849e-2448117400f0)
