### PR TITLE
fix: refactor f-strings to avoid backslash expressions in generateLocales

### DIFF
--- a/tools/localization/localeTypes.py
+++ b/tools/localization/localeTypes.py
@@ -138,7 +138,9 @@ def generate_type_object(locales):
               js_plural_object += "\n    },"
 
               all_locales_plurals.append(js_plural_object)
-            js_plural_object_container += f'  {wrapValue(key)}: {{\n{"\n".join(all_locales_plurals)}\n    args: {args_to_type(as_record_type_en)}\n  }},\n'
+            joined_plurals = "\n".join(all_locales_plurals)
+            js_plural_object_container += f'  {wrapValue(key)}: {{\n{joined_plurals}\n    args: {args_to_type(as_record_type_en)}\n  }},\n'
+
 
         else:
           extracted_vars_en = extract_vars(value_en)
@@ -153,7 +155,9 @@ def generate_type_object(locales):
               all_locales_strings.append(f'{wrapValue(locale.replace("_","-"))}: "{escape_str(value_en)}"')
 
           # print('key',key, " other_locales_replaced_values:", other_locales_replaced_values)
-          js_object += f'  {wrapValue(key)}: {{\n      {",\n      ".join(all_locales_strings)},\n      args: {args_to_type(as_record_type_en)}\n  }},\n'
+          joined_strings = ",\n      ".join(all_locales_strings)
+          js_object += f'  {wrapValue(key)}: {{\n      {joined_strings},\n      args: {args_to_type(as_record_type_en)}\n  }},\n'
+
 
     js_object += "}"
     js_plural_object_container += "}"


### PR DESCRIPTION
### Contributor checklist:

- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`dev`](https://github.com/session-foundation/session-desktop/tree/dev) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/session-foundation/session-desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Refactored Python f-strings in localeTypes.py to remove backslash (\) characters inside the curly braces of f-string expressions. Instead, multiline strings with newlines are constructed outside the f-string and then injected as variables. This avoids a Python SyntaxError related to backslashes in f-string expressions and ensures compatibility across Python versions.

By fixing the syntax errors in the locale generation scripts, the build process for localization files runs smoothly without interruptions. This enables developers to generate and update locale typings reliably, reducing friction when working on internationalization or language-related features. It eliminates blocking errors during builds, improving overall productivity and developer experience.

Before:
```
yarn build:locales
yarn run v1.22.22
$ python3 ./tools/localization/generateLocales.py --generate-types --print-problems --error-on-problems --error-old-dynamic-variables
Traceback (most recent call last):
  File "/home/javabudd/session/session-desktop/./tools/localization/generateLocales.py", line 20, in <module>
    from localization.localeTypes import generateLocalesType, generateLocalesMergedType
  File "/home/javabudd/session/session-desktop/tools/localization/localeTypes.py", line 141
    js_plural_object_container += f'  {wrapValue(key)}: {{\n{"\n".join(all_locales_plurals)}\n    args: {args_to_type(as_record_type_en)}\n  }},\n'
                                                                                                                                                   ^
SyntaxError: f-string expression part cannot include a backslash
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

After:
```
yarn build:locales
yarn run v1.22.22
$ python3 ./tools/localization/generateLocales.py --generate-types --print-problems --error-on-problems --error-old-dynamic-variables
[INFO] Locales generated at: ./ts/localization/locales.ts

--------------------------------------------------

+ Keys: Keys present in the master locale but missing in the locale
- Keys: Keys present in the locale but missing in the master locale
- Vars: Dynamic variables present in the master locale but missing in the locale
+ Vars: Dynamic variables present in the locale but missing in the master locale

Locale    + Keys    - Keys    - Vars    + Vars    
--------------------------------------------------
ar        121       0         0         0         
uz        188       0         0         0         
it        153       0         0         0         
vi        120       0         0         0         
cy        179       0         0         0         
fi        178       0         0         0         
be        189       0         0         0         
tl        188       0         0         0         
sv        115       0         0         0         
el        179       0         0         0         
ne        191       0         0         0         
eu        189       0         0         0         
mn        179       0         0         0         
ru        16        0         0         0         
pl        56        0         0         0         
xh        188       0         0         0         
ur        183       0         0         0         
es_419    150       0         0         0         
pt_PT     179       0         0         0         
nn        186       0         0         0         
pt_BR     178       0         0         0         
sk        188       0         0         0         
ja        158       0         0         0         
fil       189       0         0         0         
sq        189       0         0         0         
hr        189       0         0         0         
nl        60        0         0         0         
my        189       0         0         0         
cs        8         0         0         0         
az        28        0         0         0         
pa        189       0         0         0         
he        189       0         0         0         
sl        189       0         0         0         
ta        183       0         0         0         
ro        167       0         0         0         
th        188       0         0         0         
hu        41        0         0         0         
ko        56        0         0         0         
da        83        0         0         0         
no        186       0         0         0         
ha        189       0         0         0         
tr        28        0         0         0         
ny        189       0         0         0         
ps        189       0         0         0         
mk        189       0         0         0         
fr        37        0         0         0         
et        189       0         0         0         
zh_CN     74        0         0         0         
sw        188       0         0         0         
uk        8         0         0         0         
hi        112       0         0         0         
lg        189       0         0         0         
af        188       0         0         0         
kmr       174       0         0         0         
de        111       0         0         0         
ka        176       0         0         0         
sh        189       0         0         0         
eo        97        0         0         0         
te        188       0         0         0         
si        189       0         0         0         
bn        189       0         0         0         
hy_AM     189       0         0         0         
gl        266       0         0         0         
bal       189       0         0         0         
kn        189       0         0         0         
nb        185       0         0         0         
ku        187       0         0         0         
lv        237       0         0         0         
lo        713       0         0         0         
bg        189       0         0         0         
id        102       0         0         0         
sr_SP     189       0         0         0         
fa        190       0         0         0         
lt        186       0         0         0         
ms        179       0         0         0         
es        150       0         0         0         
zh_TW     179       0         0         0         
ca        42        0         0         0         
sr_CS     189       0         0         0         
km        189       0         0         0         
[WARN] There are issues with the locales. See above for details.
Elapsed time: 0.77 seconds
Missing keys: 12995
Done in 0.92s
```