### PR TITLE
fix: show the outgoing message request content in the side bar

### DIFF
--- a/ts/components/leftpane/conversation-list-item/MessageItem.tsx
+++ b/ts/components/leftpane/conversation-list-item/MessageItem.tsx
@@ -4,7 +4,6 @@ import clsx from 'clsx';
 import { useConvoIdFromContext } from '../../../contexts/ConvoIdContext';
 import {
   useHasUnread,
-  useIsOutgoingRequest,
   useIsPrivate,
   useIsTyping,
   useLastMessage,
@@ -26,13 +25,8 @@ export const MessageItem = () => {
   const hasUnread = useHasUnread(conversationId);
   const isConvoTyping = useIsTyping(conversationId);
   const isMessageRequest = useIsMessageRequestOverlayShown();
-  const isOutgoingRequest = useIsOutgoingRequest(conversationId);
 
   const isSearching = useIsSearchingForType('global');
-
-  if (isOutgoingRequest) {
-    return null;
-  }
 
   if (lastMessage?.interactionType && lastMessage?.interactionStatus) {
     return <InteractionItem conversationId={conversationId} lastMessage={lastMessage} />;


### PR DESCRIPTION
Fixes an issue where the outgoing message request content isn't shown in the left panel.

**Problem Example:**
![image](https://github.com/user-attachments/assets/788c0f67-ad7b-4d64-9904-4d2e08e4b988)
 