### PR TITLE
fix: focus composition input when typing

### DIFF
--- a/ts/components/conversation/composition/CompositionTextArea.tsx
+++ b/ts/components/conversation/composition/CompositionTextArea.tsx
@@ -71,7 +71,8 @@ function isEditableTarget(target: EventTarget | null) {
     return false;
   }
 
-  const editableSelector = 'input, textarea, select, [contenteditable="true"], [contenteditable="plaintext-only"]';
+  const editableSelector =
+    'input, textarea, select, [contenteditable="true"], [contenteditable="plaintext-only"]';
   return !!target.closest(editableSelector);
 }
 
@@ -604,7 +605,7 @@ export function CompositionTextArea(props: Props) {
     },
   });
 
-      useEffect(() => {
+  useEffect(() => {
     if (!selectedConversationKey || !typingEnabled) {
       return undefined;
     }

--- a/ts/components/conversation/composition/CompositionTextArea.tsx
+++ b/ts/components/conversation/composition/CompositionTextArea.tsx
@@ -66,6 +66,25 @@ type Props = {
 
 type SearchableSuggestion = SessionSuggestionDataItem & { searchable?: Array<string> };
 
+function isEditableTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  const editableSelector = 'input, textarea, select, [contenteditable="true"], [contenteditable="plaintext-only"]';
+  return !!target.closest(editableSelector);
+}
+
+function isPrintableTypingEvent(event: globalThis.KeyboardEvent) {
+  return (
+    event.key.length === 1 &&
+    !event.altKey &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.defaultPrevented
+  );
+}
+
 function useMembersInThisChat(): Array<SearchableSuggestion> {
   const selectedConvoKey = useSelectedConversationKey();
   const isPrivate = useSelectedIsPrivate();
@@ -584,6 +603,33 @@ export function CompositionTextArea(props: Props) {
       }
     },
   });
+
+      useEffect(() => {
+    if (!selectedConversationKey || !typingEnabled) {
+      return undefined;
+    }
+
+    const handleTypingFocus = (event: globalThis.KeyboardEvent) => {
+      if (!isPrintableTypingEvent(event) || isEditableTarget(event.target)) {
+        return;
+      }
+
+      const input = inputRef.current;
+      if (!input) {
+        return;
+      }
+
+      event.preventDefault();
+      input.focus();
+      input.typeAtCaret(event.key);
+    };
+
+    document.addEventListener('keydown', handleTypingFocus, true);
+
+    return () => {
+      document.removeEventListener('keydown', handleTypingFocus, true);
+    };
+  }, [inputRef, selectedConversationKey, typingEnabled]);
 
   const onFocus = () => {
     dispatch(setIsCompositionTextAreaFocused(true));


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/session-foundation/session-desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/session-foundation/session-desktop/blob/master/CONTRIBUTING.md)

### Contributor checklist:

- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`dev`](https://github.com/session-foundation/session-desktop/tree/dev) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/session-foundation/session-desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description
## What does this PR do?

Focuses the conversation composition input when the user starts typing a normal printable character outside the chatbar. The first typed character is preserved by using the existing composition input ref methods.

## Why was this PR needed?

Typing while a conversation is open currently does nothing unless the user first clicks the chatbar or uses the existing focus shortcut. This makes composing messages feel finicky.

## What are the relevant issue numbers?

Closes #460

## Testing

- Manually verified typing a normal letter outside the chatbar focuses the chatbar.
- Manually verified the first typed character is inserted.
- Manually verified typing inside search/input fields does not move focus to the chatbar.
- Manually verified modifier-key shortcuts are ignored.
