### PR TITLE
Pro (desktop): fix grace-period display + keep get_pro_status fresh

### DIFF
--- a/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
@@ -1,5 +1,12 @@
 import { isNumber } from 'lodash';
-import { MouseEventHandler, SessionDataTestId, useCallback, useMemo, type ReactNode } from 'react';
+import {
+  MouseEventHandler,
+  SessionDataTestId,
+  useCallback,
+  useEffect,
+  useMemo,
+  type ReactNode,
+} from 'react';
 import useUpdate from 'react-use/lib/useUpdate';
 import styled from 'styled-components';
 import { getAppDispatch } from '../../../../../state/dispatch';
@@ -61,6 +68,9 @@ import {
   useProBackendRefetch,
 } from '../../../../../state/selectors/proBackendData';
 import { formatNumber } from '../../../../../util/i18n/formatting/generics';
+import { NetworkTime } from '../../../../../util/NetworkTime';
+import { DURATION } from '../../../../../session/constants';
+import { proBackendDataActions } from '../../../../../state/ducks/proBackendData';
 
 type ProSettingsModalState = {
   fromCTA?: boolean;
@@ -220,6 +230,46 @@ const useCurrentUserHasExpiredProInternal = useCurrentUserHasExpiredPro;
 const useCurrentNeverHadProInternal = useCurrentNeverHadPro;
 const useIsDarkThemeInternal = useIsDarkTheme;
 const usePinnedConversationsCountInternal = usePinnedConversationsCount;
+
+// Extracted into its own hook so the react compiler compiles a small, clean function rather than
+// choking on a raw useEffect inside the large ProSettings component.
+function useKeepProStatusFresh({
+  expiryTimeMs,
+  autoRenew,
+  userHasExpiredPro,
+  isLoading,
+  isError,
+}: {
+  expiryTimeMs: number;
+  autoRenew: boolean;
+  userHasExpiredPro: boolean;
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  // Keep get_pro_status fresh around the paid-through end while the pro page is open, so the "renewal
+  // unsuccessful" warning reflects reality rather than a pre-expiry snapshot. Without it, a renewal
+  // that lands while the page is open isn't picked up until the page is closed and reopened.
+  useEffect(() => {
+    if (isLoading || isError || userHasExpiredPro || !autoRenew || !expiryTimeMs) {
+      return undefined;
+    }
+    const fire = () =>
+      window.inboxStore?.dispatch(
+        proBackendDataActions.refreshGetProStatusFromProBackend({}) as any
+      );
+    const msUntilExpiry = expiryTimeMs - NetworkTime.now();
+    if (msUntilExpiry > 0) {
+      // Refetch just after the crossing, so a renewal (or a genuine failure) replaces the stale value.
+      const timeoutId = setTimeout(fire, msUntilExpiry + 5 * DURATION.SECONDS);
+      return () => clearTimeout(timeoutId);
+    }
+    // Past expiry and still auto-renewing (grace/renewal window): the renewal can succeed at any
+    // point, so re-check until get_pro_status reports the new expiry (the deps change re-arms the
+    // one-shot above) or the account flips to expired (the guard returns).
+    const intervalId = setInterval(fire, DURATION.MINUTES);
+    return () => clearInterval(intervalId);
+  }, [expiryTimeMs, autoRenew, userHasExpiredPro, isLoading, isError]);
+}
 
 function ProNonProContinueButton({ state }: SectionProps) {
   const { returnToThisModalAction, centerAlign, afterCloseAction } = state;
@@ -436,6 +486,14 @@ function ProSettings({ state }: SectionProps) {
   const userNeverHadPro = useCurrentNeverHadProInternal();
   const { data, isLoading, isError } = useProBackendProStatusInternal();
   const backendErrorButtons = useBackendErrorDialogButtons();
+
+  useKeepProStatusFresh({
+    expiryTimeMs: data.expiryTimeMs,
+    autoRenew: data.autoRenew,
+    userHasExpiredPro,
+    isLoading,
+    isError,
+  });
 
   const forceRefresh = useUpdate();
 

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -232,14 +232,19 @@ async function applyProofOutcome(
       }
       break;
     case 'not_subscribed':
-      // Clear the (absent) credential but leave pro_prepaid so a pending purchase keeps polling.
+      // Clear the (absent) credential AND the access-expiry (E), but leave pro_prepaid so a pending
+      // purchase keeps polling. Clearing E is required: libsession's renewal target now fires on
+      // "future E but no proof", so a stale future E left here would spin.
       if (!haveValidProof()) {
         await UserConfigWrapperActions.removeProConfig();
+        await UserConfigWrapperActions.setProAccessExpiry(null);
       }
       break;
     case 'revoked':
-      // Terminal: revocation must kill even an unexpired proof (bypasses the downgrade guard). No E.
+      // Terminal: revocation kills even an unexpired proof (bypasses the downgrade guard). With the
+      // proof gone we must also clear E, or the renewal target (future E, no proof) would spin.
       await UserConfigWrapperActions.removeProConfig();
+      await UserConfigWrapperActions.setProAccessExpiry(null);
       break;
     default:
       // Unrecognized error_code: fail closed, non-destructively — treat as transient (no write/clear).

--- a/ts/state/selectors/proBackendData.ts
+++ b/ts/state/selectors/proBackendData.ts
@@ -280,14 +280,21 @@ function processProBackendData({
     ? !mockCancelled
     : (data?.autoRenewing ?? defaultProAccessDetailsSourceData.autoRenew);
 
+  // Auto-renew is due AT the paid-through end (`expiryMs`). user_status stays `active` through the
+  // grace window (the backend judges coverage against expiry + grace_period_duration), so being past
+  // expiry while still active IS the grace period. Subtracting grace here put "renew due" a whole
+  // grace period early, so inGracePeriod was perpetually true whenever grace exceeded the period.
   let beginAutoRenew = 0;
   if (data) {
-    beginAutoRenew = data.expiryMs - data.gracePeriodDurationMs;
+    beginAutoRenew = data.expiryMs;
   }
 
   let inGracePeriod = mockInGracePeriod;
   if (beginAutoRenew && !mockInGracePeriod) {
-    inGracePeriod = autoRenew && now >= beginAutoRenew && now < expiryTimeMs;
+    // Only surface "renewal unsuccessful" off data we actually fetched at/after the paid-through
+    // end — never off a pre-expiry snapshot that predates a possible renewal. The pro page refetches
+    // at the crossing (and polls through grace), so a stale snapshot resolves rather than sticking.
+    inGracePeriod = autoRenew && now >= expiryTimeMs && lastFetchedMs >= expiryTimeMs;
   }
 
   // Refund-requested is now a synced config flag (UserProfile key R), not a backend response field.


### PR DESCRIPTION
- Grace display: renewal is due AT the paid-through end (expiryMs), not expiryMs - grace. Subtracting grace put 'renew due' a whole grace period early, so inGracePeriod was perpetually true whenever grace exceeded the billing period.
- Only surface 'renewal unsuccessful' off status actually fetched at/after the paid-through end (lastFetchedMs >= expiryTimeMs), never off a stale pre-expiry snapshot.
- useKeepProStatusFresh: while the pro page is open, refetch get_pro_status just after the paid-through crossing and poll through the grace window, so a renewal that lands (or genuinely fails) is reflected without leaving and reopening the page.
- E contract: clear pro_access_expiry (E) on not_subscribed and revoked proof outcomes, so libsession's renewal target (future E, no proof) doesn't spin.