### PR TITLE
fix: build rpm with _build_id_links none to avoid file conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -229,6 +229,12 @@
         "nsis"
       ]
     },
+    "rpm": {
+      "fpm": [
+        "--rpm-rpmbuild-define",
+        "_build_id_links none"
+      ]
+    },
     "nsis": {
       "deleteAppDataOnUninstall": true,
       "oneClick": false,


### PR DESCRIPTION
Relates  https://github.com/session-foundation/session-desktop/issues/1362