### PR TITLE
ci: add CodeQL security analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,34 @@
+name: "CodeQL"
+on:
+  push:
+    branches: [ "master", "dev" ]
+  pull_request:
+    branches: [ "master", "dev" ]
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript-typescript' ]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v3
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Adds a `.github/workflows/codeql.yml` so GitHub's CodeQL static-analysis runs on every push + PR + weekly schedule. Surfaces JavaScript/TypeScript security findings (XSS sinks, unsafe regex, prototype pollution, etc.) before they ship.

## Scope

Single new workflow file:
- `.github/workflows/codeql.yml` — `javascript-typescript` analysis on push / pull_request / weekly cron, default query suite.

## Important config detail

The workflow targets `branches: [master, dev]` (upstream's two long-lived branches). The original draft of this file was written against `[main, dev]` because it was lifted from a downstream fork that uses `main` — fixed before submitting so the workflow actually triggers here.

## Motivation

Pure security hygiene. Additive — no source files touched, no behavioural change. The workflow has been running on the downstream fork for 2 weeks with manageable signal-to-noise (default query suite, no project-specific tuning yet).

## Validation

- Workflow YAML validated locally with `actionlint`.
- Triggers verified to match upstream branch layout (`master` + `dev`).
- Backported from klodr/session-desktop where it's been live without breaking the build.

🤖 Originating maintainer: klodr — happy to iterate on query selection or schedule if upstream wants a tighter scope.