### PR TITLE
fix: macos + needs shift to be accessible

### DIFF
--- a/ts/hooks/useZoomingShortcut.ts
+++ b/ts/hooks/useZoomingShortcut.ts
@@ -1,5 +1,6 @@
 import useKey from 'react-use/lib/useKey';
 import { ZOOM_FACTOR } from '../session/constants';
+import { isMacOS } from '../OS';
 
 const changeZoom = async (
   change: { typeOfChange: 'delta'; delta: number } | { typeOfChange: 'reset' }
@@ -20,7 +21,9 @@ const changeZoom = async (
 
 export function useZoomShortcuts() {
   useKey(
-    event => (event.ctrlKey || event.metaKey) && (event.key === '+' || event.key === '='),
+    event =>
+      // macos + is accessible through shift only, so we need to allow `=` for macos
+      (event.ctrlKey || event.metaKey) && (event.key === '+' || (isMacOS() && event.key === '=')),
     event => {
       event.preventDefault();
       void changeZoom({ typeOfChange: 'delta', delta: ZOOM_FACTOR.STEP });
@@ -28,7 +31,7 @@ export function useZoomShortcuts() {
   );
 
   useKey(
-    event => (event.ctrlKey || event.metaKey) && event.key === '-',
+    event => (event.ctrlKey || event.metaKey) && event.key === '-', // macos - is accessible without shift
     event => {
       event.preventDefault();
       void changeZoom({ typeOfChange: 'delta', delta: -ZOOM_FACTOR.STEP });


### PR DESCRIPTION
so we allow the = to be used a zoomin
