### PR TITLE
fix: avoid jumping back after sending

### DIFF
--- a/ts/components/conversation/SessionConversation.tsx
+++ b/ts/components/conversation/SessionConversation.tsx
@@ -68,6 +68,7 @@ import {
 } from '../../state/selectors/selectedConversation';
 import { LUCIDE_ICONS_UNICODE } from '../icon/lucide';
 import { sleepFor } from '../../session/utils/Promise';
+import { shouldScrollAfterSend } from './shouldScrollAfterSend';
 
 interface State {
   isDraggingFile: boolean;
@@ -217,7 +218,14 @@ export class SessionConversation extends Component<Props, State> {
       // this needs to be awaited otherwise, the scrollToNow won't find the new message in the db.
       // and this make the showScrollButton to be visible (even if we just scrolled to now)
       await conversationModel.sendMessage(msg);
-      await this.scrollToNowWithRetries(5);
+      if (
+        shouldScrollAfterSend({
+          selectedConversationKey: this.props.selectedConversationKey,
+          sentConversationId: msg.conversationId,
+        })
+      ) {
+        await this.scrollToNowWithRetries(5);
+      }
     };
 
     const recoveryPhrase = getCurrentRecoveryPhrase();

--- a/ts/components/conversation/shouldScrollAfterSend.ts
+++ b/ts/components/conversation/shouldScrollAfterSend.ts
@@ -1,0 +1,9 @@
+export function shouldScrollAfterSend({
+  selectedConversationKey,
+  sentConversationId,
+}: {
+  selectedConversationKey?: string;
+  sentConversationId?: string;
+}) {
+  return Boolean(sentConversationId && selectedConversationKey === sentConversationId);
+}

--- a/ts/test/session/unit/components/conversation/shouldScrollAfterSend_test.ts
+++ b/ts/test/session/unit/components/conversation/shouldScrollAfterSend_test.ts
@@ -1,0 +1,34 @@
+import chai from 'chai';
+
+import { shouldScrollAfterSend } from '../../../../../components/conversation/shouldScrollAfterSend';
+
+const { expect } = chai;
+
+describe('shouldScrollAfterSend', () => {
+  it('allows scrolling when the sent conversation is still selected', () => {
+    expect(
+      shouldScrollAfterSend({
+        selectedConversationKey: 'conversation-a',
+        sentConversationId: 'conversation-a',
+      })
+    ).to.equal(true);
+  });
+
+  it('does not allow scrolling when another conversation is selected', () => {
+    expect(
+      shouldScrollAfterSend({
+        selectedConversationKey: 'conversation-b',
+        sentConversationId: 'conversation-a',
+      })
+    ).to.equal(false);
+  });
+
+  it('does not allow scrolling without a sent conversation id', () => {
+    expect(
+      shouldScrollAfterSend({
+        selectedConversationKey: 'conversation-a',
+        sentConversationId: undefined,
+      })
+    ).to.equal(false);
+  });
+});


### PR DESCRIPTION
### Contributor checklist:

- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`dev`](https://github.com/session-foundation/session-desktop/tree/dev) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/session-foundation/session-desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Fixes #1749

This stops the post-send scroll fallback from reopening the sent conversation when the user has already switched to another conversation while the send was still finishing

The scroll still runs when the sent conversation is still selected, so the normal send-and-scroll behavior stays unchanged

Tested:
- `pnpm ready`