### PR TITLE
fix: support pinch-to-zoom and drag-to-pan in lightbox

### DIFF
--- a/ts/components/lightbox/Lightbox.tsx
+++ b/ts/components/lightbox/Lightbox.tsx
@@ -69,8 +69,8 @@ const styles = {
   object: {
     flexGrow: 1,
     flexShrink: 0,
-    maxWidth: '80vw',
-    maxHeight: '80vh',
+    maxWidth: 'none',
+    maxHeight: 'none',
     objectFit: 'contain',
   } as CSSProperties,
   caption: {

--- a/ts/components/lightbox/Lightbox.tsx
+++ b/ts/components/lightbox/Lightbox.tsx
@@ -195,6 +195,13 @@ const LightboxObject = ({
   const dragStart = useRef({ x: 0, y: 0 });
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // Keep the latest scale/translate available to the native wheel listener without
+  // having to re-register it on every zoom step.
+  const scaleRef = useRef(scale);
+  const translateRef = useRef(translate);
+  scaleRef.current = scale;
+  translateRef.current = translate;
+
   // Reset zoom and pan whenever the displayed image changes (prev/next navigation)
   useEffect(() => {
     setScale(1);
@@ -202,6 +209,59 @@ const LightboxObject = ({
   }, [objectURL]);
 
   const isImageTypeSupported = GoogleChrome.isImageTypeSupported(contentType);
+
+  // Register the wheel listener natively with { passive: false } so we can call
+  // preventDefault(). React's onWheel is passive by default, which both prints
+  // "Unable to preventDefault inside passive event listener invocation" and fails
+  // to stop the page from scrolling while zooming.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || !isImageTypeSupported) {
+      return undefined;
+    }
+
+    const handleWheelNative = (e: WheelEvent) => {
+      // ctrlKey is true for pinch-to-zoom on macOS trackpads as well as Ctrl+scroll on all platforms
+      if (!e.ctrlKey && !e.metaKey) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+
+      const rect = container.getBoundingClientRect();
+      // Pointer position relative to container center (the transform origin)
+      const pointerX = e.clientX - rect.left - rect.width / 2;
+      const pointerY = e.clientY - rect.top - rect.height / 2;
+
+      const currentScale = scaleRef.current;
+      const currentTranslate = translateRef.current;
+
+      const delta = -e.deltaY * ZOOM_SENSITIVITY;
+      const newScale = Math.min(MAX_SCALE, Math.max(MIN_SCALE, currentScale * (1 + delta)));
+
+      if (newScale === currentScale) {
+        return;
+      }
+
+      // Adjust translate so the point under the pointer stays fixed
+      const scaleFactor = newScale / currentScale;
+      const newTranslateX = pointerX - scaleFactor * (pointerX - currentTranslate.x);
+      const newTranslateY = pointerY - scaleFactor * (pointerY - currentTranslate.y);
+
+      setScale(newScale);
+      // Snap translate back to zero when returning to fit-to-screen
+      if (newScale === MIN_SCALE) {
+        setTranslate({ x: 0, y: 0 });
+      } else {
+        setTranslate({ x: newTranslateX, y: newTranslateY });
+      }
+    };
+
+    container.addEventListener('wheel', handleWheelNative, { passive: false });
+    return () => {
+      container.removeEventListener('wheel', handleWheelNative);
+    };
+  }, [isImageTypeSupported]);
 
   // auto play video on showing a video attachment
   useUnmount(() => {
@@ -214,45 +274,6 @@ const LightboxObject = ({
 
   if (isImageTypeSupported) {
     const isZoomed = scale > 1;
-
-    const handleWheel = (e: React.WheelEvent<HTMLDivElement>) => {
-      // ctrlKey is true for pinch-to-zoom on macOS trackpads as well as Ctrl+scroll on all platforms
-      if (!e.ctrlKey && !e.metaKey) {
-        return;
-      }
-      e.preventDefault();
-      e.stopPropagation();
-
-      const container = containerRef.current;
-      if (!container) {
-        return;
-      }
-
-      const rect = container.getBoundingClientRect();
-      // Pointer position relative to container center (the transform origin)
-      const pointerX = e.clientX - rect.left - rect.width / 2;
-      const pointerY = e.clientY - rect.top - rect.height / 2;
-
-      const delta = -e.deltaY * ZOOM_SENSITIVITY;
-      const newScale = Math.min(MAX_SCALE, Math.max(MIN_SCALE, scale * (1 + delta)));
-
-      if (newScale === scale) {
-        return;
-      }
-
-      // Adjust translate so the point under the pointer stays fixed
-      const scaleFactor = newScale / scale;
-      const newTranslateX = pointerX - scaleFactor * (pointerX - translate.x);
-      const newTranslateY = pointerY - scaleFactor * (pointerY - translate.y);
-
-      setScale(newScale);
-      // Snap translate back to zero when returning to fit-to-screen
-      if (newScale === MIN_SCALE) {
-        setTranslate({ x: 0, y: 0 });
-      } else {
-        setTranslate({ x: newTranslateX, y: newTranslateY });
-      }
-    };
 
     const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
       if (!isZoomed) {
@@ -305,7 +326,6 @@ const LightboxObject = ({
       <div
         ref={containerRef}
         style={{ overflow: 'hidden' }}
-        onWheel={handleWheel}
         onMouseDown={handleMouseDown}
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}

--- a/ts/components/lightbox/Lightbox.tsx
+++ b/ts/components/lightbox/Lightbox.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, MouseEvent, useRef, type Ref } from 'react';
+import { CSSProperties, MouseEvent, useEffect, useRef, useState, type Ref } from 'react';
 
 import { isUndefined } from 'lodash';
 import useUnmount from 'react-use/lib/useUnmount';
@@ -28,6 +28,9 @@ type Props = {
 
 const CONTROLS_WIDTH = 50;
 const CONTROLS_SPACING = 10;
+const MIN_SCALE = 1;
+const MAX_SCALE = 10;
+const ZOOM_SENSITIVITY = 0.002;
 
 const styles = {
   container: {
@@ -60,6 +63,7 @@ const styles = {
     flexGrow: 1,
     display: 'inline-flex',
     justifyContent: 'center',
+    overflow: 'hidden',
   } as CSSProperties,
   objectParentContainer: {
     flexGrow: 1,
@@ -69,8 +73,8 @@ const styles = {
   object: {
     flexGrow: 1,
     flexShrink: 0,
-    maxWidth: 'none',
-    maxHeight: 'none',
+    maxWidth: '80vw',
+    maxHeight: '80vh',
     objectFit: 'contain',
   } as CSSProperties,
   caption: {
@@ -183,6 +187,20 @@ const LightboxObject = ({
 }) => {
   const { urlToLoad } = useEncryptedFileFetch(objectURL, contentType, false);
 
+  // scale: 1 = fit-to-screen. translate is in px, relative to centered origin.
+  const [scale, setScale] = useState(1);
+  const [translate, setTranslate] = useState({ x: 0, y: 0 });
+  const isDragging = useRef(false);
+  const didDrag = useRef(false);
+  const dragStart = useRef({ x: 0, y: 0 });
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Reset zoom and pan whenever the displayed image changes (prev/next navigation)
+  useEffect(() => {
+    setScale(1);
+    setTranslate({ x: 0, y: 0 });
+  }, [objectURL]);
+
   const isImageTypeSupported = GoogleChrome.isImageTypeSupported(contentType);
 
   // auto play video on showing a video attachment
@@ -195,14 +213,118 @@ const LightboxObject = ({
   const disableDrag = useDisableDrag();
 
   if (isImageTypeSupported) {
+    const isZoomed = scale > 1;
+
+    const handleWheel = (e: React.WheelEvent<HTMLDivElement>) => {
+      // ctrlKey is true for pinch-to-zoom on macOS trackpads as well as Ctrl+scroll on all platforms
+      if (!e.ctrlKey && !e.metaKey) {
+        return;
+      }
+      e.preventDefault();
+      e.stopPropagation();
+
+      const container = containerRef.current;
+      if (!container) {
+        return;
+      }
+
+      const rect = container.getBoundingClientRect();
+      // Pointer position relative to container center (the transform origin)
+      const pointerX = e.clientX - rect.left - rect.width / 2;
+      const pointerY = e.clientY - rect.top - rect.height / 2;
+
+      const delta = -e.deltaY * ZOOM_SENSITIVITY;
+      const newScale = Math.min(MAX_SCALE, Math.max(MIN_SCALE, scale * (1 + delta)));
+
+      if (newScale === scale) {
+        return;
+      }
+
+      // Adjust translate so the point under the pointer stays fixed
+      const scaleFactor = newScale / scale;
+      const newTranslateX = pointerX - scaleFactor * (pointerX - translate.x);
+      const newTranslateY = pointerY - scaleFactor * (pointerY - translate.y);
+
+      setScale(newScale);
+      // Snap translate back to zero when returning to fit-to-screen
+      if (newScale === MIN_SCALE) {
+        setTranslate({ x: 0, y: 0 });
+      } else {
+        setTranslate({ x: newTranslateX, y: newTranslateY });
+      }
+    };
+
+    const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isZoomed) {
+        return;
+      }
+      isDragging.current = true;
+      didDrag.current = false;
+      dragStart.current = { x: e.clientX - translate.x, y: e.clientY - translate.y };
+      e.preventDefault();
+      e.stopPropagation();
+    };
+
+    const handleMouseMove = (e: React.MouseEvent<HTMLDivElement>) => {
+      if (!isDragging.current) {
+        return;
+      }
+      didDrag.current = true;
+      e.stopPropagation();
+      setTranslate({
+        x: e.clientX - dragStart.current.x,
+        y: e.clientY - dragStart.current.y,
+      });
+    };
+
+    const handleMouseUp = (e: React.MouseEvent<HTMLDivElement>) => {
+      if (isDragging.current) {
+        e.stopPropagation();
+      }
+      isDragging.current = false;
+    };
+
+    const handleDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+      e.stopPropagation();
+      setScale(1);
+      setTranslate({ x: 0, y: 0 });
+    };
+
+    const imgStyle: CSSProperties = {
+      ...styles.object,
+      transform: `scale(${scale}) translate(${translate.x / scale}px, ${translate.y / scale}px)`,
+      transformOrigin: 'center center',
+      transition: isDragging.current ? 'none' : 'transform 0.05s ease-out',
+      cursor: isZoomed ? (isDragging.current ? 'grabbing' : 'grab') : 'default',
+      // Let the image overflow the container; the container clips it
+      flexShrink: 0,
+      userSelect: 'none',
+    };
+
     return (
-      <img
-        style={styles.object as any}
-        onDragStart={disableDrag}
-        src={urlToLoad}
-        alt={AriaLabels.imageSentInConversation}
-        ref={renderedRef}
-      />
+      <div
+        ref={containerRef}
+        style={{ overflow: 'hidden' }}
+        onWheel={handleWheel}
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+        onDoubleClick={handleDoubleClick}
+      >
+        <img
+          style={imgStyle as any}
+          onDragStart={disableDrag}
+          src={urlToLoad}
+          alt={AriaLabels.imageSentInConversation}
+          ref={renderedRef}
+          onClick={e => {
+            if (didDrag.current) {
+              e.stopPropagation();
+            }
+          }}
+        />
+      </div>
     );
   }
 

--- a/ts/components/lightbox/Lightbox.tsx
+++ b/ts/components/lightbox/Lightbox.tsx
@@ -1,4 +1,12 @@
-import { CSSProperties, MouseEvent, useEffect, useRef, useState, type Ref } from 'react';
+import {
+  CSSProperties,
+  MouseEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Ref,
+} from 'react';
 
 import { isUndefined } from 'lodash';
 import useUnmount from 'react-use/lib/useUnmount';
@@ -31,6 +39,8 @@ const CONTROLS_SPACING = 10;
 const MIN_SCALE = 1;
 const MAX_SCALE = 10;
 const ZOOM_SENSITIVITY = 0.002;
+// Successive scales the double-click zoom steps through before cycling back to fit-to-screen.
+const DOUBLE_CLICK_ZOOM_STEPS = [2.5, MAX_SCALE];
 
 const styles = {
   container: {
@@ -202,11 +212,78 @@ const LightboxObject = ({
   scaleRef.current = scale;
   translateRef.current = translate;
 
-  // Reset zoom and pan whenever the displayed image changes (prev/next navigation)
-  useEffect(() => {
+  // Double-click zoom sequence tracking. dblClickStepRef is the index into
+  // DOUBLE_CLICK_ZOOM_STEPS for the next double-click; lastDblClickScaleRef is the scale we
+  // last set via double-click (null when the current zoom came from the wheel instead).
+  const dblClickStepRef = useRef(0);
+  const lastDblClickScaleRef = useRef<number | null>(null);
+
+  // Clamp a translate to the scaled overflow so the image edges can't be dragged past the
+  // container (which would leave empty space / let the image be lost off-screen).
+  const clampTranslate = useCallback(
+    (tx: number, ty: number, atScale: number) => {
+      const container = containerRef.current;
+      const img = renderedRef?.current as HTMLElement | null;
+      if (!container || !img) {
+        return { x: tx, y: ty };
+      }
+      const overflowX = Math.max(0, (img.offsetWidth * atScale - container.clientWidth) / 2);
+      const overflowY = Math.max(0, (img.offsetHeight * atScale - container.clientHeight) / 2);
+      return {
+        x: Math.min(overflowX, Math.max(-overflowX, tx)),
+        y: Math.min(overflowY, Math.max(-overflowY, ty)),
+      };
+    },
+    [renderedRef]
+  );
+
+  // Zoom to a target scale while keeping the point under (clientX, clientY) fixed on screen.
+  // Shared by the wheel and double-click handlers.
+  const applyZoom = useCallback(
+    (targetScale: number, clientX: number, clientY: number) => {
+      const container = containerRef.current;
+      if (!container) {
+        return;
+      }
+      const currentScale = scaleRef.current;
+      const currentTranslate = translateRef.current;
+      const clampedScale = Math.min(MAX_SCALE, Math.max(MIN_SCALE, targetScale));
+      if (clampedScale === currentScale) {
+        return;
+      }
+
+      const rect = container.getBoundingClientRect();
+      // Pointer position relative to container center (the transform origin)
+      const pointerX = clientX - rect.left - rect.width / 2;
+      const pointerY = clientY - rect.top - rect.height / 2;
+
+      // Adjust translate so the point under the pointer stays fixed
+      const scaleFactor = clampedScale / currentScale;
+      const newTranslateX = pointerX - scaleFactor * (pointerX - currentTranslate.x);
+      const newTranslateY = pointerY - scaleFactor * (pointerY - currentTranslate.y);
+
+      setScale(clampedScale);
+      // Snap translate back to zero when returning to fit-to-screen
+      if (clampedScale === MIN_SCALE) {
+        setTranslate({ x: 0, y: 0 });
+      } else {
+        setTranslate(clampTranslate(newTranslateX, newTranslateY, clampedScale));
+      }
+    },
+    [clampTranslate]
+  );
+
+  const resetZoom = useCallback(() => {
     setScale(1);
     setTranslate({ x: 0, y: 0 });
-  }, [objectURL]);
+    dblClickStepRef.current = 0;
+    lastDblClickScaleRef.current = null;
+  }, []);
+
+  // Reset zoom and pan whenever the displayed image changes (prev/next navigation)
+  useEffect(() => {
+    resetZoom();
+  }, [objectURL, resetZoom]);
 
   const isImageTypeSupported = GoogleChrome.isImageTypeSupported(contentType);
 
@@ -228,40 +305,19 @@ const LightboxObject = ({
       e.preventDefault();
       e.stopPropagation();
 
-      const rect = container.getBoundingClientRect();
-      // Pointer position relative to container center (the transform origin)
-      const pointerX = e.clientX - rect.left - rect.width / 2;
-      const pointerY = e.clientY - rect.top - rect.height / 2;
-
-      const currentScale = scaleRef.current;
-      const currentTranslate = translateRef.current;
-
       const delta = -e.deltaY * ZOOM_SENSITIVITY;
-      const newScale = Math.min(MAX_SCALE, Math.max(MIN_SCALE, currentScale * (1 + delta)));
+      applyZoom(scaleRef.current * (1 + delta), e.clientX, e.clientY);
 
-      if (newScale === currentScale) {
-        return;
-      }
-
-      // Adjust translate so the point under the pointer stays fixed
-      const scaleFactor = newScale / currentScale;
-      const newTranslateX = pointerX - scaleFactor * (pointerX - currentTranslate.x);
-      const newTranslateY = pointerY - scaleFactor * (pointerY - currentTranslate.y);
-
-      setScale(newScale);
-      // Snap translate back to zero when returning to fit-to-screen
-      if (newScale === MIN_SCALE) {
-        setTranslate({ x: 0, y: 0 });
-      } else {
-        setTranslate({ x: newTranslateX, y: newTranslateY });
-      }
+      // A wheel zoom breaks out of the double-click sequence, so the next double-click resets.
+      dblClickStepRef.current = 0;
+      lastDblClickScaleRef.current = null;
     };
 
     container.addEventListener('wheel', handleWheelNative, { passive: false });
     return () => {
       container.removeEventListener('wheel', handleWheelNative);
     };
-  }, [isImageTypeSupported]);
+  }, [isImageTypeSupported, applyZoom]);
 
   // auto play video on showing a video attachment
   useUnmount(() => {
@@ -292,10 +348,13 @@ const LightboxObject = ({
       }
       didDrag.current = true;
       e.stopPropagation();
-      setTranslate({
-        x: e.clientX - dragStart.current.x,
-        y: e.clientY - dragStart.current.y,
-      });
+      setTranslate(
+        clampTranslate(
+          e.clientX - dragStart.current.x,
+          e.clientY - dragStart.current.y,
+          scaleRef.current
+        )
+      );
     };
 
     const handleMouseUp = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -307,8 +366,29 @@ const LightboxObject = ({
 
     const handleDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
       e.stopPropagation();
-      setScale(1);
-      setTranslate({ x: 0, y: 0 });
+
+      const currentScale = scaleRef.current;
+      // Whether the current zoom came from our double-click sequence (vs. a wheel zoom).
+      const inSequence =
+        lastDblClickScaleRef.current !== null && currentScale === lastDblClickScaleRef.current;
+
+      // Zoomed in some other way (wheel) -> reset straight back to fit-to-screen.
+      if (currentScale > MIN_SCALE && !inSequence) {
+        resetZoom();
+        return;
+      }
+
+      const step = inSequence ? dblClickStepRef.current : 0;
+      // Past the last zoom step -> cycle back to fit-to-screen.
+      if (step >= DOUBLE_CLICK_ZOOM_STEPS.length) {
+        resetZoom();
+        return;
+      }
+
+      const targetScale = DOUBLE_CLICK_ZOOM_STEPS[step];
+      applyZoom(targetScale, e.clientX, e.clientY);
+      dblClickStepRef.current = step + 1;
+      lastDblClickScaleRef.current = targetScale;
     };
 
     const imgStyle: CSSProperties = {


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

Hi @Bilb  — this is my first contribution to this project. I've fixed #701 by adding pinch-to-zoom and drag-to-pan to the Lightbox image viewer. Would appreciate a review when you have time!

### First time contributor checklist:

- [x] I have read the [README](https://github.com/session-foundation/session-desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/session-foundation/session-desktop/blob/master/CONTRIBUTING.md)

### Contributor checklist:

- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`dev`](https://github.com/session-foundation/session-desktop/tree/dev) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/session-foundation/session-desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Adds pinch-to-zoom and drag-to-pan to the Lightbox image viewer. Images containing text are often difficult to read at fit-to-screen size, requiring users to download and open them externally to inspect the content.

### How it works:
- Pinch or Ctrl+scroll to zoom in and out toward the pointer position
- Drag to pan while zoomed
- Double-click to reset to fit-to-screen
- Zoom and pan reset automatically when navigating to the next or previous image
- Video and unsupported file types are unaffected

### Manual testing performed:
- [x] Pinch-to-zoom on Mac trackpad — zooms toward pointer
- [x] Ctrl+scroll on Mac — zooms in and out
- [x] Drag while zoomed — pans without closing the lightbox 
- [x] Double-click — resets to fit-to-screen from any zoom level
- [x] Click dark background — closes the lightbox at any zoom level
- [x] Click image without dragging — lightbox stays open
- [x] Navigate prev/next — zoom resets on each new image
- [x] Video attachments — no change in behavior


No new automated tests added — the meaningful behavior (gesture feel, pointer anchoring, click vs drag distinction) is covered by manual testing above.

OS tested: macOS [14.8.7]