### PR TITLE
fix: small gap between staged attachments

### DIFF
--- a/ts/components/conversation/StagedAttachmentList.tsx
+++ b/ts/components/conversation/StagedAttachmentList.tsx
@@ -29,6 +29,8 @@ const IMAGE_WIDTH = 120;
 const IMAGE_HEIGHT = 120;
 
 const StyledRail = styled.div`
+  display: flex;
+  gap: var(--margins-xs);
   margin-top: 12px;
   margin-inline-start: 16px;
   padding-inline-end: 16px;

--- a/ts/components/conversation/StagedPlaceholderAttachment.tsx
+++ b/ts/components/conversation/StagedPlaceholderAttachment.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 const StyledStagedPlaceholderAttachment = styled.div`
-  margin: 1px var(--margins-sm);
+  margin: 1px 0;
   border-radius: var(--border-radius-message-box);
   border: 1px solid var(--border-color);
   height: 120px;


### PR DESCRIPTION
Added a small gap between the staged attachement

![image](https://github.com/user-attachments/assets/c49490a9-41fd-461b-a10d-afc313bf96d6)
