### PR TITLE
WIP: fix: sogs seqno number check

### DIFF
--- a/ts/session/apis/open_group_api/sogsv3/sogsApiV3.ts
+++ b/ts/session/apis/open_group_api/sogsv3/sogsApiV3.ts
@@ -294,8 +294,7 @@ const handleMessagesResponseV4 = async (
     }
 
     // we use the unverified newMessages seqno and id as last polled because we actually did poll up to those ids.
-
-    const incomingMessageSeqNo = compact(messages.map(n => n.seqno));
+    const incomingMessageSeqNo = messages.map(n => n.seqno).filter(n => isNumber(n));
     const maxNewMessageSeqNo = Math.max(...incomingMessageSeqNo);
 
     let decryptedItems: AwaitedReturn<(typeof MultiEncryptWrapperActions)['decryptForCommunity']>;


### PR DESCRIPTION
Note: **DO NOT MERGE** until we have a proper way to handle whisper messages.

Currently, this will reset the seqno to 0, when the only fetched message is a whisper messages (they all are a seqno of 0)