### PR TITLE
Add macOS aarch64 build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "build": "nvm install && nvm use && yarn install --frozen-lockfile && yarn build-everything"
+  }
+}

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -221,6 +221,13 @@ jobs:
           architecture: arm64
           should_publish: ${{ env.SHOULD_PUBLISH == 'true' || env.SHOULD_PUBLISH_ALPHA == 'true' }}
 
+      - name: Upload artefacts
+        # always run this, except on "push" to "master" or alpha releases
+        if: ${{ env.SHOULD_PUBLISH == 'false' && env.SHOULD_PUBLISH_ALPHA == 'false'  }}
+        uses: ./actions/upload_prod_artefacts
+        with:
+          upload_prefix: mac-arm64
+
   build_mac_x64:
     runs-on: macos-13
     env:

--- a/actions/make_release_build/action.yml
+++ b/actions/make_release_build/action.yml
@@ -5,6 +5,10 @@ inputs:
   architecture:
     description: 'cpu architecture'
     required: true
+    default: 'x64'
+    options:
+      - x64
+      - arm64
   should_publish:
     description: 'should publish'
     required: true


### PR DESCRIPTION
of note is that copilot indicAted macos 13 is for intel and macos 14 is for aarch64

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/session-foundation/session-desktop/pull/1398?shareId=c86148bb-39a2-442f-8f9c-4a17852c53b0).