### PR TITLE
fix: use closest attachment index for context menu download

### DIFF
--- a/ts/components/conversation/message/message-content/MessageContextMenu.tsx
+++ b/ts/components/conversation/message/message-content/MessageContextMenu.tsx
@@ -80,9 +80,11 @@ export function showMessageContextMenu({
   // this is quite dirty but considering that we want the context menu of the message to show on click on the attachment
   // and the context menu save attachment item to save the right attachment I did not find a better way for now.
   // NOTE: If you change this, also make sure to update the `saveAttachment()`
-  const attachmentIndexStr = (event?.target as any)?.parentElement?.getAttribute?.(
-    'data-attachmentindex'
-  );
+  const target = event?.target;
+  const attachmentIndexStr =
+    target instanceof Element
+      ? target.closest('[data-attachmentindex]')?.getAttribute('data-attachmentindex')
+      : undefined;
   const attachmentIndex =
     isString(attachmentIndexStr) && !isNil(toNumber(attachmentIndexStr))
       ? toNumber(attachmentIndexStr)

--- a/ts/test/components/MessageContextMenu_test.tsx
+++ b/ts/test/components/MessageContextMenu_test.tsx
@@ -1,0 +1,38 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { expect } from 'chai';
+import Sinon from 'sinon';
+import { showMessageContextMenu } from '../../components/conversation/message/message-content/MessageContextMenu';
+import * as contextMenu from '../../util/contextMenu';
+
+describe('MessageContextMenu', () => {
+  afterEach(() => {
+    Sinon.restore();
+    document.body.innerHTML = '';
+  });
+
+  it('uses the nearest attachment index when right-clicking nested elements', () => {
+    const showStub = Sinon.stub(contextMenu, 'showContextMenu');
+
+    const attachmentWrapper = document.createElement('div');
+    attachmentWrapper.setAttribute('data-attachmentindex', '2');
+
+    const svg = document.createElement('svg');
+    const path = document.createElement('path');
+    svg.appendChild(path);
+    attachmentWrapper.appendChild(svg);
+    document.body.appendChild(attachmentWrapper);
+
+    showMessageContextMenu({
+      id: 'message-context-menu',
+      event: {
+        target: path,
+        clientX: 40,
+        clientY: 60,
+      } as any,
+    });
+
+    expect(showStub.calledOnce).to.equal(true);
+    const params = showStub.firstCall.args[0] as any;
+    expect((params.props as any)?.dataAttachmentIndex).to.equal(2);
+  });
+});


### PR DESCRIPTION
### First time contributor checklist:
- [x] I have read the README and Contributor Guidelines

### Contributor checklist:
- [x] My commits are in nice logical chunks with good commit messages
- [x] My changes are rebased on the latest dev branch
- [x] A yarn ready run passes successfully (ran `pnpm ready`)
- [x] My changes are ready to be shipped to users

### Description

Fixes #1828

Summary:
- Use the nearest data-attachmentindex ancestor when opening the message context menu so nested targets (e.g., the play icon) map to the correct attachment.
- Add a unit test that exercises nested attachment targets.

Repro steps (pre-fix):
1. Open Session Desktop 1.17.8 on Ubuntu.
2. Receive a message with multiple video attachments.
3. Right-click the play icon on the second video and choose Save.
4. The downloaded file is the first video.

Test plan:
- Pre-fix: pnpm exec mocha --require jsdom-global/register app/ts/test/components/MessageContextMenu_test.js (fails: expected 0 to equal 2)
- Post-fix: pnpm exec mocha --require jsdom-global/register app/ts/test/components/MessageContextMenu_test.js
- pnpm ready

Manual testing:
- Not run (CLI-only environment).

Co-Authored-By: Warp <agent@warp.dev>
