### PR TITLE
ci: add Dependabot for npm dependency scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary

Adds a `.github/dependabot.yml` config so npm dependency updates get a regular weekly bump PR — keeps transitive supply-chain risk visible without manual `npm audit` sweeps.

## Scope

Single new file:
- `.github/dependabot.yml` — npm package ecosystem, weekly schedule, default group config (security + version updates).

## Motivation

Pure security / supply-chain hygiene. Additive — no behavioural change to the desktop app, no workflow modifications, no source touched.

## Validation

- Config validated locally against the Dependabot config schema (`gh api repos/session-foundation/session-desktop/dependency-graph/snapshots` is unaffected; `dependabot.yml` only drives the bot).
- Backported from a hardening pass on a downstream fork (klodr/session-desktop) where it has been running for the past 2 weeks without noise.

🤖 Originating maintainer: klodr — happy to iterate on schedule / grouping if upstream prefers a different cadence.