### PR TITLE
fix: sending attachments to the wrong conversation

### DIFF
--- a/ts/components/conversation/SessionConversation.tsx
+++ b/ts/components/conversation/SessionConversation.tsx
@@ -202,8 +202,11 @@ export class SessionConversation extends Component<Props, State> {
   }
 
   public sendMessageFn(msg: SendMessageType) {
-    const { selectedConversationKey } = this.props;
-    const conversationModel = ConvoHub.use().get(selectedConversationKey);
+    if (!msg.conversationId) {
+      return;
+    }
+
+    const conversationModel = ConvoHub.use().get(msg.conversationId);
 
     if (!conversationModel) {
       return;

--- a/ts/components/conversation/composition/CompositionBox.tsx
+++ b/ts/components/conversation/composition/CompositionBox.tsx
@@ -89,6 +89,7 @@ export interface StagedAttachmentType extends AttachmentType {
 }
 
 export type SendMessageType = {
+  conversationId: string;
   body: string;
   attachments: Array<StagedAttachmentImportedType> | undefined;
   quote: any | undefined;
@@ -709,15 +710,28 @@ class CompositionBoxInner extends Component<Props, State> {
   }
 
   private async onSendMessage() {
-    if (!this.props.selectedConversationKey) {
+    const {
+      selectedConversationKey,
+      selectedConversation,
+      stagedAttachments,
+      quotedMessageProps,
+      weAreProUser: hasPro,
+    } = this.props;
+
+    const { stagedLinkPreview } = this.state;
+
+    if (!selectedConversationKey) {
       throw new Error('selectedConversationKey is needed');
     }
+
+    if (!selectedConversation) {
+      return;
+    }
+
     this.linkPreviewAbortController?.abort();
 
     const isProAvailable = getFeatureFlag('proAvailable');
 
-    // TODO: get pro status from store once available
-    const hasPro = this.props.weAreProUser;
     const charLimit = hasPro
       ? Constants.CONVERSATION.MAX_MESSAGE_CHAR_COUNT_PRO
       : Constants.CONVERSATION.MAX_MESSAGE_CHAR_COUNT_STANDARD;
@@ -749,19 +763,13 @@ class CompositionBoxInner extends Component<Props, State> {
       return;
     }
 
-    const { selectedConversation } = this.props;
-
-    if (!selectedConversation) {
-      return;
-    }
-
     if (selectedConversation.isBlocked) {
       ToastUtils.pushUnblockToSend();
       return;
     }
     // Verify message length
     const msgLen = text?.length || 0;
-    if (msgLen === 0 && this.props.stagedAttachments?.length === 0) {
+    if (msgLen === 0 && stagedAttachments?.length === 0) {
       return;
     }
 
@@ -769,10 +777,6 @@ class CompositionBoxInner extends Component<Props, State> {
       ToastUtils.pushYouLeftTheGroup();
       return;
     }
-
-    const { quotedMessageProps } = this.props;
-
-    const { stagedLinkPreview } = this.state;
 
     // Send message
     const extractedQuotedMessageProps = _.pick(
@@ -790,9 +794,10 @@ class CompositionBoxInner extends Component<Props, State> {
         : undefined;
 
     try {
-      const { attachments, previews } = await this.getFiles(linkPreview);
+      const { attachments, previews } = await this.getFiles(linkPreview, stagedAttachments);
 
       this.props.sendMessage({
+        conversationId: selectedConversationKey,
         body: text.trim(),
         attachments: attachments || [],
         quote: extractedQuotedMessageProps,
@@ -802,7 +807,7 @@ class CompositionBoxInner extends Component<Props, State> {
 
       window.inboxStore?.dispatch(
         removeAllStagedAttachmentsInConversation({
-          conversationId: this.props.selectedConversationKey,
+          conversationId: selectedConversationKey,
         })
       );
       // Empty composition box and stagedAttachments
@@ -814,7 +819,7 @@ class CompositionBoxInner extends Component<Props, State> {
         characterCount: 0,
       });
       updateDraftForConversation({
-        conversationKey: this.props.selectedConversationKey,
+        conversationKey: selectedConversationKey,
         draft: '',
       });
     } catch (e) {
@@ -826,13 +831,12 @@ class CompositionBoxInner extends Component<Props, State> {
   // This function is called right before sending a message, to gather really the
   // files content behind the staged attachments.
   private async getFiles(
-    linkPreview?: Pick<StagedLinkPreviewData, 'url' | 'title' | 'scaledDown'>
+    linkPreview?: Pick<StagedLinkPreviewData, 'url' | 'title' | 'scaledDown'>,
+    stagedAttachments: Array<StagedAttachmentType> = []
   ): Promise<{
     attachments: Array<StagedAttachmentImportedType>;
     previews: Array<StagedPreviewImportedType>;
   }> {
-    const { stagedAttachments } = this.props;
-
     let attachments: Array<StagedAttachmentImportedType> = [];
     let previews: Array<StagedPreviewImportedType> = [];
 
@@ -864,7 +868,8 @@ class CompositionBoxInner extends Component<Props, State> {
   }
 
   private async sendVoiceMessage(audioBlob: Blob) {
-    if (!this.state.showRecordingView) {
+    const { selectedConversationKey } = this.props;
+    if (!this.state.showRecordingView || !selectedConversationKey) {
       return;
     }
 
@@ -888,6 +893,7 @@ class CompositionBoxInner extends Component<Props, State> {
     };
 
     this.props.sendMessage({
+      conversationId: selectedConversationKey,
       body: '',
       attachments: [audioAttachment],
       preview: undefined,

--- a/ts/components/dialog/InviteContactsDialog.tsx
+++ b/ts/components/dialog/InviteContactsDialog.tsx
@@ -62,6 +62,7 @@ async function submitForOpenGroup(convoId: string, pubkeys: Array<string>) {
 
       if (privateConvo) {
         void privateConvo.sendMessage({
+          conversationId: convoId,
           body: '',
           attachments: undefined,
           groupInvitation,


### PR DESCRIPTION
* Added a `conversationId` field to the `SendMessageType` type and updated all places where messages are sent to include this field.
* Refactored `CompositionBoxInner` to destructure props and state variables at the start of methods.
* Updated the `getFiles` method to accept `stagedAttachments` as a parameter instead of relying on parent state props. 