### PR TITLE
chore: allow any Node 24.x patch version in engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,7 +220,7 @@
     "webpack-cli": "6.0.1"
   },
   "engines": {
-    "node": "24.12.0"
+    "node": "24.x"
   },
   "build": {
     "appId": "com.loki-project.messenger-desktop",


### PR DESCRIPTION
## Why

`engines.node` is currently pinned to the exact patch version
`24.12.0`. Contributors on any other 24.x patch release (24.10,
24.13, etc.) get a hard `EBADENGINE` error from `yarn install`
and have to either downgrade Node or pass `--ignore-engines` to
work around it.

The pin offers no real reproducibility benefit since the same
lockfile applies to every 24.x release; it just adds friction.

## What

Replace the exact pin with `^24`, accepting any Node 24 release.
`yarn install` still produces an identical dependency graph (the
lockfile is unchanged); only the engines check loosens.

```diff
   "engines": {
-    "node": "24.12.0"
+    "node": "^24"
   }
```

## Test plan

- [ ] `yarn install` on Node 24.10 / 24.12 / 24.13 → succeeds
      without `--ignore-engines`.
- [ ] CI continues to pass (the workflow already pins Node via
      `actions/setup-node`, so the engines value is advisory there).
- [ ] No change for contributors already on 24.12.0.