### PR TITLE
fix: reduce update file server polling

### DIFF
--- a/ts/components/dialog/user-settings/pages/PreferencesSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/PreferencesSettingsPage.tsx
@@ -19,6 +19,7 @@ import { ToastUtils } from '../../../../session/utils';
 import { PanelRadioButton } from '../../../buttons/panel/PanelRadioButton';
 import { useHasEnterSendEnabled } from '../../../../state/selectors/settings';
 import { UserSettingsModalContainer } from '../components/UserSettingsModalContainer';
+import { fetchLatestReleaseFromFileServerIfEnabled } from '../../../../hooks/useFetchLatestReleaseFromFileServer';
 
 async function toggleStartInTray() {
   try {
@@ -122,7 +123,11 @@ export function PreferencesSettingsPage(modalState: UserSettingsModalState) {
           subText={{ token: 'permissionsAutoUpdateDescription' }}
           onClick={async () => {
             const old = Boolean(window.getSettingValue(SettingsKey.settingsAutoUpdate));
-            await window.setSettingValue(SettingsKey.settingsAutoUpdate, !old);
+            const enabled = !old;
+            await window.setSettingValue(SettingsKey.settingsAutoUpdate, enabled);
+            if (enabled) {
+              await fetchLatestReleaseFromFileServerIfEnabled();
+            }
             forceUpdate();
           }}
           active={Boolean(window.getSettingValue(SettingsKey.settingsAutoUpdate))}

--- a/ts/hooks/useFetchLatestReleaseFromFileServer.ts
+++ b/ts/hooks/useFetchLatestReleaseFromFileServer.ts
@@ -1,20 +1,43 @@
 import { isEmpty } from 'lodash';
+import { useCallback, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import useInterval from 'react-use/lib/useInterval';
+import { SettingsKey } from '../data/settings-key';
 import { fetchLatestRelease } from '../session/fetch_latest_release';
 import { UserUtils } from '../session/utils';
 import { getOurPrimaryConversation } from '../state/selectors/conversations';
 
+export async function fetchLatestReleaseFromFileServerIfEnabled() {
+  if (!window.getSettingValue(SettingsKey.settingsAutoUpdate)) {
+    return;
+  }
+
+  const userEd25519SecretKey = (await UserUtils.getUserED25519KeyPairBytes())?.privKeyBytes;
+  if (userEd25519SecretKey && !isEmpty(userEd25519SecretKey)) {
+    void fetchLatestRelease.fetchReleaseFromFSAndUpdateMain(userEd25519SecretKey);
+  }
+}
+
 export function useFetchLatestReleaseFromFileServer() {
   const ourPrimaryConversation = useSelector(getOurPrimaryConversation);
+  const fetchedOnStartupRef = useRef(false);
 
-  useInterval(async () => {
+  const fetchReleaseIfEnabled = useCallback(async () => {
     if (!ourPrimaryConversation) {
       return;
     }
-    const userEd25519SecretKey = (await UserUtils.getUserED25519KeyPairBytes())?.privKeyBytes;
-    if (userEd25519SecretKey && !isEmpty(userEd25519SecretKey)) {
-      void fetchLatestRelease.fetchReleaseFromFSAndUpdateMain(userEd25519SecretKey);
+
+    await fetchLatestReleaseFromFileServerIfEnabled();
+  }, [ourPrimaryConversation]);
+
+  useEffect(() => {
+    if (fetchedOnStartupRef.current || !ourPrimaryConversation) {
+      return;
     }
-  }, fetchLatestRelease.fetchReleaseFromFileServerInterval);
+
+    fetchedOnStartupRef.current = true;
+    void fetchReleaseIfEnabled();
+  }, [fetchReleaseIfEnabled, ourPrimaryConversation]);
+
+  useInterval(fetchReleaseIfEnabled, fetchLatestRelease.fetchReleaseFromFileServerInterval);
 }

--- a/ts/mains/main_node.ts
+++ b/ts/mains/main_node.ts
@@ -598,6 +598,35 @@ ipc.handle('force-update-check', async () => {
   }
 });
 
+// Softer counterpart to 'force-update-check': triggered by the renderer when routine
+// polling fetches a newer release from the file server. Unlike force-update-check it does
+// not force a file server refetch and stays quiet (no throw/toast); it only re-prompts a
+// user who dismissed a download when the new release is strictly newer than the one they
+// dismissed. See checkForUpdates' triggeredByNewRelease argument.
+ipc.handle('trigger-update-check', async () => {
+  try {
+    if (!log) {
+      throw new Error('Must provide logger!');
+    }
+
+    if (!isReadyForUpdates) {
+      log.info('[updater] trigger-update-check: not ready for updates yet, skipping');
+      return false;
+    }
+
+    const canUpdate = await canAutoUpdate();
+    if (!canUpdate) {
+      log.info('[updater] trigger-update-check: cannot auto update, skipping');
+      return false;
+    }
+
+    return await checkForUpdates(getMainWindow, log, false, true);
+  } catch (error) {
+    console.error('[updater] trigger-update-check', error && error.stack ? error.stack : error);
+    return false;
+  }
+});
+
 // Forcefully call readyForUpdates after 10 minutes.
 // This ensures we start the updater.
 const TEN_MINUTES = 10 * 60 * 1000;

--- a/ts/session/fetch_latest_release/index.ts
+++ b/ts/session/fetch_latest_release/index.ts
@@ -48,6 +48,12 @@ async function fetchReleaseFromFSAndUpdateMain(
       lastFetchedTimestamp = Date.now();
       ipcRenderer.send('set-release-from-file-server', justFetched);
       window.readyForUpdates();
+      // When we detect a new release through routine polling, trigger an immediate check
+      // instead of waiting for the next updater interval tick. The forced (debug menu) path
+      // runs its own 'force-update-check', so we skip it here to avoid a duplicate check.
+      if (!force) {
+        void ipcRenderer.invoke('trigger-update-check');
+      }
       return releaseVersion;
     }
 

--- a/ts/session/fetch_latest_release/index.ts
+++ b/ts/session/fetch_latest_release/index.ts
@@ -1,4 +1,4 @@
-// every 1 minute we fetch from the fileserver to check for a new release
+// Periodically fetch from the fileserver to check for a new release
 // * if there is none, no request to github are made.
 // * if there is a version on the fileserver more recent than our current, we fetch github to get the UpdateInfos and trigger an update as usual (asking user via dialog)
 
@@ -9,9 +9,9 @@ import { getLatestReleaseFromFileServer } from '../apis/file_server_api/FileServ
 import { isReleaseChannel } from '../../updater/types';
 
 /**
- * We don't want to hit the fileserver too often. Only often on start, and then every 30 minutes
+ * We don't want to hit the fileserver too often. Only often on start, and then every 30 minutes.
  */
-const skipIfLessThan = DURATION.MINUTES * 30;
+const fetchReleaseFromFileServerInterval = DURATION.MINUTES * 30;
 
 let lastFetchedTimestamp = Number.MIN_SAFE_INTEGER;
 
@@ -26,9 +26,9 @@ async function fetchReleaseFromFSAndUpdateMain(
   try {
     window.log.info('[updater] about to fetchReleaseFromFSAndUpdateMain');
     const diff = Date.now() - lastFetchedTimestamp;
-    if (!force && diff < skipIfLessThan) {
+    if (!force && diff < fetchReleaseFromFileServerInterval) {
       window.log.debug(
-        `[updater] fetched release from fs ${Math.floor(diff / DURATION.MINUTES)} minutes ago, skipping until that's at least ${Math.floor(skipIfLessThan / DURATION.MINUTES)}`
+        `[updater] fetched release from fs ${Math.floor(diff / DURATION.MINUTES)} minutes ago, skipping until that's at least ${Math.floor(fetchReleaseFromFileServerInterval / DURATION.MINUTES)}`
       );
       return null;
     }
@@ -60,10 +60,9 @@ async function fetchReleaseFromFSAndUpdateMain(
 
 export const fetchLatestRelease = {
   /**
-   * Try to fetch the latest release from the fileserver every 1 minute.
-   * If we did fetch a release already in the last 30 minutes, we will skip the call.
+   * Try to fetch the latest release from the fileserver every 30 minutes.
    */
-  fetchReleaseFromFileServerInterval: DURATION.MINUTES * 1,
+  fetchReleaseFromFileServerInterval,
   fetchReleaseFromFSAndUpdateMain,
   resetForTesting,
 };

--- a/ts/test/session/unit/updater/updater_test.ts
+++ b/ts/test/session/unit/updater/updater_test.ts
@@ -4,6 +4,8 @@ import { readFileSync } from 'fs-extra';
 import { isEmpty } from 'lodash';
 import { expect } from 'chai';
 import { enableLogRedirect } from '../../../test-utils/utils';
+import { DURATION } from '../../../../session/constants';
+import { fetchLatestRelease } from '../../../../session/fetch_latest_release';
 
 describe('Updater', () => {
   it('package.json target is correct', () => {
@@ -24,5 +26,9 @@ describe('Updater', () => {
       false,
       'If you see this message, just set `enableLogRedirect` to false in `ts/test/test-utils/utils/stubbing.ts'
     );
+  });
+
+  it('checks the file server on the same cadence as the update throttle', () => {
+    expect(fetchLatestRelease.fetchReleaseFromFileServerInterval).to.equal(30 * DURATION.MINUTES);
   });
 });

--- a/ts/updater/updater.ts
+++ b/ts/updater/updater.ts
@@ -18,6 +18,12 @@ import { isDebianBased, isRunningViaAppImage } from '../OS';
 
 let isUpdating = false;
 let downloadIgnored = false;
+/**
+ * The version the user dismissed when we last showed the download dialog.
+ * Used so a check triggered by a freshly-fetched release only re-prompts when
+ * the release is strictly newer than the one they already said no to.
+ */
+let ignoredVersion: string | undefined;
 let interval: NodeJS.Timeout | undefined;
 let stopped = false;
 
@@ -72,11 +78,17 @@ export function stop() {
 export async function checkForUpdates(
   getMainWindow: () => BrowserWindow | null,
   logger: LoggerType,
-  force?: boolean
+  force?: boolean,
+  triggeredByNewRelease?: boolean
 ) {
-  if (stopped || isUpdating || (downloadIgnored && !force)) {
+  // `force` (from the debug menu) always re-prompts. A check triggered because we
+  // just fetched a new release from the file server should only re-prompt when that
+  // release is strictly newer than the one the user previously dismissed.
+  const bypassDownloadIgnored = force || (triggeredByNewRelease && isNewReleaseNewerThanIgnored());
+
+  if (stopped || isUpdating || (downloadIgnored && !bypassDownloadIgnored)) {
     logger.info(
-      `[updater] checkForUpdates is returning early stopped ${stopped} isUpdating ${isUpdating} downloadIgnored ${downloadIgnored}`
+      `[updater] checkForUpdates is returning early stopped ${stopped} isUpdating ${isUpdating} downloadIgnored ${downloadIgnored} bypassDownloadIgnored ${bypassDownloadIgnored}`
     );
     return false;
   }
@@ -149,6 +161,7 @@ export async function checkForUpdates(
 
       if (!shouldDownload) {
         downloadIgnored = true;
+        ignoredVersion = result.updateInfo.version;
         logger.info('[updater] download cancelled by user');
         return true;
       }
@@ -183,6 +196,18 @@ export async function checkForUpdates(
   } finally {
     isUpdating = false;
   }
+}
+
+/**
+ * Whether the release currently advertised by the file server is strictly newer than
+ * the version the user dismissed. Returns true when nothing has been dismissed yet.
+ */
+function isNewReleaseNewerThanIgnored(): boolean {
+  if (!ignoredVersion) {
+    return true;
+  }
+  const [updateVersionFromFs] = getLatestRelease();
+  return Boolean(updateVersionFromFs && isVersionGreaterThan(updateVersionFromFs, ignoredVersion));
 }
 
 function isUpdateAvailable(updateInfo: UpdateInfo): boolean {


### PR DESCRIPTION
### Contributor checklist:

- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`dev`](https://github.com/session-foundation/session-desktop/tree/dev) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/session-foundation/session-desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Fixes #1809

This lines up the renderer file-server release polling interval with the existing 30 minute throttle, so the app stops waking up every minute just to skip the request

It also skips the renderer-side release check when auto updates are disabled, while still doing one startup fetch and one fetch after auto updates are enabled from preferences so the updater has fresh file-server release data before the main update check runs

Tested with:

- `pnpm ready`
