### PR TITLE
Release 1.16.1 [hotfix]

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "session-desktop",
   "productName": "Session",
   "description": "Private messaging from your desktop",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "license": "GPL-3.0",
   "author": {
     "name": "Session Foundation",

--- a/ts/session/apis/seed_node_api/SeedNodeAPI.ts
+++ b/ts/session/apis/seed_node_api/SeedNodeAPI.ts
@@ -294,9 +294,9 @@ async function getSnodesFromSeedUrl(urlObj: URL): Promise<Array<any>> {
       );
       throw new Error(`getSnodesFromSeedUrl: json.result is empty from ${urlObj.href}`);
     }
-    // Filter 0.0.0.0 nodes which haven't submitted uptime proofs
+    // NOTE Filter out nodes that have missing ip addresses since they are not valid or 0.0.0.0 nodes which haven't submitted uptime proofs
     const validNodes = result.service_node_states.filter(
-      (snode: any) => snode.public_ip !== '0.0.0.0'
+      (snode: any) => snode.public_ip && snode.public_ip !== '0.0.0.0'
     );
 
     if (validNodes.length === 0) {

--- a/ts/session/apis/snode_api/getServiceNodesList.ts
+++ b/ts/session/apis/snode_api/getServiceNodesList.ts
@@ -39,9 +39,9 @@ async function getSnodePoolFromSnode(targetNode: Snode): Promise<Array<Snode>> {
       return [];
     }
 
-    // Filter 0.0.0.0 nodes which haven't submitted uptime proofs
+    // NOTE Filter out nodes that have missing ip addresses since they are not valid or 0.0.0.0 nodes which haven't submitted uptime proofs
     const snodes: Array<Snode> = json.result.service_node_states
-      .filter((snode: any) => snode.public_ip !== '0.0.0.0')
+      .filter((snode: any) => snode.public_ip && snode.public_ip !== '0.0.0.0')
       .map((snode: any) => ({
         ip: snode.public_ip,
         port: snode.storage_port,
@@ -95,7 +95,7 @@ async function getSnodePoolFromSnodes() {
     })
   );
 
-  // we want those at least `requiredSnodesForAgreement` snodes common between all the result
+  // we want those at least `requiredSnodesForAgreement` snodes common between all the results
   const commonSnodes = intersectionWith(
     results[0],
     results[1],

--- a/ts/session/apis/snode_api/getSwarmFor.ts
+++ b/ts/session/apis/snode_api/getSwarmFor.ts
@@ -55,6 +55,7 @@ async function requestSnodesForPubkeyWithTargetNodeRetryable(
       throw new Error('requestSnodesForPubkey: Invalid json (empty)');
     }
 
+    // NOTE Filter out 0.0.0.0 nodes which haven't submitted uptime proofs
     const snodes = body.snodes.filter((tSnode: any) => tSnode.ip !== '0.0.0.0');
     GetNetworkTime.handleTimestampOffsetFromNetwork('get_swarm', body.t);
     return snodes;

--- a/ts/session/utils/errors.ts
+++ b/ts/session/utils/errors.ts
@@ -81,6 +81,8 @@ class BaseError extends Error {
   }
 }
 
+// NOTE If you make a custom error with a custom message, make sure to restore the prototype chain again using the new class prototype.
+// OTHERWISE instanceof CHECKS WILL BE FALSE
 export class SigningFailed extends BaseError {}
 export class InvalidSigningType extends BaseError {}
 export class GroupV2SigningFailed extends SigningFailed {}
@@ -99,10 +101,15 @@ export class RetrieveDisplayNameError extends BaseError {
     Object.setPrototypeOf(this, RetrieveDisplayNameError.prototype);
   }
 }
-
 export class EmptyDisplayNameError extends BaseError {
   constructor(message = 'display name is empty') {
     super(message);
     Object.setPrototypeOf(this, EmptyDisplayNameError.prototype);
+  }
+}
+export class OnionPathEmptyError extends BaseError {
+  constructor(message = 'onion path is empty') {
+    super(message);
+    Object.setPrototypeOf(this, OnionPathEmptyError.prototype);
   }
 }


### PR DESCRIPTION
## Fixes for onion path building.

- If any services nodes in our snode pool have invalid `public_ip` we want to remove them. If we have no snodes to create an onion path then we want to force a refresh of the snodepool from seed.
- Introduced a new custom error class `OnionPathEmptyError` to handle cases where onion paths are unavailable, replacing generic error messages