### PR TITLE
Pro: unify the `get_pro_status` refresh discipline (Desktop)

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "framer-motion": "^12.5.0",
     "fs-extra": "11.3.0",
     "image-type": "^4.1.0",
-    "libsession_util_nodejs": "https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.6.19/libsession_util_nodejs-v0.6.19.tar.gz",
+    "libsession_util_nodejs": "https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.0/libsession_util_nodejs-v0.7.0.tar.gz",
     "libsodium-wrappers-sumo": "^0.7.15",
     "linkify-it": "^5.0.0",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,8 +99,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       libsession_util_nodejs:
-        specifier: https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.6.19/libsession_util_nodejs-v0.6.19.tar.gz
-        version: https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.6.19/libsession_util_nodejs-v0.6.19.tar.gz
+        specifier: https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.0/libsession_util_nodejs-v0.7.0.tar.gz
+        version: https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.0/libsession_util_nodejs-v0.7.0.tar.gz
       libsodium-wrappers-sumo:
         specifier: ^0.7.15
         version: 0.7.15
@@ -4020,9 +4020,9 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  libsession_util_nodejs@https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.6.19/libsession_util_nodejs-v0.6.19.tar.gz:
-    resolution: {tarball: https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.6.19/libsession_util_nodejs-v0.6.19.tar.gz}
-    version: 0.6.19
+  libsession_util_nodejs@https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.0/libsession_util_nodejs-v0.7.0.tar.gz:
+    resolution: {integrity: sha512-RJ9n4tf/JCPqVCNkSz9x6AllUyNg/uWqXRAjxAXfvoUNTtEYO3HNqyF2EytBkfPoPvkogVuonHgWo1F5jdjEtQ==, tarball: https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.0/libsession_util_nodejs-v0.7.0.tar.gz}
+    version: 0.7.0
 
   libsodium-sumo@0.7.15:
     resolution: {integrity: sha512-5tPmqPmq8T8Nikpm1Nqj0hBHvsLFCXvdhBFV7SGOitQPZAA6jso8XoL0r4L7vmfKXr486fiQInvErHtEvizFMw==}
@@ -10126,7 +10126,7 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  libsession_util_nodejs@https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.6.19/libsession_util_nodejs-v0.6.19.tar.gz:
+  libsession_util_nodejs@https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.0/libsession_util_nodejs-v0.7.0.tar.gz:
     dependencies:
       cmake-js: 7.3.1
       node-addon-api: 8.5.0

--- a/ts/components/conversation/composition/CompositionBox.tsx
+++ b/ts/components/conversation/composition/CompositionBox.tsx
@@ -56,7 +56,6 @@ import type { CompositionInputRef } from './CompositionInput';
 import { useShowBlockUnblock } from '../../menuAndSettingsHooks/useShowBlockUnblock';
 import { showLocalizedPopupDialog } from '../../dialog/LocalizedPopupDialog';
 import { formatNumber } from '../../../util/i18n/formatting/generics';
-import { getFeatureFlag } from '../../../state/ducks/types/releasedFeaturesReduxTypes';
 import { showSessionCTA } from '../../dialog/SessionCTA';
 import type { ProcessedLinkPreviewThumbnailType } from '../../../webworker/workers/node/image_processor/image_processor';
 import { CTAVariant } from '../../dialog/cta/types';
@@ -661,8 +660,6 @@ class CompositionBoxInner extends Component<Props, State> {
 
     this.linkPreviewAbortController?.abort();
 
-    const isProAvailable = getFeatureFlag('proAvailable');
-
     const charLimit = hasPro
       ? LIBSESSION_CONSTANTS.MESSAGE_CHARACTER_LIMIT_PRO
       : LIBSESSION_CONSTANTS.MESSAGE_CHARACTER_LIMIT_STANDARD;
@@ -674,7 +671,7 @@ class CompositionBoxInner extends Component<Props, State> {
     if (codepointCount > charLimit) {
       const dispatch = window.inboxStore?.dispatch;
       if (dispatch) {
-        if (isProAvailable && !hasPro) {
+        if (!hasPro) {
           showSessionCTA(CTAVariant.PRO_MESSAGE_CHARACTER_LIMIT, dispatch);
         } else {
           showLocalizedPopupDialog(

--- a/ts/components/dialog/EditProfilePictureModal.tsx
+++ b/ts/components/dialog/EditProfilePictureModal.tsx
@@ -29,7 +29,6 @@ import {
   ModalBasicHeader,
   SessionWrapperModal,
 } from '../SessionWrapperModal';
-import { getIsProAvailableMemo } from '../../hooks/useIsProAvailable';
 import { SpacerLG, SpacerSM } from '../basic/Text';
 import { AvatarSize } from '../avatar/Avatar';
 import { ProIconButton } from '../buttons/ProButton';
@@ -139,7 +138,6 @@ export const EditProfilePictureModal = ({ conversationId }: EditProfilePictureMo
   const isMe = useIsMe(conversationId);
   const isCommunity = useIsPublic(conversationId);
   const weHavePro = useCurrentUserHasPro() && isMe;
-  const isProAvailable = getIsProAvailableMemo();
 
   const avatarPath = useAvatarPath(conversationId) || '';
 
@@ -229,7 +227,7 @@ export const EditProfilePictureModal = ({ conversationId }: EditProfilePictureMo
      * C. Community admin uploading a community profile picture
      * All of those are taken care of as part of the `isProUser` check in the conversation model
      */
-    if (isProAvailable && !weHavePro && isNewAvatarAnimated && !isCommunity) {
+    if (!weHavePro && isNewAvatarAnimated && !isCommunity) {
       dispatch(
         updateSessionCTA({
           variant: CTAVariant.PRO_ANIMATED_DISPLAY_PICTURE,

--- a/ts/components/dialog/SessionCTA.tsx
+++ b/ts/components/dialog/SessionCTA.tsx
@@ -24,7 +24,6 @@ import {
 import { SpacerSM, SpacerXL } from '../basic/Text';
 import type { MergedLocalizerTokens } from '../../localization/localeTools';
 import { SessionButtonShiny } from '../basic/SessionButtonShiny';
-import { getIsProAvailableMemo } from '../../hooks/useIsProAvailable';
 import { useCurrentUserHasPro } from '../../hooks/useHasPro';
 import { assertUnreachable } from '../../types/sqlSharedTypes';
 import { Storage } from '../../util/storage';
@@ -38,7 +37,6 @@ import {
   type ProCTAVariant,
   isProCTAFeatureVariant,
 } from './cta/types';
-import { getFeatureFlag } from '../../state/ducks/types/releasedFeaturesReduxTypes';
 import { openUrlNoDialog, showLinkVisitWarningDialog } from './OpenUrlModal';
 import { APP_URL, DURATION } from '../../session/constants';
 import { Data } from '../../data/data';
@@ -475,33 +473,22 @@ export const showSessionCTA = (variant: CTAVariant, dispatch: Dispatch<any>) => 
 
 export const useShowSessionCTACb = (variant: CTAVariant) => {
   const dispatch = getAppDispatch();
-  const isProAvailable = getIsProAvailableMemo();
-  const isProCTA = useIsProCTAVariant(variant);
-  if (isProCTA && !isProAvailable) {
-    return () => null;
-  }
 
   return () => showSessionCTA(variant, dispatch);
 };
 
 export const useShowSessionCTACbWithVariant = () => {
   const dispatch = getAppDispatch();
-  const isProAvailable = getIsProAvailableMemo();
 
   return (variant: CTAVariant) => {
-    if (isProCTAVariant(variant) && !isProAvailable) {
-      return;
-    }
     showSessionCTA(variant, dispatch);
   };
 };
 
 export async function handleTriggeredCTAs(dispatch: Dispatch<any>, fromAppStart: boolean) {
-  const proAvailable = getFeatureFlag('proAvailable');
-
   if (Storage.get(SettingsKey.proExpiringSoonCTA)) {
     // Note: postpone showing the pro CTAs as we need to make sure we've fetched our latest pro status from the backend
-    if (!proAvailable || fromAppStart) {
+    if (fromAppStart) {
       return;
     }
     dispatch(
@@ -513,7 +500,7 @@ export async function handleTriggeredCTAs(dispatch: Dispatch<any>, fromAppStart:
   } else if (Storage.get(SettingsKey.proExpiredCTA)) {
     // Note: postpone showing the pro CTAs as we need to make sure we've fetched our latest pro status from the backend
 
-    if (!proAvailable || fromAppStart) {
+    if (fromAppStart) {
       return;
     }
     dispatch(

--- a/ts/components/dialog/SessionCTA.tsx
+++ b/ts/components/dialog/SessionCTA.tsx
@@ -3,6 +3,7 @@ import { Dispatch, useMemo, type ReactNode } from 'react';
 import styled from 'styled-components';
 import type { CSSProperties } from 'styled-components';
 import { getAppDispatch } from '../../state/dispatch';
+import type { StateType } from '../../state/reducer';
 import {
   type SessionCTAState,
   updateSessionCTA,
@@ -485,10 +486,39 @@ export const useShowSessionCTACbWithVariant = () => {
   };
 };
 
+/**
+ * Whether *this process* holds a `get_pro_status` it confirmed itself.
+ *
+ * `details.lastFetchedMs` is per-run (0 until a fetch completes) and is stamped on completion, so it
+ * is the honest answer to "may we act on the Pro status we hold". Read straight off the store rather
+ * than threaded in as a parameter, so a new call site cannot inherit an answer by copying a
+ * neighbour — which is how the two unguarded callers below came about.
+ *
+ * Deliberately not read via the proBackendData selectors: they import the duck, and the duck imports
+ * this module.
+ */
+function haveConfirmedProStatusThisProcess(): boolean {
+  const lastFetchedMs = (window.inboxStore?.getState() as StateType | undefined)?.proBackendData
+    ?.details?.lastFetchedMs;
+  return !!lastFetchedMs;
+}
+
 export async function handleTriggeredCTAs(dispatch: Dispatch<any>, fromAppStart: boolean) {
+  // The Pro CTAs must never fire off an unconfirmed status. The flags are persisted, so a previous
+  // run's "expired" verdict outlives the entitlement it described, and showing it after an
+  // out-of-band renewal is the false-expired case this guard exists to prevent.
+  //
+  // This was `if (fromAppStart) return`, which worked only because startup fetched unconditionally —
+  // every non-startup caller was therefore guaranteed that a fetch had happened or was in flight.
+  // Gating the startup fetch removed that guarantee, leaving openConversationWithMessages and the
+  // settings-modal close able to display a stale flag with nothing confirming it this session.
+  //
+  // `fromAppStart` is still needed below, where it *enables* the donate CTA rather than suppressing a
+  // Pro one. Those are different questions and must not be collapsed into one flag.
+  const mayShowProCTA = haveConfirmedProStatusThisProcess();
+
   if (Storage.get(SettingsKey.proExpiringSoonCTA)) {
-    // Note: postpone showing the pro CTAs as we need to make sure we've fetched our latest pro status from the backend
-    if (fromAppStart) {
+    if (!mayShowProCTA) {
       return;
     }
     dispatch(
@@ -498,9 +528,7 @@ export async function handleTriggeredCTAs(dispatch: Dispatch<any>, fromAppStart:
     );
     await Storage.put(SettingsKey.proExpiringSoonCTA, false);
   } else if (Storage.get(SettingsKey.proExpiredCTA)) {
-    // Note: postpone showing the pro CTAs as we need to make sure we've fetched our latest pro status from the backend
-
-    if (fromAppStart) {
+    if (!mayShowProCTA) {
       return;
     }
     dispatch(

--- a/ts/components/dialog/SessionCTA.tsx
+++ b/ts/components/dialog/SessionCTA.tsx
@@ -489,13 +489,11 @@ export const useShowSessionCTACbWithVariant = () => {
 /**
  * Whether *this process* holds a `get_pro_status` it confirmed itself.
  *
- * `details.lastFetchedMs` is per-run (0 until a fetch completes) and is stamped on completion, so it
- * is the honest answer to "may we act on the Pro status we hold". Read straight off the store rather
- * than threaded in as a parameter, so a new call site cannot inherit an answer by copying a
- * neighbour — which is how the two unguarded callers below came about.
+ * `details.lastFetchedMs` is per-run and stamped on completion, so it answers "may we act on the Pro
+ * status we hold". Read off the store rather than threaded in as a parameter, so a new call site cannot
+ * inherit an answer by copying a neighbour.
  *
- * Deliberately not read via the proBackendData selectors: they import the duck, and the duck imports
- * this module.
+ * Not read via the proBackendData selectors: they import the duck, and the duck imports this module.
  */
 function haveConfirmedProStatusThisProcess(): boolean {
   const lastFetchedMs = (window.inboxStore?.getState() as StateType | undefined)?.proBackendData
@@ -504,14 +502,10 @@ function haveConfirmedProStatusThisProcess(): boolean {
 }
 
 export async function handleTriggeredCTAs(dispatch: Dispatch<any>, fromAppStart: boolean) {
-  // The Pro CTAs must never fire off an unconfirmed status. The flags are persisted, so a previous
-  // run's "expired" verdict outlives the entitlement it described, and showing it after an
-  // out-of-band renewal is the false-expired case this guard exists to prevent.
-  //
-  // This was `if (fromAppStart) return`, which worked only because startup fetched unconditionally —
-  // every non-startup caller was therefore guaranteed that a fetch had happened or was in flight.
-  // Gating the startup fetch removed that guarantee, leaving openConversationWithMessages and the
-  // settings-modal close able to display a stale flag with nothing confirming it this session.
+  // The Pro CTAs must never fire off an unconfirmed status: the flags are persisted, so a previous run's
+  // "expired" verdict outlives the entitlement it described, and showing it after an out-of-band renewal
+  // is the false-expired case this guard prevents. Every caller needs it — a status confirmed this
+  // session is not implied by having reached any particular entry point.
   //
   // `fromAppStart` is still needed below, where it *enables* the donate CTA rather than suppressing a
   // Pro one. Those are different questions and must not be collapsed into one flag.

--- a/ts/components/dialog/debug/FeatureFlags.tsx
+++ b/ts/components/dialog/debug/FeatureFlags.tsx
@@ -799,7 +799,10 @@ function ProConfigManager({ forceUpdate }: { forceUpdate: () => void }) {
   ) : (
     <div style={{ width: '100%' }}>
       <h2>Pro Config Manager</h2>
-      <DebugButton onClick={() => refetch()}>Generate New Proof From Backend (refresh)</DebugButton>
+      {/* Developer path: exempt from the status floor, so a debug button always does something. */}
+      <DebugButton onClick={() => refetch({ immediate: true })}>
+        Generate New Proof From Backend (refresh)
+      </DebugButton>
       <i>Changing the pro config may result in an invalid pro config</i>
       <ProConfigForm proConfig={proConfig ?? initialState.value} forceUpdate={_forceUpdate} />
     </div>
@@ -883,7 +886,11 @@ export const ProDebugSection = ({
       <DebugButton onClick={() => setPage(DEBUG_MENU_PAGE.Pro)}>Pro Playground</DebugButton>
       <DebugButton
         onClick={() => {
-          dispatch(proBackendDataActions.refreshGetProStatusFromProBackend({}) as any);
+          // Developer path: exempt from the status floor (a debug button that silently no-ops for
+          // 60s is worse than useless when you are trying to observe a backend change).
+          dispatch(
+            proBackendDataActions.refreshGetProStatusFromProBackend({ immediate: true }) as any
+          );
         }}
       >
         Refresh Pro Status

--- a/ts/components/dialog/debug/FeatureFlags.tsx
+++ b/ts/components/dialog/debug/FeatureFlags.tsx
@@ -12,7 +12,6 @@ import {
   getDataFeatureFlagMemo,
   type SessionDataFeatureFlagKeys,
   type SessionBooleanFeatureFlagKeys,
-  getFeatureFlagMemo,
 } from '../../../state/ducks/types/releasedFeaturesReduxTypes';
 import { Flex } from '../../basic/Flex';
 import { SessionToggle } from '../../basic/SessionToggle';
@@ -39,7 +38,6 @@ import {
   defaultProDataFeatureFlags,
 } from '../../../state/ducks/types/defaultFeatureFlags';
 import { UserConfigWrapperActions } from '../../../webworker/workers/browser/libsession/libsession_worker_userconfig_interface';
-import { isDebugMode } from '../../../shared/env_vars';
 import {
   useProBackendProStatus,
   useProBackendRefetch,
@@ -431,7 +429,6 @@ const proBooleanFlags: BooleanFlags = [
   {
     label: 'Platform Refund Expired',
     flag: 'mockCurrentUserHasProPlatformRefundExpired',
-    visibleWithBooleanFlag: 'proAvailable',
     visibleWithEnumFlag: {
       flag: 'mockProCurrentStatus',
       isVisible: v => v === ProStatus.Active,
@@ -460,25 +457,21 @@ const proBackendBooleanFlags: BooleanFlags = [
   {
     label: 'Backend Loading',
     flag: 'mockProBackendLoading',
-    visibleWithBooleanFlag: 'proAvailable',
     hiddenAndDisabledWhenKeyEnabled: 'mockProBackendError',
   },
   {
     label: 'Backend Error',
     flag: 'mockProBackendError',
-    visibleWithBooleanFlag: 'proAvailable',
     hiddenAndDisabledWhenKeyEnabled: 'mockProBackendLoading',
   },
   {
     label: 'Recover always succeeds',
     flag: 'mockProRecoverButtonAlwaysSucceed',
-    visibleWithBooleanFlag: 'proAvailable',
     hiddenAndDisabledWhenKeyEnabled: 'mockProRecoverButtonAlwaysFail',
   },
   {
     label: 'Recover always fails',
     flag: 'mockProRecoverButtonAlwaysFail',
-    visibleWithBooleanFlag: 'proAvailable',
     hiddenAndDisabledWhenKeyEnabled: 'mockProRecoverButtonAlwaysSucceed',
   },
 ];
@@ -497,7 +490,6 @@ const handledBooleanFeatureFlags = proBooleanFlags
   .concat(proBackendBooleanFlags.map(({ flag: key }) => key))
   .concat(debugFeatureFlags.map(({ flag: key }) => key))
   .concat([
-    'proAvailable',
     'proGroupsAvailable',
     'useTestProBackend',
     'debugLogging',
@@ -666,12 +658,7 @@ export function FeatureFlagDumper({ forceUpdate }: { forceUpdate: () => void }) 
 }
 
 function MessageProFeatures({ forceUpdate }: { forceUpdate: () => void }) {
-  const proIsAvailable = getFeatureFlagMemo('proAvailable');
   const value = getDataFeatureFlagMemo('mockMessageProFeatures') ?? [];
-
-  if (!proIsAvailable) {
-    return null;
-  }
 
   return (
     <Flex
@@ -825,7 +812,6 @@ export const ProDebugSection = ({
 }: DebugMenuPageProps & { forceUpdate: () => void }) => {
   const dispatch = getAppDispatch();
   const mockExpiry = getDataFeatureFlagMemo('mockProAccessExpiry');
-  const proAvailable = getFeatureFlagMemo('proAvailable');
 
   const resetPro = useCallback(async () => {
     await UserConfigWrapperActions.removeProConfig();
@@ -889,92 +875,67 @@ export const ProDebugSection = ({
     };
   }, [proExpiredCTASetting]);
 
-  if (!proAvailable && !isDebugMode()) {
-    return null;
-  }
-
   return (
     <DebugMenuSection title="Session Pro">
-      <FlagToggle forceUpdate={forceUpdate} flag="proAvailable" label="Pro Beta Released" />
-      {proAvailable ? (
-        <>
-          <DebugButton buttonColor={SessionButtonColor.Danger} onClick={resetPro}>
-            Reset All Pro State
-          </DebugButton>
-          <DebugButton onClick={() => setPage(DEBUG_MENU_PAGE.Pro)}>Pro Playground</DebugButton>
-          <DebugButton
-            onClick={() => {
-              if (!proAvailable) {
-                return;
-              }
-              dispatch(proBackendDataActions.refreshGetProStatusFromProBackend({}) as any);
-            }}
-          >
-            Refresh Pro Status
-          </DebugButton>
-          <DebugButton
-            onClick={async () => {
-              const masterPrivKeyHex = await getProMasterKeyHex();
-              const { rotatingSeedHex, rotatingPrivKeyHex } =
-                await UserUtils.deriveCurrentProRotatingKey();
-              const response = await ProBackendAPI.generateProProof({
-                masterPrivKeyHex,
-                rotatingPrivKeyHex,
-              });
-              if (getFeatureFlag('debugServerRequests')) {
-                window?.log?.debug('getProProof response: ', response);
-              }
-              if (response && response.status === 'ok') {
-                // libsession returns a ready-made ProProof; relay it verbatim.
-                await UserConfigWrapperActions.setProConfig({
-                  proProof: response.proof,
-                  rotatingSeedHex,
-                });
-              }
-            }}
-          >
-            Get Pro Proof
-          </DebugButton>
-          <DebugButton
-            onClick={async () => {
-              const masterPrivKeyHex = await getProMasterKeyHex();
-              const response = await ProBackendAPI.getProStatus({ masterPrivKeyHex });
-              if (getFeatureFlag('debugServerRequests')) {
-                window?.log?.debug('Pro Status: ', response);
-              }
-            }}
-          >
-            Get Pro Status
-          </DebugButton>
-          <DebugButton
-            hide={!proAvailable}
-            onClick={async () => {
-              const response = await ProBackendAPI.getRevocationList({ ticket: 0 });
-              window?.log?.debug('Pro Revocation List: ', response);
-            }}
-          >
-            Get Pro Revocation List (from ticket 0)
-          </DebugButton>
-        </>
-      ) : null}
+      <DebugButton buttonColor={SessionButtonColor.Danger} onClick={resetPro}>
+        Reset All Pro State
+      </DebugButton>
+      <DebugButton onClick={() => setPage(DEBUG_MENU_PAGE.Pro)}>Pro Playground</DebugButton>
+      <DebugButton
+        onClick={() => {
+          dispatch(proBackendDataActions.refreshGetProStatusFromProBackend({}) as any);
+        }}
+      >
+        Refresh Pro Status
+      </DebugButton>
+      <DebugButton
+        onClick={async () => {
+          const masterPrivKeyHex = await getProMasterKeyHex();
+          const { rotatingSeedHex, rotatingPrivKeyHex } =
+            await UserUtils.deriveCurrentProRotatingKey();
+          const response = await ProBackendAPI.generateProProof({
+            masterPrivKeyHex,
+            rotatingPrivKeyHex,
+          });
+          if (getFeatureFlag('debugServerRequests')) {
+            window?.log?.debug('getProProof response: ', response);
+          }
+          if (response && response.status === 'ok') {
+            // libsession returns a ready-made ProProof; relay it verbatim.
+            await UserConfigWrapperActions.setProConfig({
+              proProof: response.proof,
+              rotatingSeedHex,
+            });
+          }
+        }}
+      >
+        Get Pro Proof
+      </DebugButton>
+      <DebugButton
+        onClick={async () => {
+          const masterPrivKeyHex = await getProMasterKeyHex();
+          const response = await ProBackendAPI.getProStatus({ masterPrivKeyHex });
+          if (getFeatureFlag('debugServerRequests')) {
+            window?.log?.debug('Pro Status: ', response);
+          }
+        }}
+      >
+        Get Pro Status
+      </DebugButton>
+      <DebugButton
+        onClick={async () => {
+          const response = await ProBackendAPI.getRevocationList({ ticket: 0 });
+          window?.log?.debug('Pro Revocation List: ', response);
+        }}
+      >
+        Get Pro Revocation List (from ticket 0)
+      </DebugButton>
 
-      <FlagToggle
-        forceUpdate={forceUpdate}
-        flag="useTestProBackend"
-        visibleWithBooleanFlag="proAvailable"
-        label="Use Test Pro Backend"
-      />
-      <FlagToggle
-        forceUpdate={forceUpdate}
-        flag="proGroupsAvailable"
-        visibleWithBooleanFlag="proAvailable"
-        label="Pro Groups Released"
-      />
-      {proAvailable ? (
-        <DebugButton buttonColor={SessionButtonColor.Danger} onClick={resetProMocking}>
-          Reset Pro Mocking
-        </DebugButton>
-      ) : null}
+      <FlagToggle forceUpdate={forceUpdate} flag="useTestProBackend" label="Use Test Pro Backend" />
+      <FlagToggle forceUpdate={forceUpdate} flag="proGroupsAvailable" label="Pro Groups Released" />
+      <DebugButton buttonColor={SessionButtonColor.Danger} onClick={resetProMocking}>
+        Reset Pro Mocking
+      </DebugButton>
 
       <FlagEnumDropdownInput
         label="Current Status"
@@ -986,7 +947,6 @@ export const ProDebugSection = ({
         ]}
         forceUpdate={forceUpdate}
         unsetOption={{ label: 'Select Current Status', value: null }}
-        visibleWithBooleanFlag="proAvailable"
       />
       {proBooleanFlags.map(props => (
         <FlagToggle {...props} key={props.flag} forceUpdate={forceUpdate} />
@@ -1001,7 +961,6 @@ export const ProDebugSection = ({
         ]}
         forceUpdate={forceUpdate}
         unsetOption={{ label: 'Select originating platform', value: null }}
-        visibleWithBooleanFlag="proAvailable"
         visibleWithEnumFlag={{
           flag: 'mockProCurrentStatus',
           isVisible: v => v !== ProStatus.Never,
@@ -1017,7 +976,6 @@ export const ProDebugSection = ({
         ]}
         forceUpdate={forceUpdate}
         unsetOption={{ label: 'Select access variant', value: null }}
-        visibleWithBooleanFlag="proAvailable"
         visibleWithEnumFlag={{
           flag: 'mockProCurrentStatus',
           isVisible: v => v !== ProStatus.Never,
@@ -1043,7 +1001,6 @@ export const ProDebugSection = ({
         ]}
         forceUpdate={forceUpdate}
         unsetOption={{ label: 'Select expiry', value: null }}
-        visibleWithBooleanFlag="proAvailable"
         visibleWithEnumFlag={{
           flag: 'mockProCurrentStatus',
           isVisible: v => v === ProStatus.Active,
@@ -1056,25 +1013,21 @@ export const ProDebugSection = ({
         label="Longer Messages Sent"
         flag="mockProLongerMessagesSent"
         forceUpdate={forceUpdate}
-        visibleWithBooleanFlag="proAvailable"
       />
       <FlagIntegerInput
         label="Pinned Conversations"
         flag="mockProPinnedConversations"
         forceUpdate={forceUpdate}
-        visibleWithBooleanFlag="proAvailable"
       />
       <FlagIntegerInput
         label="Pro Badges Sent"
         flag="mockProBadgesSent"
         forceUpdate={forceUpdate}
-        visibleWithBooleanFlag="proAvailable"
       />
       <FlagIntegerInput
         label="Groups Upgraded"
         flag="mockProGroupsUpgraded"
         forceUpdate={forceUpdate}
-        visibleWithBooleanFlag="proAvailable"
       />
       {proBackendBooleanFlags.map(props => (
         <FlagToggle {...props} key={props.flag} forceUpdate={forceUpdate} />
@@ -1084,27 +1037,23 @@ export const ProDebugSection = ({
         The CTAs will show when a conversation is next opened or the user settings modal is next
         closed
       </i>
-      {proAvailable ? (
-        <DebugButton
-          onClick={async () => {
-            await handleSetExpiringSoonCTA();
-            forceUpdate();
-          }}
-        >
-          {setExpiringSoonCTAString}
-        </DebugButton>
-      ) : null}
-      {proAvailable ? (
-        <DebugButton
-          onClick={async () => {
-            await handleSetExpiredCTA();
-            forceUpdate();
-          }}
-        >
-          {setExpiredCTAString}
-        </DebugButton>
-      ) : null}
-      {proAvailable ? <ProConfigManager forceUpdate={forceUpdate} /> : null}
+      <DebugButton
+        onClick={async () => {
+          await handleSetExpiringSoonCTA();
+          forceUpdate();
+        }}
+      >
+        {setExpiringSoonCTAString}
+      </DebugButton>
+      <DebugButton
+        onClick={async () => {
+          await handleSetExpiredCTA();
+          forceUpdate();
+        }}
+      >
+        {setExpiredCTAString}
+      </DebugButton>
+      <ProConfigManager forceUpdate={forceUpdate} />
     </DebugMenuSection>
   );
 };

--- a/ts/components/dialog/debug/components.tsx
+++ b/ts/components/dialog/debug/components.tsx
@@ -54,7 +54,6 @@ import {
 import { formatRoundedUpTimeUntilTimestamp } from '../../../util/i18n/formatting/generics';
 import { LucideIcon } from '../../icon/LucideIcon';
 import { LUCIDE_ICONS_UNICODE } from '../../icon/lucide';
-import { getIsProAvailableMemo } from '../../../hooks/useIsProAvailable';
 import {
   clearAllCtaInteractions,
   getCtaInteractions,
@@ -319,12 +318,6 @@ export const LoggingDebugSection = ({ forceUpdate }: { forceUpdate: () => void }
 };
 
 export const Playgrounds = ({ setPage }: DebugMenuPageProps) => {
-  const proAvailable = getIsProAvailableMemo();
-
-  if (!proAvailable) {
-    return null;
-  }
-
   return (
     <DebugMenuSection title="Playgrounds" rowWrap={true}>
       <DebugButton onClick={() => setPage(DEBUG_MENU_PAGE.POPOVER)}>Popover Playground</DebugButton>

--- a/ts/components/dialog/debug/constants.ts
+++ b/ts/components/dialog/debug/constants.ts
@@ -12,7 +12,7 @@ type DebugFeatureFlagsType = {
 
 export const DEBUG_FEATURE_FLAGS: DebugFeatureFlagsType = {
   // NOTE Put new feature flags in here during development so they are not available in production environments. Remove from here when they are ready for QA and production
-  DEV: ['showPopoverAnchors', 'debugInputCommands', 'proAvailable', 'useTestProBackend'],
+  DEV: ['showPopoverAnchors', 'debugInputCommands', 'useTestProBackend'],
   UNSUPPORTED: ['useTestNet', 'useLocalDevNet', 'fsTTL30s', 'proGroupsAvailable'],
   UNTESTED: ['disableOnionRequests', 'replaceLocalizedStringsWithKeys'],
 };

--- a/ts/components/dialog/debug/playgrounds/ProPlaygroundPage.tsx
+++ b/ts/components/dialog/debug/playgrounds/ProPlaygroundPage.tsx
@@ -8,16 +8,10 @@ import { LUCIDE_ICONS_UNICODE } from '../../../icon/lucide';
 import { DebugButton } from '../components';
 import { DebugMenuPageProps, DebugMenuSection } from '../DebugMenuModal';
 import { CTAVariant } from '../../cta/types';
-import { getIsProAvailableMemo } from '../../../../hooks/useIsProAvailable';
 
 export function ProPlaygroundPage(props: DebugMenuPageProps) {
   const forceUpdate = useUpdate();
   const handleClick = useShowSessionCTACbWithVariant();
-  const proAvailable = getIsProAvailableMemo();
-
-  if (!proAvailable) {
-    return null;
-  }
 
   return (
     <>

--- a/ts/components/dialog/user-settings/pages/DefaultSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/DefaultSettingsPage.tsx
@@ -30,7 +30,6 @@ import { ModalPencilIcon } from '../../shared/ModalPencilButton';
 import { ProfileHeader, ProfileName } from '../components';
 import type { ProfileDialogModes } from '../ProfileDialogModes';
 import { tr } from '../../../../localization/localeTools';
-import { getIsProAvailableMemo } from '../../../../hooks/useIsProAvailable';
 import { setDebugMode } from '../../../../state/ducks/debug';
 import { useHideRecoveryPasswordEnabled } from '../../../../state/selectors/settings';
 import { OnionStatusLight } from '../../OnionStatusPathDialog';
@@ -38,7 +37,6 @@ import { UserSettingsModalContainer } from '../components/UserSettingsModalConta
 import { useCurrentUserHasExpiredPro, useCurrentUserHasPro } from '../../../../hooks/useHasPro';
 import { NetworkTime } from '../../../../util/NetworkTime';
 import { APP_URL, DURATION } from '../../../../session/constants';
-import { getFeatureFlag } from '../../../../state/ducks/types/releasedFeaturesReduxTypes';
 import { useUserSettingsCloseAction } from './userSettingsHooks';
 import {
   useProBackendProStatus,
@@ -73,13 +71,8 @@ function LucideIconForSettings(props: Omit<LucideIconProps, 'iconSize' | 'style'
 function SessionProSection() {
   const dispatch = getAppDispatch();
 
-  const isProAvailable = getIsProAvailableMemo();
   const userHasPro = useCurrentUserHasPro();
   const currentUserHasExpiredPro = useCurrentUserHasExpiredPro();
-
-  if (!isProAvailable) {
-    return null;
-  }
 
   return (
     <PanelButtonGroup>
@@ -351,9 +344,6 @@ export const DefaultSettingPage = (modalState: UserSettingsModalState) => {
   }
 
   useMount(() => {
-    if (!getFeatureFlag('proAvailable')) {
-      return;
-    }
     // Opportunistic refresh when opening the settings, throttled to once a minute (and always done
     // when we haven't had a successful fetch yet this run, i.e. lastFetchedMs is still 0).
     if (NetworkTime.now() > lastFetchedMs + 1 * DURATION.MINUTES) {

--- a/ts/components/dialog/user-settings/pages/DefaultSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/DefaultSettingsPage.tsx
@@ -35,13 +35,9 @@ import { useHideRecoveryPasswordEnabled } from '../../../../state/selectors/sett
 import { OnionStatusLight } from '../../OnionStatusPathDialog';
 import { UserSettingsModalContainer } from '../components/UserSettingsModalContainer';
 import { useCurrentUserHasExpiredPro, useCurrentUserHasPro } from '../../../../hooks/useHasPro';
-import { NetworkTime } from '../../../../util/NetworkTime';
-import { APP_URL, DURATION } from '../../../../session/constants';
+import { APP_URL } from '../../../../session/constants';
 import { useUserSettingsCloseAction } from './userSettingsHooks';
-import {
-  useProBackendProStatus,
-  useProBackendRefetch,
-} from '../../../../state/selectors/proBackendData';
+import { useProBackendRefetch } from '../../../../state/selectors/proBackendData';
 import { focusVisibleBoxShadowOutsetStr } from '../../../../styles/focusVisible';
 import { createButtonOnKeyDownForClickEventHandler } from '../../../../util/keyboardShortcuts';
 import { useDebugMode } from '../../../../state/selectors/debug';
@@ -323,7 +319,6 @@ const SessionInfo = () => {
 export const DefaultSettingPage = (modalState: UserSettingsModalState) => {
   const dispatch = getAppDispatch();
   const closeAction = useUserSettingsCloseAction(modalState);
-  const { lastFetchedMs } = useProBackendProStatus();
   const refetch = useProBackendRefetch();
 
   const profileName = useOurConversationUsername() || '';
@@ -344,11 +339,13 @@ export const DefaultSettingPage = (modalState: UserSettingsModalState) => {
   }
 
   useMount(() => {
-    // Opportunistic refresh when opening the settings, throttled to once a minute (and always done
-    // when we haven't had a successful fetch yet this run, i.e. lastFetchedMs is still 0).
-    if (NetworkTime.now() > lastFetchedMs + 1 * DURATION.MINUTES) {
-      void refetch();
-    }
+    // Trigger #3: opportunistic refresh when opening the settings, floored (cached-if-fresh).
+    //
+    // This used to carry its own once-a-minute throttle off `details.lastFetchedMs`. That value is
+    // per-run — 0 again after every restart — so the throttle was defeated by relaunching, which on
+    // a desktop app is often. The status floor is the same 60s but persisted, so it subsumes this
+    // check; keeping both would just be two throttles disagreeing about the same question.
+    void refetch();
   });
 
   return (

--- a/ts/components/dialog/user-settings/pages/DefaultSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/DefaultSettingsPage.tsx
@@ -341,10 +341,9 @@ export const DefaultSettingPage = (modalState: UserSettingsModalState) => {
   useMount(() => {
     // Trigger #3: opportunistic refresh when opening the settings, floored (cached-if-fresh).
     //
-    // This used to carry its own once-a-minute throttle off `details.lastFetchedMs`. That value is
-    // per-run — 0 again after every restart — so the throttle was defeated by relaunching, which on
-    // a desktop app is often. The status floor is the same 60s but persisted, so it subsumes this
-    // check; keeping both would just be two throttles disagreeing about the same question.
+    // Unthrottled on purpose: the status floor owns the 60s bound, and it is persisted, so it holds
+    // across the relaunches that a per-run throttle here would be defeated by. A second throttle would
+    // only give two answers to the same question.
     void refetch();
   });
 

--- a/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
@@ -270,7 +270,6 @@ function useKeepProStatusFresh({
     // bounded, and being unfloored is what makes an unbounded version expensive. `!autoRenew` means no
     // renewal is in flight, so there is nothing to poll for; without it a lapsed non-renewing
     // subscription would poll the backend every 60s, floor-exempt, for as long as the page is open.
-    // iOS shipped exactly that (no guard, no coverage bound) and is adding this guard to match.
     // Removing it becomes correct only if this poll stops being floor-exempt, or gains an independent
     // upper bound on its lifetime. Not before.
     const fire = () =>

--- a/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
@@ -203,7 +203,9 @@ function useBackendErrorDialogButtons() {
       {
         label: { token: 'retry' },
         dataTestId: 'pro-backend-error-retry-button',
-        onClick: refetch,
+        // Trigger #5, a manual retry: one of the two sanctioned `immediate` callers. Wrapped rather
+        // than passed as `onClick: refetch` so the click event isn't handed over as the options arg.
+        onClick: () => refetch({ immediate: true }),
         closeAfterClick: true,
       },
       {
@@ -231,6 +233,13 @@ const useCurrentNeverHadProInternal = useCurrentNeverHadPro;
 const useIsDarkThemeInternal = useIsDarkTheme;
 const usePinnedConversationsCountInternal = usePinnedConversationsCount;
 
+// Trigger #4's cadence (a cross-client contract, see the constants in ducks/proBackendData.ts).
+/** How long past the `user_expiry` crossing to wait before the first refetch. */
+const GRACE_POLL_CROSSING_SLACK_MS = 5 * DURATION.SECONDS;
+/** Then re-check on this cadence while still un-renewed. Equal to STATUS_FLOOR_MS by design, which
+ * is why #4 must bypass the floor rather than be halved by it. */
+const GRACE_POLL_INTERVAL_MS = 1 * DURATION.MINUTES;
+
 // Extracted into its own hook so the react compiler compiles a small, clean function rather than
 // choking on a raw useEffect inside the large ProSettings component.
 function useKeepProStatusFresh({
@@ -253,20 +262,31 @@ function useKeepProStatusFresh({
     if (isLoading || isError || userHasExpiredPro || !autoRenew || !expiryTimeMs) {
       return undefined;
     }
+    // Trigger #4 is exempt from the status floor: it is a bounded poll with its own cadence and its
+    // own termination (the guard above), and its 60s interval would otherwise sit right on the 60s
+    // floor and be dropped about half the time.
+    //
+    // ⚠️ The exemption and the `!autoRenew` guard above are a PAIR — the guard is what makes this
+    // bounded, and being unfloored is what makes an unbounded version expensive. `!autoRenew` means no
+    // renewal is in flight, so there is nothing to poll for; without it a lapsed non-renewing
+    // subscription would poll the backend every 60s, floor-exempt, for as long as the page is open.
+    // iOS shipped exactly that (no guard, no coverage bound) and is adding this guard to match.
+    // Removing it becomes correct only if this poll stops being floor-exempt, or gains an independent
+    // upper bound on its lifetime. Not before.
     const fire = () =>
       window.inboxStore?.dispatch(
-        proBackendDataActions.refreshGetProStatusFromProBackend({}) as any
+        proBackendDataActions.refreshGetProStatusFromProBackend({ immediate: true }) as any
       );
     const msUntilExpiry = expiryTimeMs - NetworkTime.now();
     if (msUntilExpiry > 0) {
       // Refetch just after the crossing, so a renewal (or a genuine failure) replaces the stale value.
-      const timeoutId = setTimeout(fire, msUntilExpiry + 5 * DURATION.SECONDS);
+      const timeoutId = setTimeout(fire, msUntilExpiry + GRACE_POLL_CROSSING_SLACK_MS);
       return () => clearTimeout(timeoutId);
     }
     // Past expiry and still auto-renewing (grace/renewal window): the renewal can succeed at any
     // point, so re-check until get_pro_status reports the new expiry (the deps change re-arms the
     // one-shot above) or the account flips to expired (the guard returns).
-    const intervalId = setInterval(fire, DURATION.MINUTES);
+    const intervalId = setInterval(fire, GRACE_POLL_INTERVAL_MS);
     return () => clearInterval(intervalId);
   }, [expiryTimeMs, autoRenew, userHasExpiredPro, isLoading, isError]);
 }

--- a/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
@@ -244,12 +244,14 @@ const GRACE_POLL_INTERVAL_MS = 1 * DURATION.MINUTES;
 // choking on a raw useEffect inside the large ProSettings component.
 function useKeepProStatusFresh({
   expiryTimeMs,
+  coverageEndMs,
   autoRenew,
   userHasExpiredPro,
   isLoading,
   isError,
 }: {
   expiryTimeMs: number;
+  coverageEndMs: number;
   autoRenew: boolean;
   userHasExpiredPro: boolean;
   isLoading: boolean;
@@ -267,24 +269,37 @@ function useKeepProStatusFresh({
     //
     // The exemption and the `autoRenew` guard above are a pair: the guard is what bounds this, and being
     // unfloored is what makes an unbounded version expensive. Without it a lapsed non-renewing
-    // subscription polls every 60s, floor-exempt, for as long as the page is open. Removing the guard
-    // needs this poll to either lose the exemption or gain an independent lifetime bound.
+    // subscription polls every 60s, floor-exempt, for as long as the page is open. The coverage-end
+    // (`E + G`) bound below is that independent lifetime bound: the poll stops when the grace window
+    // closes rather than running for as long as the page stays open, matching Android/iOS, which bound
+    // their while-open poll at coverage end rather than leaning on `userHasExpiredPro` flipping.
     const fire = () =>
       window.inboxStore?.dispatch(
         proBackendDataActions.refreshGetProStatusFromProBackend({ immediate: true }) as any
       );
-    const msUntilExpiry = expiryTimeMs - NetworkTime.now();
+    const now = NetworkTime.now();
+    // Nothing left to catch once coverage has ended, so never arm past it.
+    if (now >= coverageEndMs) {
+      return undefined;
+    }
+    const msUntilExpiry = expiryTimeMs - now;
     if (msUntilExpiry > 0) {
       // Refetch just after the crossing, so a renewal (or a genuine failure) replaces the stale value.
       const timeoutId = setTimeout(fire, msUntilExpiry + GRACE_POLL_CROSSING_SLACK_MS);
       return () => clearTimeout(timeoutId);
     }
-    // Past expiry and still auto-renewing (grace/renewal window): the renewal can succeed at any
-    // point, so re-check until get_pro_status reports the new expiry (the deps change re-arms the
-    // one-shot above) or the account flips to expired (the guard returns).
-    const intervalId = setInterval(fire, GRACE_POLL_INTERVAL_MS);
+    // In the grace window [E, E+G): the renewal can succeed at any point, so re-check until
+    // get_pro_status reports the new expiry (the deps change re-arms this) or coverage ends, whichever
+    // comes first. The interval clears itself at coverage end so it can never outlive the grace window.
+    const intervalId = setInterval(() => {
+      if (NetworkTime.now() >= coverageEndMs) {
+        clearInterval(intervalId);
+        return;
+      }
+      fire();
+    }, GRACE_POLL_INTERVAL_MS);
     return () => clearInterval(intervalId);
-  }, [expiryTimeMs, autoRenew, userHasExpiredPro, isLoading, isError]);
+  }, [expiryTimeMs, coverageEndMs, autoRenew, userHasExpiredPro, isLoading, isError]);
 }
 
 function ProNonProContinueButton({ state }: SectionProps) {
@@ -505,6 +520,7 @@ function ProSettings({ state }: SectionProps) {
 
   useKeepProStatusFresh({
     expiryTimeMs: data.expiryTimeMs,
+    coverageEndMs: data.coverageEndMs,
     autoRenew: data.autoRenew,
     userHasExpiredPro,
     isLoading,

--- a/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
@@ -262,16 +262,13 @@ function useKeepProStatusFresh({
     if (isLoading || isError || userHasExpiredPro || !autoRenew || !expiryTimeMs) {
       return undefined;
     }
-    // Trigger #4 is exempt from the status floor: it is a bounded poll with its own cadence and its
-    // own termination (the guard above), and its 60s interval would otherwise sit right on the 60s
-    // floor and be dropped about half the time.
+    // Floor-exempt because its 60s interval would otherwise sit exactly on the 60s floor and be dropped
+    // about half the time.
     //
-    // ⚠️ The exemption and the `!autoRenew` guard above are a PAIR — the guard is what makes this
-    // bounded, and being unfloored is what makes an unbounded version expensive. `!autoRenew` means no
-    // renewal is in flight, so there is nothing to poll for; without it a lapsed non-renewing
-    // subscription would poll the backend every 60s, floor-exempt, for as long as the page is open.
-    // Removing it becomes correct only if this poll stops being floor-exempt, or gains an independent
-    // upper bound on its lifetime. Not before.
+    // The exemption and the `autoRenew` guard above are a pair: the guard is what bounds this, and being
+    // unfloored is what makes an unbounded version expensive. Without it a lapsed non-renewing
+    // subscription polls every 60s, floor-exempt, for as long as the page is open. Removing the guard
+    // needs this poll to either lose the exemption or gain an independent lifetime bound.
     const fire = () =>
       window.inboxStore?.dispatch(
         proBackendDataActions.refreshGetProStatusFromProBackend({ immediate: true }) as any

--- a/ts/components/dialog/user-settings/pages/userSettingsHooks.tsx
+++ b/ts/components/dialog/user-settings/pages/userSettingsHooks.tsx
@@ -7,7 +7,6 @@ import {
 } from '../../../../state/ducks/modalDialog';
 import { assertUnreachable } from '../../../../types/sqlSharedTypes';
 import { handleTriggeredCTAs } from '../../SessionCTA';
-import { getFeatureFlag } from '../../../../state/ducks/types/releasedFeaturesReduxTypes';
 
 export function useUserSettingsTitle(page: UserSettingsModalState | undefined) {
   if (!page) {
@@ -81,9 +80,7 @@ export function useUserSettingsCloseAction(props: UserSettingsModalState) {
     case 'proNonOriginating':
       return () => {
         dispatch(userSettingsModal(null));
-        if (getFeatureFlag('proAvailable')) {
-          void handleTriggeredCTAs(dispatch, false);
-        }
+        void handleTriggeredCTAs(dispatch, false);
         props.afterCloseAction?.();
       };
 

--- a/ts/components/leftpane/ActionsPanel.tsx
+++ b/ts/components/leftpane/ActionsPanel.tsx
@@ -59,7 +59,6 @@ import {
 } from '../../state/ducks/types/releasedFeaturesReduxTypes';
 import { useDebugKey } from '../../hooks/useDebugKey';
 import { UpdateProRevocationList } from '../../session/utils/job_runners/jobs/UpdateProRevocationListJob';
-import { getIsProAvailableMemo } from '../../hooks/useIsProAvailable';
 import { SettingsKey } from '../../data/settings-key';
 import { useKeyboardShortcut } from '../../hooks/useKeyboardShortcut';
 import { KbdShortcut } from '../../util/keyboardShortcuts';
@@ -119,12 +118,8 @@ function useUpdateBadgeCount() {
  * Note: a job will only be added if it wasn't fetched recently, so there is no harm in running this every minute.
  */
 function usePeriodicFetchRevocationList() {
-  const proAvailable = getIsProAvailableMemo();
   useInterval(
     () => {
-      if (!proAvailable) {
-        return;
-      }
       void UpdateProRevocationList.queueNewJobIfNeeded();
     },
     // Note: we tick every 15 minutes in prod, but the job won't be added unless it needs to

--- a/ts/components/menuAndSettingsHooks/UseTogglePinConversationHandler.tsx
+++ b/ts/components/menuAndSettingsHooks/UseTogglePinConversationHandler.tsx
@@ -1,5 +1,4 @@
 import { useSelector } from 'react-redux';
-import { getIsProAvailableMemo } from '../../hooks/useIsProAvailable';
 import { ConvoHub } from '../../session/conversations';
 import {
   useIsKickedFromGroup,
@@ -55,15 +54,12 @@ export function useTogglePinConversationHandler(id: string) {
 
   const showPinUnpin = useShowPinUnpin(id);
 
-  const isProAvailable = getIsProAvailableMemo();
-
   if (!showPinUnpin) {
     return null;
   }
 
   if (
     isPinned ||
-    !isProAvailable ||
     hasPro ||
     pinnedConversationsCount < Constants.CONVERSATION.MAX_PINNED_CONVERSATIONS_STANDARD
   ) {

--- a/ts/components/menuAndSettingsHooks/useProBadgeOnClickCb.tsx
+++ b/ts/components/menuAndSettingsHooks/useProBadgeOnClickCb.tsx
@@ -1,5 +1,4 @@
 import { getAppDispatch } from '../../state/dispatch';
-import { getIsProAvailableMemo } from '../../hooks/useIsProAvailable';
 import { ProMessageFeature } from '../../models/proMessageFeature';
 import { SessionCTAState, updateSessionCTA } from '../../state/ducks/modalDialog';
 import { assertUnreachable } from '../../types/sqlSharedTypes';
@@ -127,12 +126,6 @@ export function useProBadgeOnClickCb(
 ): ShowTagWithCb | ShowTagNoCb | DoNotShowTag {
   const dispatch = getAppDispatch();
   const handleShowProInfoModal = useShowSessionCTACbWithVariant();
-  const isProAvailable = getIsProAvailableMemo();
-
-  if (!isProAvailable) {
-    // if pro is globally disabled, we never show the badge.
-    return doNotShow;
-  }
 
   const { context, args } = opts;
 

--- a/ts/data/settings-key.ts
+++ b/ts/data/settings-key.ts
@@ -93,6 +93,27 @@ export const SettingsKey = {
    */
   proRevocationListNextRunAtMs: 'proRevocationListNextRunAtMs',
   proStatus: 'proStatus',
+  /**
+   * When a get_pro_status request was last STARTED, number | undefined (ms since epoch, network
+   * time). Backs the 60s status-refresh floor, which exists to bound requests — a failing request
+   * costs the backend the same as a succeeding one, so this is stamped on attempt, not on success.
+   *
+   * Persisted rather than kept in redux because the floor's whole job is to survive a process
+   * restart; an in-memory timestamp resets on every cold start, which is the exact path the startup
+   * gate is about.
+   *
+   * ⚠️ NOT interchangeable with redux `proBackendData.details.lastFetchedMs`, which is per-run and
+   * stamped on COMPLETION. Anything asking "have we confirmed our status (since X)" — the grace
+   * warning's debounce, the home CTA gate — must use that one. Using this key there would let a
+   * *failed* request satisfy the check and surface the false alarm the debounce exists to prevent.
+   */
+  proStatusLastFetchAttemptMs: 'proStatusLastFetchAttemptMs',
+  /**
+   * When we last let a *cold start* fetch get_pro_status, number | undefined (ms since epoch,
+   * network time). Separate from proStatusLastFetchAttemptMs so the ~24h startup interval isn't reset by
+   * routine in-session refreshes.
+   */
+  proStatusLastStartupFetchMs: 'proStatusLastStartupFetchMs',
   // NOTE: for these CTAs undefined means it has never been shown in this cycle of pro access, true means it needs to be shown and false means it has been shown and dont show it again.
   proExpiringSoonCTA: 'proExpiringSoonCTA',
   proExpiredCTA: 'proExpiredCTA',

--- a/ts/data/settings-key.ts
+++ b/ts/data/settings-key.ts
@@ -94,18 +94,14 @@ export const SettingsKey = {
   proRevocationListNextRunAtMs: 'proRevocationListNextRunAtMs',
   proStatus: 'proStatus',
   /**
-   * When a get_pro_status request was last STARTED, number | undefined (ms since epoch, network
-   * time). Backs the 60s status-refresh floor, which exists to bound requests — a failing request
-   * costs the backend the same as a succeeding one, so this is stamped on attempt, not on success.
+   * When a get_pro_status request was last STARTED, number | undefined (ms since epoch, network time).
+   * Backs the 60s status-refresh floor. Stamped on attempt rather than success because a failing request
+   * costs the backend the same as a succeeding one, and persisted because the floor has to survive the
+   * process restart that the startup gate is about.
    *
-   * Persisted rather than kept in redux because the floor's whole job is to survive a process
-   * restart; an in-memory timestamp resets on every cold start, which is the exact path the startup
-   * gate is about.
-   *
-   * ⚠️ NOT interchangeable with redux `proBackendData.details.lastFetchedMs`, which is per-run and
-   * stamped on COMPLETION. Anything asking "have we confirmed our status (since X)" — the grace
-   * warning's debounce, the home CTA gate — must use that one. Using this key there would let a
-   * *failed* request satisfy the check and surface the false alarm the debounce exists to prevent.
+   * Not interchangeable with redux `proBackendData.details.lastFetchedMs`, which is per-run and stamped
+   * on COMPLETION. Anything asking "have we confirmed our status" must use that one — this key would let
+   * a *failed* request satisfy the check.
    */
   proStatusLastFetchAttemptMs: 'proStatusLastFetchAttemptMs',
   /**

--- a/ts/hooks/useHasPro.ts
+++ b/ts/hooks/useHasPro.ts
@@ -1,6 +1,5 @@
 import { useSelector } from 'react-redux';
 import { getDataFeatureFlagMemo } from '../state/ducks/types/releasedFeaturesReduxTypes';
-import { getIsProAvailableMemo } from './useIsProAvailable';
 import {
   defaultProAccessDetailsSourceData,
   getProBackendCurrentUserStatus,
@@ -32,20 +31,18 @@ function useCurrentUserProStatus() {
  * Returns true if pro is available, and the current user has pro (active, not expired)
  */
 export function useCurrentUserHasPro() {
-  const isProAvailable = getIsProAvailableMemo();
   const status = useCurrentUserProStatus();
 
-  return isProAvailable && status === ProStatus.Active;
+  return status === ProStatus.Active;
 }
 
 /**
  * Returns true if pro is available, and the current user has expired pro.
  */
 export function useCurrentUserHasExpiredPro() {
-  const isProAvailable = getIsProAvailableMemo();
   const status = useCurrentUserProStatus();
 
-  return isProAvailable && status === ProStatus.Expired;
+  return status === ProStatus.Expired;
 }
 
 /**
@@ -53,10 +50,9 @@ export function useCurrentUserHasExpiredPro() {
  * (i.e. the user does not have pro currently and doesn't have an expired pro either)
  */
 export function useCurrentNeverHadPro() {
-  const isProAvailable = getIsProAvailableMemo();
   const status = useCurrentUserProStatus();
 
-  return isProAvailable && status === ProStatus.Never;
+  return status === ProStatus.Never;
 }
 
 /**
@@ -70,15 +66,10 @@ function useShowProBadgeForOther(convoId?: string) {
 }
 
 export function useShowProBadgeFor(convoId?: string) {
-  const isProAvailable = getIsProAvailableMemo();
   // the current user pro badge is always shown if we have a valid pro
   const currentUserHasPro = useCurrentUserHasPro();
   // the other user pro badge is shown if they have a valid pro proof and pro badge feature enabled
   const otherUserHasPro = useShowProBadgeForOther(convoId);
-
-  if (!isProAvailable) {
-    return false;
-  }
 
   if (UserUtils.isUsFromCache(convoId)) {
     return currentUserHasPro;

--- a/ts/hooks/useIsProAvailable.ts
+++ b/ts/hooks/useIsProAvailable.ts
@@ -1,9 +1,5 @@
 import { getFeatureFlagMemo } from '../state/ducks/types/releasedFeaturesReduxTypes';
 
-export function getIsProAvailableMemo() {
-  return !!getFeatureFlagMemo('proAvailable');
-}
-
 export function getIsProGroupsAvailableMemo() {
   return !!getFeatureFlagMemo('proGroupsAvailable');
 }

--- a/ts/models/conversation.ts
+++ b/ts/models/conversation.ts
@@ -2039,22 +2039,9 @@ export class ConversationModel extends Model<ConversationAttributes> {
    * If the user is not a pro user, return the fallback avatar path (first or only frame extracted)
    */
   public getProOrNotAvatarPath() {
-    const proAvailable = getFeatureFlag('proAvailable');
-    const avatarPicked =
-      proAvailable && !this.hasValidCurrentProProof()
-        ? this.getFallbackAvatarInProfilePath()
-        : this.getAvatarInProfilePath();
-
-    // window.log.debug(
-    //   `getProOrNotAvatarPath for ${ed25519Str(this.id)}: `,
-    //   JSON.stringify({
-    //     proAvailable,
-    //     validCurrentProof: this.hasValidCurrentProProof(),
-    //     avatarInProfilePath: this.getAvatarInProfilePath(),
-    //     fallbackAvatarInProfilePath: this.getFallbackAvatarInProfilePath(),
-    //     avatarPicked,
-    //   })
-    // );
+    const avatarPicked = !this.hasValidCurrentProProof()
+      ? this.getFallbackAvatarInProfilePath()
+      : this.getAvatarInProfilePath();
 
     return avatarPicked;
   }

--- a/ts/models/message.ts
+++ b/ts/models/message.ts
@@ -108,7 +108,6 @@ import { tStrippedWithObj, tr, tStripped } from '../localization/localeTools';
 import type { QuotedAttachmentType } from '../components/conversation/message/message-content/quote/Quote';
 import { ProFeatures, ProMessageFeature } from './proMessageFeature';
 import { privateSet, privateSetKey } from './modelFriends';
-import { getFeatureFlag } from '../state/ducks/types/releasedFeaturesReduxTypes';
 import type { OutgoingProMessageDetails } from '../types/message/OutgoingProMessageDetails';
 import { longOrNumberToBigInt } from '../types/Bigint';
 import type { WithLocalMessageDeletionType } from '../session/types/with';
@@ -1533,10 +1532,6 @@ export class MessageModel extends Model<MessageAttributes> {
   }
 
   private getProFeaturesUsed(): Array<ProMessageFeature> {
-    if (!getFeatureFlag('proAvailable')) {
-      return [];
-    }
-
     const proProfileBitset = this.get('proProfileBitset');
     const proMessageBitset = this.get('proMessageBitset');
     if (!proProfileBitset && !proMessageBitset) {
@@ -1557,9 +1552,6 @@ export class MessageModel extends Model<MessageAttributes> {
     proProfileBitset: bigint | null;
     proMessageBitset: bigint | null;
   }) {
-    if (!getFeatureFlag('proAvailable')) {
-      return false;
-    }
     const proProfileStr = proProfileBitset ? proProfileBitset.toString() : undefined;
     const proMessageStr = proMessageBitset ? proMessageBitset.toString() : undefined;
     if (

--- a/ts/receiver/configMessage.ts
+++ b/ts/receiver/configMessage.ts
@@ -61,7 +61,7 @@ import {
   getCachedUserConfig,
   UserConfigWrapperActions,
 } from '../webworker/workers/browser/libsession/libsession_worker_userconfig_interface';
-import { proBackendDataActions } from '../state/ducks/proBackendData';
+import { proBackendDataActions, reconcileProProof } from '../state/ducks/proBackendData';
 
 type IncomingUserResult = {
   needsPush: boolean;
@@ -144,18 +144,47 @@ async function mergeUserConfigsWithIncomingUpdates(
       // the GenericWrapperActions
       switch (variant) {
         case 'UserConfig': {
+          // Trigger #2 watches BOTH the access expiry (`E`) and the prepaid marker (`I`). `I` matters
+          // on its own: another device's purchase syncs a prepaid marker without `E` having moved
+          // yet, and that is exactly the moment we want to re-read our status. Android has always
+          // watched the pair; Desktop watched `E` alone.
+          //
+          // Deliberately NOT watching `auto_renewing` (`A`): a change there re-derives the display
+          // from the synced value we just received, and fetching to confirm what we were told would
+          // be a pointless round trip.
+          //
           // Note: those `?? 0` is here because android sets it to 0 even if it should be unset.
           const proAccessExpiryBefore = (await UserConfigWrapperActions.getProAccessExpiry()) ?? 0;
+          const proPrepaidBefore = (await UserConfigWrapperActions.getProPrepaid()) ?? 0;
           hashesMerged = await UserConfigWrapperActions.merge(toMerge);
           const proAccessExpiryAfter = (await UserConfigWrapperActions.getProAccessExpiry()) ?? 0;
+          const proPrepaidAfter = (await UserConfigWrapperActions.getProPrepaid()) ?? 0;
 
-          if (proAccessExpiryBefore !== proAccessExpiryAfter) {
+          const accessExpiryChanged = proAccessExpiryBefore !== proAccessExpiryAfter;
+          const prepaidChanged = proPrepaidBefore !== proPrepaidAfter;
+
+          if (accessExpiryChanged || prepaidChanged) {
             window.log.debug(
-              `[mergeConfigsWithInboxUpdates] proAccessExpiry changed from ${proAccessExpiryBefore} to ${proAccessExpiryAfter}. Refreshing our pro status.`
+              `[mergeConfigsWithInboxUpdates] pro config changed (proAccessExpiry ${proAccessExpiryBefore} -> ${proAccessExpiryAfter}, proPrepaid ${proPrepaidBefore} -> ${proPrepaidAfter}). Refreshing our pro status.`
             );
             window.inboxStore?.dispatch(
               proBackendDataActions.refreshGetProStatusFromProBackend({}) as any
             );
+          }
+
+          if (accessExpiryChanged) {
+            // The `E`-changed proof nudge, called directly rather than relied upon as a side effect
+            // of the status fetch above. It used to arrive that way (every completed fetch ends with
+            // a reconcile), but the status refresh is now floored and a dropped fetch never reaches
+            // that callback — so the nudge has to be independent of whether the fetch ran.
+            //
+            // It is the one edge from config to the proof loop, and it is load-bearing: if the
+            // account had lapsed and the proof expired, `pro_renewal_target` returns nothing and the
+            // loop sits dormant with no wake. A synced `E` that advances means it would now say
+            // "renew now", and nothing else re-evaluates that. A nudge the reconcile ignores (valid
+            // proof, future target) is a harmless no-op, so any change is nudged, not just
+            // past -> future.
+            void reconcileProProof();
           }
 
           break;

--- a/ts/receiver/configMessage.ts
+++ b/ts/receiver/configMessage.ts
@@ -146,8 +146,7 @@ async function mergeUserConfigsWithIncomingUpdates(
         case 'UserConfig': {
           // Trigger #2 watches BOTH the access expiry (`E`) and the prepaid marker (`I`). `I` matters
           // on its own: another device's purchase syncs a prepaid marker without `E` having moved
-          // yet, and that is exactly the moment we want to re-read our status. Android has always
-          // watched the pair; Desktop watched `E` alone.
+          // yet, and that is exactly the moment we want to re-read our status.
           //
           // Deliberately NOT watching `auto_renewing` (`A`): a change there re-derives the display
           // from the synced value we just received, and fetching to confirm what we were told would
@@ -173,10 +172,10 @@ async function mergeUserConfigsWithIncomingUpdates(
           }
 
           if (accessExpiryChanged) {
-            // The `E`-changed proof nudge, called directly rather than relied upon as a side effect
-            // of the status fetch above. It used to arrive that way (every completed fetch ends with
-            // a reconcile), but the status refresh is now floored and a dropped fetch never reaches
-            // that callback — so the nudge has to be independent of whether the fetch ran.
+            // The `E`-changed proof nudge, called directly rather than left to the status fetch above
+            // as a side effect. Every completed fetch does end with a reconcile, but that fetch is
+            // floored and a dropped one never reaches its callback, so the nudge has to hold whether or
+            // not the fetch ran.
             //
             // It is the one edge from config to the proof loop, and it is load-bearing: if the
             // account had lapsed and the proof expired, `pro_renewal_target` returns nothing and the

--- a/ts/receiver/configMessage.ts
+++ b/ts/receiver/configMessage.ts
@@ -144,13 +144,11 @@ async function mergeUserConfigsWithIncomingUpdates(
       // the GenericWrapperActions
       switch (variant) {
         case 'UserConfig': {
-          // Trigger #2 watches BOTH the access expiry (`E`) and the prepaid marker (`I`). `I` matters
-          // on its own: another device's purchase syncs a prepaid marker without `E` having moved
-          // yet, and that is exactly the moment we want to re-read our status.
-          //
-          // Deliberately NOT watching `auto_renewing` (`A`): a change there re-derives the display
-          // from the synced value we just received, and fetching to confirm what we were told would
-          // be a pointless round trip.
+          // Watches both the access expiry (`E`) and the prepaid marker (`I`). `I` matters on its own:
+          // another device's purchase syncs a prepaid marker before `E` moves, which is exactly when we
+          // want to re-read our status. `auto_renewing` is deliberately not watched — a change there
+          // re-derives the display from the value we just received, so fetching would confirm what we
+          // were already told.
           //
           // Note: those `?? 0` is here because android sets it to 0 even if it should be unset.
           const proAccessExpiryBefore = (await UserConfigWrapperActions.getProAccessExpiry()) ?? 0;

--- a/ts/receiver/queuedJob.ts
+++ b/ts/receiver/queuedJob.ts
@@ -20,7 +20,6 @@ import LIBSESSION_CONSTANTS from '../session/utils/libsession/libsession_constan
 import { longOrNumberToNumber } from '../types/long/longOrNumberToNumber';
 import { getHideMessageRequestBannerOutsideRedux } from '../state/selectors/settings';
 import { showMessageRequestBannerOutsideRedux } from '../state/ducks/settings';
-import { getFeatureFlag } from '../state/ducks/types/releasedFeaturesReduxTypes';
 import type { StateType } from '../state/reducer';
 import { isUsFromCache } from '../session/utils/User';
 import { isUsAnySogsFromCache } from '../session/apis/open_group_api/sogsv3/knownBlindedkeys';
@@ -230,11 +229,9 @@ async function handleRegularMessage(
 
   handleLinkPreviews(rawDataMessage.body, rawDataMessage.preview, message);
 
-  // NOTE: The truncation value must be the Pro count so when Pro is released older clients wont truncate pro messages.
-  const maxChars =
-    !getFeatureFlag('proAvailable') || sendingDeviceConversation.hasValidCurrentProProof()
-      ? LIBSESSION_CONSTANTS.MESSAGE_CHARACTER_LIMIT_PRO
-      : LIBSESSION_CONSTANTS.MESSAGE_CHARACTER_LIMIT_STANDARD;
+  const maxChars = sendingDeviceConversation.hasValidCurrentProProof()
+    ? LIBSESSION_CONSTANTS.MESSAGE_CHARACTER_LIMIT_PRO
+    : LIBSESSION_CONSTANTS.MESSAGE_CHARACTER_LIMIT_STANDARD;
 
   const body = [...rawDataMessage.body].slice(0, maxChars).join('');
 

--- a/ts/session/utils/User.ts
+++ b/ts/session/utils/User.ts
@@ -11,7 +11,6 @@ import { ProWrapperActions } from '../../webworker/workers/browser/libsession_wo
 import { OutgoingUserProfile } from '../../types/message';
 import { SettingsKey } from '../../data/settings-key';
 import { OutgoingProMessageDetails } from '../../types/message/OutgoingProMessageDetails';
-import { getFeatureFlag } from '../../state/ducks/types/releasedFeaturesReduxTypes';
 import {
   getCachedUserConfig,
   UserConfigWrapperActions,
@@ -142,9 +141,6 @@ export async function getOutgoingProMessageDetails({
 }: {
   utf16: string | null | undefined;
 }) {
-  if (!getFeatureFlag('proAvailable')) {
-    return null;
-  }
   const [proConfig, proProfileBitset] = await Promise.all([
     UserConfigWrapperActions.getProConfig(),
     UserConfigWrapperActions.getProProfileBitset(),

--- a/ts/session/utils/job_runners/jobs/UpdateProRevocationListJob.ts
+++ b/ts/session/utils/job_runners/jobs/UpdateProRevocationListJob.ts
@@ -77,9 +77,6 @@ class UpdateProRevocationListJob extends PersistedJob<UpdateProRevocationListPer
   }
 
   public async run(): Promise<RunJobResult> {
-    if (!getFeatureFlag('proAvailable')) {
-      return RunJobResult.Success;
-    }
     const start = Date.now();
 
     try {

--- a/ts/state/ducks/conversations.ts
+++ b/ts/state/ducks/conversations.ts
@@ -38,7 +38,6 @@ import { ed25519Str } from '../../session/utils/String';
 import { UserUtils } from '../../session/utils';
 import type { ProMessageFeature } from '../../models/proMessageFeature';
 import { handleTriggeredCTAs } from '../../components/dialog/SessionCTA';
-import { getFeatureFlag } from './types/releasedFeaturesReduxTypes';
 import type { Quote } from '../../session/messages/outgoing/visibleMessage/VisibleMessage';
 import { PopoverTriggerPosition } from '../../components/SessionTooltip';
 
@@ -1289,9 +1288,7 @@ export async function openConversationWithMessages(args: {
   window.inboxStore?.dispatch(sectionActions.resetRightOverlayMode());
 
   if (window.inboxStore) {
-    if (getFeatureFlag('proAvailable')) {
-      await handleTriggeredCTAs(window.inboxStore.dispatch, false);
-    }
+    await handleTriggeredCTAs(window.inboxStore.dispatch, false);
   }
 }
 

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -264,6 +264,15 @@ async function applyProofOutcome(
       if (!haveValidProof()) {
         await UserConfigWrapperActions.removeProConfig();
         await UserConfigWrapperActions.setProAccessExpiry(null);
+        // Entitlement ended, and nothing observes that: the config watch that would refresh our status
+        // runs on incoming merges, so a local write reaches no one. The Expired CTA needs a status fetch
+        // to be raised at all — it is written by one — and the clear above leaves the cold-start gate
+        // without a horizon to decide from, so this is the only edge from "we just lapsed" to "find out
+        // what to show". Floored like every routine trigger: when a status fetch has just run, this is
+        // dropped, which is right — that fetch already had the chance to raise it.
+        window.inboxStore?.dispatch(
+          proBackendDataActions.refreshGetProStatusFromProBackend({}) as any
+        );
       }
       break;
     case 'not_subscribed':

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -258,21 +258,20 @@ async function applyProofOutcome(
     // false are the same bit), and `E - G` could pair a fresh expiry with a grace learned in a different
     // billing period.
     //
-    // ⚠️ All three writes are CONDITIONAL ON PRESENCE, and that is load-bearing rather than defensive.
-    // These are advisory optionals: absent means "the backend did not say", NOT false or zero. Writing a
-    // collapsed `?? false` / `?? 0` would ERASE the key — both are stored presence-only — so against a
-    // backend predating either field, every proof fetch would wipe a correct value learned from
-    // `get_pro_status`. That is strictly worse than not writing at all: today the value merely fails to
-    // be refreshed; collapsed, it would be actively destroyed.
+    // ⚠️ These writes belong INSIDE the success branch and must stay there. `accountAutoRenewing` and
+    // `accountGracePeriodMs` are non-null because core requires them on a successful parse — a response
+    // missing either is a parse error, not a defaulted value. But on a *failure* outcome core never fills
+    // them and its struct defaults (`false` / `0`) come through, which are indistinguishable from a
+    // backend that really said "not renewing, no grace". Both config keys are presence-only, so writing
+    // that false or zero would ERASE what a `get_pro_status` fetch had learned. The success branch is the
+    // only place these two mean anything.
+    //
+    // `accountExpiryMs` is still nullable — absent on `not_subscribed` and `revoked` — hence its guard.
     if (response.accountExpiryMs !== null) {
       await UserConfigWrapperActions.setProAccessExpiry(response.accountExpiryMs);
     }
-    if (response.accountAutoRenewing !== null) {
-      await writeProAutoRenewingToConfig(response.accountAutoRenewing);
-    }
-    if (response.accountGracePeriodMs !== null) {
-      await UserConfigWrapperActions.setProGracePeriod(response.accountGracePeriodMs);
-    }
+    await writeProAutoRenewingToConfig(response.accountAutoRenewing);
+    await UserConfigWrapperActions.setProGracePeriod(response.accountGracePeriodMs);
     return;
   }
   // Non-ok: the machine slug (error_code) decides.

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -35,7 +35,7 @@ type RequestState<D = unknown> = {
   //
   // Per-run and completion-stamped, which makes it the answer to "has this process confirmed our
   // status (since some threshold)": the floor's never-confirmed-this-process exemption, the home Pro
-  // CTA gate, and the grace warning's `lastFetchedMs >= renewalDueAtMs` debounce all read it.
+  // CTA gate, and the grace warning's `lastFetchedMs >= E` debounce all read it.
   //
   // ⚠️ Do NOT substitute SettingsKey.proStatusLastFetchAttemptMs for any of those. That one is
   // persisted and stamped on *attempt*, because it backs the 60s floor, whose job is to bound
@@ -255,7 +255,7 @@ async function applyProofOutcome(
     // `A` and `G` ride along, so every path that writes `E` writes all three from the same response.
     // This path used to write `E` alone, with two consequences: an account whose expiry came only from a
     // proof read back as terminal while it was in fact renewing (`A` is presence-only, so unwritten and
-    // false are the same bit), and `E - G` could pair a fresh expiry with a grace learned in a different
+    // false are the same bit), and `E + G` could pair a fresh expiry with a grace learned in a different
     // billing period.
     //
     // ⚠️ These writes belong INSIDE the success branch and must stay there. `accountAutoRenewing` and
@@ -322,7 +322,7 @@ async function handleClearProProof() {
  * Minimum gap between *routine* status fetches. Drop-on-fresh — see statusFetchIsFloored.
  *
  * ⚠️ A SCHEDULED WAKE DEPENDS ON THIS NOT BEING CROSSED. `scheduleUserExpiryStatusWake` arms two
- * instants `G` apart — the renewal date and coverage end — and both emit through the *floored* path, not
+ * instants `G` apart — the expiry and coverage end — and both emit through the *floored* path, not
  * the `immediate` one. So when `G < STATUS_FLOOR_MS` the second wake fires and its fetch is dropped.
  *
  * In production `G` is at least an hour, so this cannot happen. It happens on a **compressed testing
@@ -423,10 +423,10 @@ let userExpiryWakeIds: Array<ReturnType<typeof setTimeout>> = [];
  * Schedule the background status refreshes around the end of a billing period.
  *
  * This is the background half of surfacing grace. The Pro page refetches across the crossing while it is
- * open, but that is screen-scoped: with the page closed nothing would re-check between the renewal date
- * and the proof loop's own wake, so a renewal that failed would surface only in that final hour.
+ * open, but that is screen-scoped: with the page closed nothing would re-check between the expiry and
+ * the proof loop's own wake, so a renewal that failed would surface only in that final hour.
  *
- * Two instants, at `(E - G) + 30s` and `E + 30s`, collapsing to one when `G` is zero. The second is not
+ * Two instants, at `E + 30s` and `(E + G) + 30s`, collapsing to one when `G` is zero. The second is not
  * redundant: the proof loop does wake near `E` by construction (the backend issues `proof_expiry` ~1h
  * past `E`, and `pro_renewal_target` is ~1h before proof expiry), and a proof outcome now writes
  * `E`/`A`/`G`, which fires the config-change trigger. But that chain is gated on `E` actually changing —
@@ -461,18 +461,18 @@ export async function scheduleUserExpiryStatusWake(): Promise<void> {
     return;
   }
   const gracePeriodMs = await UserConfigWrapperActions.getProGracePeriod();
-  const renewalDueAtMs = accessExpiryMs - gracePeriodMs;
+  const coverageEndMs = accessExpiryMs + gracePeriodMs;
 
   // Two instants, because two distinct transitions matter and neither implies the other:
   //
-  //   renewal due (E - G)   did the charge succeed, or has it silently failed?
-  //   coverage end (E)      did grace run out without a recovery?
+  //   expiry (E)              did the charge succeed, or has it silently failed?
+  //   coverage end (E + G)    did grace run out without a recovery?
   //
   // Only one when `G` is zero, which is every non-auto-renewing account: the two collapse to the same
   // moment and scheduling both would just double the fetch.
-  const wakeAtMs = [renewalDueAtMs];
-  if (accessExpiryMs !== renewalDueAtMs) {
-    wakeAtMs.push(accessExpiryMs);
+  const wakeAtMs = [accessExpiryMs];
+  if (coverageEndMs !== accessExpiryMs) {
+    wakeAtMs.push(coverageEndMs);
   }
 
   const now = NetworkTime.now();
@@ -504,15 +504,18 @@ export async function scheduleUserExpiryStatusWake(): Promise<void> {
  * every launch (which is what Desktop did, and what hammers the backend for every non-Pro and every
  * comfortably-active user), decide from synced config whether a CTA could plausibly fire.
  *
- * The architect's rule, which REPLACES the spec's `E + grace <= now` test — `grace` isn't knowable
- * until you are already in it, and libsession PR #121 adds `auto_renewing` only, so there is no
- * `grace` in config to test against:
+ * The rule, keyed on `E` (the paid-through expiry) and never on coverage end:
  *
  *   auto_renewing && now <  E                     -> comfortably active, no fetch
- *   auto_renewing && now >= E                     -> in/near grace, unknowable, FETCH and learn
- *                                                    `grace` from the response
+ *   auto_renewing && now >= E                     -> in grace or past it, unknowable from config,
+ *                                                    FETCH and learn which from the response
  *   !auto_renewing && E within the CTA window     -> expiring, fetch / CTA
  *   !auto_renewing && now >= E                    -> expired, confirm-fetch before the Expired CTA
+ *
+ * `G` is in config and this gate still doesn't consult it, deliberately: coverage ends at `E + G`, but
+ * grace and post-coverage both resolve to "fetch", so testing the later boundary would only delay the
+ * first fetch without changing any outcome. Nothing here needs to know how long grace runs — only that
+ * the paid term has ended.
  *
  * Capped either way at one cold-start fetch per STATUS_STARTUP_MIN_INTERVAL_MS.
  */
@@ -534,15 +537,12 @@ async function coldStartShouldFetchProStatus(): Promise<boolean> {
   const autoRenewing = await getProAutoRenewingFromConfig();
 
   if (autoRenewing) {
-    // `E` is coverage end, not the renewal date — the backend folds grace into the stored expiry for
-    // auto-renewing subscriptions. So the renewal falls due at `E - G`, and comparing against `E`
-    // itself would sleep through the entire grace window: exactly the state this gate exists to
-    // surface. Fetch from the renewal date onward.
-    //
-    // `G` is synced alongside `E` precisely so a config-only caller like this one can compute it. Both
-    // are milliseconds here; core stores `G` in seconds and the nodejs wrapper converts.
-    const gracePeriodMs = await UserConfigWrapperActions.getProGracePeriod();
-    return now >= accessExpiryMs - gracePeriodMs;
+    // `E` is the account's true expiry — what has been paid for. Past it the renewal has either landed
+    // (and `E` should have moved) or it hasn't, and config alone cannot tell which, so fetch and find
+    // out. `G` is deliberately NOT read here: coverage ends at `E + G`, but both sides of that
+    // boundary want a fetch — inside grace to surface "renewal unsuccessful", past it to surface
+    // Expired — so the only instant that changes the answer is `E` itself.
+    return now >= accessExpiryMs;
   }
 
   // Not auto-renewing. Expiring inside the CTA window, or already past `E` (where the fetch is the

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -347,13 +347,19 @@ const PRO_EXPIRED_CTA_WINDOW_MS = 30 * DURATION.DAYS;
 
 async function handleExpiryCTAs(
   accessExpiryTsMs: number,
+  gracePeriodDurationMs: number,
   autoRenewing: boolean,
   status: ProStatus
 ) {
   const now = NetworkTime.now();
 
+  // The Expiring window is anchored at `E`: "your payment is due soon" is a statement about the payment
+  // date, so coverage doesn't enter into it.
   const sevenDaysBeforeExpiry = accessExpiryTsMs - PRO_EXPIRING_CTA_WINDOW_MS;
-  const thirtyDaysAfterExpiry = accessExpiryTsMs + PRO_EXPIRED_CTA_WINDOW_MS;
+  // The Expired window is anchored at coverage end. The backend reports `Expired` only once coverage has
+  // ended, at `E + G`, so measuring the 30 days from `E` instead shortens the window by exactly `G` —
+  // and closes it entirely when `G >= 30d`, which a store grace period can reach.
+  const expiredCTADeadlineMs = accessExpiryTsMs + gracePeriodDurationMs + PRO_EXPIRED_CTA_WINDOW_MS;
 
   const proExpiringSoonCTA = !isUndefined(Storage.get(SettingsKey.proExpiringSoonCTA));
   const proExpiredCTA = !isUndefined(Storage.get(SettingsKey.proExpiredCTA));
@@ -376,7 +382,7 @@ async function handleExpiryCTAs(
     if (status === ProStatus.Active && !autoRenewing && !proExpiringSoonCTA) {
       await Storage.put(SettingsKey.proExpiringSoonCTA, true);
     }
-  } else if (accessExpiryTsMs < now && now < thirtyDaysAfterExpiry) {
+  } else if (accessExpiryTsMs < now && now < expiredCTADeadlineMs) {
     // Between expiry and 30 days after expiry, Expired CTA needs to be marked to be shown if not already
     if (status === ProStatus.Expired && !proExpiredCTA) {
       await Storage.put(SettingsKey.proExpiredCTA, true);
@@ -759,6 +765,7 @@ const fetchGetProStatusFromProBackend = createAsyncThunk(
           }
           await handleExpiryCTAs(
             state.data.expiryMs,
+            state.data.gracePeriodDurationMs,
             state.data.autoRenewing,
             state.data.userStatus
           );

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -564,13 +564,10 @@ async function coldStartShouldFetchProStatus(): Promise<boolean> {
  * from that path reads back as terminal.
  */
 async function getProAutoRenewingFromConfig(): Promise<boolean> {
-  // `A` cannot outlive the `E` it describes: libsession erases `A` and `G` alongside `E` whenever the
-  // expiry is cleared, so a renewing flag with no expiry beside it is not a reachable state. Every
-  // caller that clears `E` is handling an account with no entitlement, and none of those is renewing.
-  //
-  // ⚠️ The gate happens to read `E` before calling this, but for its own reason — no expiry means
-  // nothing a CTA could be about — so do not read that ordering as the thing upholding the invariant
-  // above. A caller that reads `A` without checking `E` first is equally correct.
+  // ⚠️ `A` is only meaningful beside the `E` it describes. It is presence-only, so an `A` left behind by
+  // an earlier subscription reads as "renewing" with no expiry to renew — indistinguishable from a live
+  // one. The single caller here establishes `E` first (for its own reason: no expiry means nothing a CTA
+  // could be about), so it never sees that pair. A new caller must establish `E` too, or read both.
   return UserConfigWrapperActions.getProAutoRenewing();
 }
 

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -33,27 +33,17 @@ type RequestState<D = unknown> = {
   error: string | null;
   // When the last successful fetch COMPLETED (ms, network time). 0 if we never got one this run.
   //
-  // Per-run and completion-stamped, which makes it the answer to "has this process confirmed our
-  // status (since some threshold)": the floor's never-confirmed-this-process exemption, the home Pro
-  // CTA gate, and the grace warning's `lastFetchedMs >= E` debounce all read it.
+  // Per-run and completion-stamped: the answer to "has this process confirmed our status", which the
+  // floor's never-confirmed exemption, the home Pro CTA gate and the grace warning's debounce all read.
   //
-  // ⚠️ Do NOT substitute SettingsKey.proStatusLastFetchAttemptMs for any of those. That one is
-  // persisted and stamped on *attempt*, because it backs the 60s floor, whose job is to bound
-  // requests rather than to confirm anything. Similar names, opposite meanings.
+  // Not interchangeable with SettingsKey.proStatusLastFetchAttemptMs, which is persisted and stamped on
+  // *attempt* because it backs the 60s floor. Similar names, opposite meanings.
   //
-  // ⚠️ This field looks redundant next to the persisted one and is not. Deleting it as "subsumed by
-  // the floor" ships a permanent spinner on the Pro screen: a relaunch inside 60s hits the floor, the
-  // fetch is dropped, and nothing is left to resolve the initial loading state — which both the spinner
-  // and the CTAs gate on.
-  //
-  // WHEN DELETING IT BECOMES CORRECT, so this is a test rather than a prohibition: when no consumer
-  // needs a *this-process* confirmation any more. Concretely, all three of —
-  //   1. the Pro screen's loading state no longer resolves only via a completed fetch,
-  //   2. the home CTAs no longer gate on one (see handleTriggeredCTAs), and
-  //   3. the grace debounce has a persisted completion-stamped value to read AND it has been decided
-  //      that a *previous* process's confirmation may satisfy it.
-  // (3) is the one to be most careful with: accepting a prior process's confirmation for the CTA gate
-  // is exactly the false-expired window that gating startup opened. Until then, keep both values.
+  // Deleting this as "subsumed by the floor" ships a permanent spinner: a relaunch inside 60s hits the
+  // floor, the fetch is dropped, and nothing resolves the initial loading state, which both the spinner
+  // and the CTAs gate on. It becomes removable once no consumer needs a *this-process* confirmation —
+  // and note that letting a previous process's confirmation satisfy the CTA gate reopens the
+  // false-expired window that gating startup created.
   lastFetchedMs: number;
   data: D | null;
 };
@@ -107,17 +97,12 @@ type CreateProBackendFetchAsyncThunk<K extends keyof ProBackendDataPayloads> = {
 export type WithCallerContext = { callerContext?: 'recover' };
 
 /**
- * `immediate` means one thing only: bypass the status floor. It does NOT bypass the
- * single-flight guard and it does NOT touch the loading state — spinner UI is a separate concern
- * (trigger #3). The name is load-bearing: a permissive one like `force` reads as something any
- * routine background trigger may pass, and a floor that every caller bypasses is dead code.
+ * `immediate` means one thing only: bypass the status floor. It does not bypass the single-flight guard
+ * and does not touch the loading state. The name is load-bearing: a permissive one like `force` reads as
+ * something any routine trigger may pass, and a floor every caller bypasses is dead code.
  *
- * Sanctioned callers, and no others:
- *   #5 manual refresh / recover  — implied by `callerContext: 'recover'`, so a future recover caller
- *                                  gets it without having to remember
- *   #4 the while-open grace poll — a bounded poll with its own cadence and termination
- *   #7 the post-purchase poll    — N/A on Desktop: no in-app payment
- *   developer/debug refresh paths
+ * Sanctioned callers and no others: manual refresh/recover (implied by `callerContext: 'recover'`), the
+ * bounded while-open grace poll, and developer/debug paths.
  */
 export type WithImmediate = { immediate?: boolean };
 
@@ -249,24 +234,17 @@ async function applyProofOutcome(
       }
       await UserConfigWrapperActions.setProConfig({ proProof, rotatingSeedHex });
     }
-    // Refresh cached access-expiry from the advisory account_expiry (decoupled from the proof guard,
-    // so a mid-period horizon extension is still picked up). Guaranteed present on a success parse.
+    // Refresh cached access-expiry from the advisory account_expiry (decoupled from the proof guard, so
+    // a mid-period horizon extension is still picked up). `A` and `G` ride along, and must: otherwise
+    // `E + G` pairs a fresh expiry with a grace from a different billing period, and an unwritten `A`
+    // reads as not-renewing.
     //
-    // `A` and `G` ride along, and must: every path that writes `E` writes all three from the same
-    // response. Writing `E` alone breaks two things — an account whose expiry came only from a proof
-    // reads back as terminal while it is in fact renewing (`A` is presence-only, so unwritten and false
-    // are the same bit), and `E + G` pairs a fresh expiry with a grace learned in a different billing
-    // period.
+    // All three writes belong inside the success branch. On a failure outcome core never fills
+    // `accountAutoRenewing`/`accountGracePeriodMs`, so its struct defaults (`false`/`0`) come through,
+    // indistinguishable from a backend that said "not renewing, no grace" — and both keys are
+    // presence-only, so writing those would erase what a `get_pro_status` fetch had learned.
     //
-    // ⚠️ These writes belong INSIDE the success branch and must stay there. `accountAutoRenewing` and
-    // `accountGracePeriodMs` are non-null because core requires them on a successful parse — a response
-    // missing either is a parse error, not a defaulted value. But on a *failure* outcome core never fills
-    // them and its struct defaults (`false` / `0`) come through, which are indistinguishable from a
-    // backend that really said "not renewing, no grace". Both config keys are presence-only, so writing
-    // that false or zero would ERASE what a `get_pro_status` fetch had learned. The success branch is the
-    // only place these two mean anything.
-    //
-    // `accountExpiryMs` is still nullable — absent on `not_subscribed` and `revoked` — hence its guard.
+    // `accountExpiryMs` is nullable — absent on `not_subscribed` and `revoked` — hence its guard.
     if (response.accountExpiryMs !== null) {
       await UserConfigWrapperActions.setProAccessExpiry(response.accountExpiryMs);
     }
@@ -322,18 +300,11 @@ async function handleClearProProof() {
 /**
  * Minimum gap between *routine* status fetches. Drop-on-fresh — see statusFetchIsFloored.
  *
- * ⚠️ A SCHEDULED WAKE DEPENDS ON THIS NOT BEING CROSSED. `scheduleUserExpiryStatusWake` arms two
- * instants `G` apart — the expiry and coverage end — and both emit through the *floored* path, not
- * the `immediate` one. So when `G < STATUS_FLOOR_MS` the second wake fires and its fetch is dropped.
- *
- * In production `G` is at least an hour, so this cannot happen. It happens on a **compressed testing
- * backend**: the Google test provider sets the grace period to ~10s, and the backend deliberately scales
- * its whole proof/renewal clock for compressed runs while this client-side constant does not participate
- * in that compression.
- *
- * **The sanctioned escape hatch is an env-var override of this constant**, and this is the value to
- * hook if you are adding one. Note the second wake is unlikely to be the only casualty: any client
- * interval shorter than its compressed equivalent has the same property.
+ * A scheduled wake depends on this not being crossed: scheduleUserExpiryStatusWake arms two instants `G`
+ * apart, both through the floored path, so when `G < STATUS_FLOOR_MS` the second fires and its fetch is
+ * dropped with no log line to say so. `G` is at least an hour in production and ~10s on a compressed test
+ * backend, whose scaled clock this constant does not participate in — override it by env var for those
+ * runs rather than shortening it.
  */
 const STATUS_FLOOR_MS = 60 * DURATION.SECONDS;
 /** Cold-start fetches are additionally capped to one per this interval, by the startup gate. */
@@ -415,13 +386,12 @@ function lastStatusFetchAttemptAtMs(): number {
 /**
  * True when a routine status refresh should be *dropped* as too soon.
  *
- * Drop-on-fresh, deliberately NOT re-arm: a floor that rescheduled the skipped fetch would turn
- * the routine triggers into a self-sustaining once/60s poll, and during grace — when `E` sits static
- * and nothing new can arrive from a config change — that poll is pure noise. Dropping is safe
+ * Drop-on-fresh, not re-arm: rescheduling the skipped fetch would turn the routine triggers into a
+ * self-sustaining once/60s poll, and during grace `E` sits static so it would carry nothing new. Safe
  * because status is display-only and backstopped by many triggers.
  *
- * The *proof* loop is the opposite by design (reconcileProProof reschedules rather than skips),
- * because a throttled proof acquisition must still eventually happen. Don't unify the two.
+ * The proof loop is deliberately the opposite — a throttled proof acquisition must still eventually
+ * happen — so don't unify the two.
  */
 function statusFetchIsFloored(): boolean {
   return NetworkTime.now() < lastStatusFetchAttemptAtMs() + STATUS_FLOOR_MS;
@@ -434,32 +404,17 @@ let userExpiryWakeIds: Array<ReturnType<typeof setTimeout>> = [];
 /**
  * Schedule the background status refreshes around the end of a billing period.
  *
- * This is the background half of surfacing grace. The Pro page refetches across the crossing while it is
- * open, but that is screen-scoped: with the page closed nothing would re-check between the expiry and
- * the proof loop's own wake, so a renewal that failed would surface only in that final hour.
+ * With the Pro page closed, nothing else re-checks between the expiry and the proof loop's own wake.
  *
- * Two instants, at `E + 30s` and `(E + G) + 30s`, collapsing to one when `G` is zero. The second is not
- * redundant: the proof loop does wake near `E` by construction (the backend issues `proof_expiry` ~1h
- * past `E`, and `pro_renewal_target` is ~1h before proof expiry), and a proof outcome now writes
- * `E`/`A`/`G`, which fires the config-change trigger. But that chain is gated on `E` actually changing —
- * so it covers a renewal that SUCCEEDED and not one that failed, which is the case the grace warning
- * exists for.
+ * Two instants, `E + 30s` and `(E + G) + 30s`, collapsing to one when `G` is zero. The second is not
+ * redundant: the proof loop wakes near `E` by construction, but that chain fires only when `E` actually
+ * changes, so it covers a renewal that succeeded and not one that failed.
  *
- * Re-derived from scratch on every call, so a renewal that advances `E` cannot leave a wake armed against
- * the old horizon.
+ * Re-derived on every call, so a renewal that advances `E` cannot leave a wake armed against the old
+ * horizon.
  *
- * ⚠️ ON A COMPRESSED TESTING BACKEND THE SECOND WAKE WILL NOT FETCH, and the symptom is indistinguishable
- * from it never having been scheduled — which is why this is written here rather than only at the floor.
- * Both instants emit through the floored path (`refreshGetProStatusFromProBackend` with no `immediate`),
- * and they are `G` apart. So whenever `G < STATUS_FLOOR_MS` (60s) the second one is inside the floor
- * window and its fetch is dropped: the timer fires, nothing happens, and no log line distinguishes that
- * from an unscheduled wake.
- *
- * Production `G` is at least an hour, so this is a test-environment property, not a wake defect. The
- * Google test provider sets grace to ~10s and the backend scales its whole clock for compressed runs;
- * this client's fixed floor doesn't. **An env-var override of `STATUS_FLOOR_MS` is the sanctioned escape
- * hatch** — so don't "fix" it by shortening the floor, and don't make this wake `immediate` to work
- * around it.
+ * Both instants emit through the floored path and are `G` apart, so a short `G` drops the second one's
+ * fetch — see STATUS_FLOOR_MS.
  */
 export async function scheduleUserExpiryStatusWake(): Promise<void> {
   // Always clear before re-deriving. This function is called on startup and after every successful
@@ -511,13 +466,9 @@ export async function scheduleUserExpiryStatusWake(): Promise<void> {
 /**
  * Whether a *cold start* is allowed to fetch `get_pro_status`.
  *
- * Startup's only real consumer is the home CTAs — entitlement comes from the proof, the settings
- * screen refreshes on open, and account-expiry awareness is trigger #6. Fetching on every launch would
- * hit the backend for every non-Pro and every comfortably-active user to learn nothing, so decide from
- * synced config whether a CTA could plausibly fire at all.
- *
- * The rule. Every lower bound is keyed on `E` (the paid-through expiry); only the upper bound is keyed
- * on coverage end:
+ * Startup's only consumer is the home CTAs — entitlement comes from the proof and the settings screen
+ * refreshes on open — so decide from synced config whether a CTA could plausibly fire, rather than
+ * fetching on every launch for every non-Pro and comfortably-active user.
  *
  *   now >= E + G + 30d                            -> lapsed too long ago for any CTA, no fetch
  *   auto_renewing && now <  E                     -> comfortably active, no fetch
@@ -526,10 +477,8 @@ export async function scheduleUserExpiryStatusWake(): Promise<void> {
  *   !auto_renewing && E within the CTA window     -> expiring, fetch / CTA
  *   !auto_renewing && now >= E                    -> expired, confirm-fetch before the Expired CTA
  *
- * The lower bounds don't consult `G` and don't need to: grace and post-coverage both resolve to "fetch",
- * so testing the later boundary would delay the first fetch without changing any outcome. The upper
- * bound is the one place the LENGTH of grace does work, because "how long ago did this lapse" is
- * measured from `E + G`.
+ * Only the upper bound uses `G`: grace and post-coverage both resolve to "fetch", so the lower bounds
+ * need only "has the paid term ended", while "how long ago did this lapse" is measured from `E + G`.
  *
  * Capped either way at one cold-start fetch per STATUS_STARTUP_MIN_INTERVAL_MS.
  */
@@ -584,32 +533,19 @@ async function coldStartShouldFetchProStatus(): Promise<boolean> {
  * `A` is presence-only in core: `set_pro_auto_renewing` uses `set_nonzero_int`, so writing false erases
  * the key and the getter returns false for both "not auto-renewing" and "never written".
  *
- * ⚠️ That ambiguity is harmless only because every path that writes `E` also writes `A`, from the same
- * response — the status fetch and the proof outcome both do. Absent therefore means not-renewing rather
- * than unknown, which is what makes the gate's `!auto_renewing` rows sound. A new writer of `E` that
- * carries no renewing flag would silently reintroduce it: an account renewing under an `E` that came
- * from that path reads back as terminal.
+ * Harmless only while every path that writes `E` also writes `A` from the same response, and every reader
+ * establishes `E` first — an `A` left by an earlier subscription otherwise reads as renewing with no
+ * expiry to renew. A new writer or reader has to keep both.
  */
 async function getProAutoRenewingFromConfig(): Promise<boolean> {
-  // ⚠️ `A` is only meaningful beside the `E` it describes. It is presence-only, so an `A` left behind by
-  // an earlier subscription reads as "renewing" with no expiry to renew — indistinguishable from a live
-  // one. The single caller here establishes `E` first (for its own reason: no expiry means nothing a CTA
-  // could be about), so it never sees that pair. A new caller must establish `E` too, or read both.
   return UserConfigWrapperActions.getProAutoRenewing();
 }
 
 /**
- * Persist `auto_renewing` into synced config, mirroring how each fetch persists `E`. Without the
- * write side the config field is never populated and the startup gate has nothing to read.
+ * Persist `auto_renewing` into synced config, mirroring how each fetch persists `E`.
  *
- * Unconditional, and deliberately so: libSession already de-dupes a no-change write one layer down
- * (`assign_if_changed` / `erase` both no-op on a clean config), which is the same property the
- * unconditional `E` write beside it relies on. A client-side guard would add nothing, and a
- * *presence*-based one would be actively wrong — `A` is presence-only, so a `false` erases the key
- * and presence flips on every change.
- *
- * Note the config-change observer watches only `E` and `I`, so an `auto_renewing` change re-derives
- * the display without triggering a fetch — we already have the synced value.
+ * Unconditional: libSession de-dupes a no-change write one layer down. A *presence*-based guard would be
+ * actively wrong — `A` is presence-only, so a `false` erases the key and presence flips on every change.
  */
 async function writeProAutoRenewingToConfig(autoRenewing: boolean): Promise<void> {
   await UserConfigWrapperActions.setProAutoRenewing(autoRenewing);
@@ -857,26 +793,13 @@ const refreshGetProStatusFromProBackend = createAsyncThunk(
       return;
     }
 
-    // Three separate things can refuse to start a status fetch, and only one of them can refuse in a
-    // process that has never fetched:
+    // Of the three things that can refuse a status fetch, only the floor's persisted timestamp can
+    // refuse in a process that has never fetched — `isFetching` and `lastFetchedMs` are both per-run. So
+    // without this exemption the floor becomes a mutex on the cold-start path rather than a rate limit.
+    // Cold-start load stays bounded by the 24h startup interval, which is the stronger limit.
     //
-    //   in-flight    `details.isFetching`                     per-run, so it cannot refuse first time
-    //   unconfirmed  `details.lastFetchedMs`                  per-run, ditto
-    //   TOO SOON     `SettingsKey.proStatusLastFetchAttemptMs` PERSISTED — outlives the process
-    //
-    // ⚠️ THIS EXEMPTION EXISTS BECAUSE OF THE THIRD ONE. The floor reads a timestamp written by a
-    // *previous* run, so without an exemption it can decline the first fetch of a process that has no
-    // status at all — turning a rate limit into a mutex on exactly the cold-start path the startup gate
-    // is about. `lastFetchedMs` is per-run (0 until this process completes a fetch), so it is the right
-    // signal, and it is why the per-run value is kept alongside the persisted one rather than replaced
-    // by it. Cold-start load stays bounded by the 24h startup interval, which is the stronger limit.
-    //
-    // The visible symptom is a permanent spinner: relaunch within 60s of a previous fetch, the floor
-    // drops the fetch, and nothing resolves the initial loading state, so the Pro screen spins and no
-    // CTA fires — both gate on a confirmed fetch. **But the spinner is the symptom, not the reason.**
-    // Fixing the spinner some other way does not make this removable; the floor would still be able to
-    // refuse a never-fetched process. (This also replaces the older "on a cold start the load state is
-    // Init, so the floor doesn't apply anyway", which stops being true once the timestamp is persisted.)
+    // Fixing the resulting spinner elsewhere would not make this removable: the floor would still be
+    // able to refuse a never-fetched process.
     const noConfirmedStatusThisProcess = state.proBackendData.details.lastFetchedMs === 0;
 
     // Single-flight (above) prevents *concurrent* fetches; the floor prevents *frequent* ones. They

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -562,6 +562,13 @@ async function coldStartShouldFetchProStatus(): Promise<boolean> {
  * `!auto_renewing` rows are correct as written.
  */
 async function getProAutoRenewingFromConfig(): Promise<boolean> {
+  // `A` cannot outlive the `E` it describes: libsession erases `A` and `G` alongside `E` whenever the
+  // expiry is cleared, so a renewing flag with no expiry beside it is not a reachable state. Every
+  // caller that clears `E` is handling an account with no entitlement, and none of those is renewing.
+  //
+  // The gate reads `E` before calling this, but for its own reason — no expiry means nothing a CTA
+  // could be about — rather than to guard against a stale flag. That guard used to be what held the
+  // invariant up; it no longer is.
   return UserConfigWrapperActions.getProAutoRenewing();
 }
 

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -504,18 +504,20 @@ export async function scheduleUserExpiryStatusWake(): Promise<void> {
  * hit the backend for every non-Pro and every comfortably-active user to learn nothing, so decide from
  * synced config whether a CTA could plausibly fire at all.
  *
- * The rule, keyed on `E` (the paid-through expiry) and never on coverage end:
+ * The rule. Every lower bound is keyed on `E` (the paid-through expiry); only the upper bound is keyed
+ * on coverage end:
  *
+ *   now >= E + G + 30d                            -> lapsed too long ago for any CTA, no fetch
  *   auto_renewing && now <  E                     -> comfortably active, no fetch
  *   auto_renewing && now >= E                     -> in grace or past it, unknowable from config,
  *                                                    FETCH and learn which from the response
  *   !auto_renewing && E within the CTA window     -> expiring, fetch / CTA
  *   !auto_renewing && now >= E                    -> expired, confirm-fetch before the Expired CTA
  *
- * `G` is in config and this gate still doesn't consult it, deliberately: coverage ends at `E + G`, but
- * grace and post-coverage both resolve to "fetch", so testing the later boundary would only delay the
- * first fetch without changing any outcome. Nothing here needs to know how long grace runs — only that
- * the paid term has ended.
+ * The lower bounds don't consult `G` and don't need to: grace and post-coverage both resolve to "fetch",
+ * so testing the later boundary would delay the first fetch without changing any outcome. The upper
+ * bound is the one place the LENGTH of grace does work, because "how long ago did this lapse" is
+ * measured from `E + G`.
  *
  * Capped either way at one cold-start fetch per STATUS_STARTUP_MIN_INTERVAL_MS.
  */
@@ -536,12 +538,25 @@ async function coldStartShouldFetchProStatus(): Promise<boolean> {
   const now = NetworkTime.now();
   const autoRenewing = await getProAutoRenewingFromConfig();
 
+  // The upper bound, and the one place this gate needs to know how LONG grace runs rather than just
+  // that the paid term has ended. Past the last instant an Expired CTA could be raised there is nothing
+  // left to learn, so an account that lapsed long ago must stop fetching — otherwise it fetches once
+  // per STATUS_STARTUP_MIN_INTERVAL_MS forever, for a CTA that can no longer fire.
+  //
+  // Measured from coverage end, not from `E`: an account is not treated as lapsed until `E + G`, so
+  // measuring the elapsed time from `E` would shorten a renewing account's window by exactly its grace
+  // period. `G` is 0 when not auto-renewing, which makes this `E + 30d` for those accounts.
+  const gracePeriodMs = await UserConfigWrapperActions.getProGracePeriod();
+  if (now >= accessExpiryMs + gracePeriodMs + PRO_EXPIRED_CTA_WINDOW_MS) {
+    return false;
+  }
+
   if (autoRenewing) {
     // `E` is the account's true expiry — what has been paid for. Past it the renewal has either landed
     // (and `E` should have moved) or it hasn't, and config alone cannot tell which, so fetch and find
-    // out. `G` is deliberately NOT read here: coverage ends at `E + G`, but both sides of that
-    // boundary want a fetch — inside grace to surface "renewal unsuccessful", past it to surface
-    // Expired — so the only instant that changes the answer is `E` itself.
+    // out. The lower bound is `E` and not coverage end: both sides of `E + G` want a fetch — inside
+    // grace to surface "renewal unsuccessful", past it to surface Expired — so the only instant that
+    // changes the answer is `E` itself.
     return now >= accessExpiryMs;
   }
 

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -470,8 +470,10 @@ export async function scheduleUserExpiryStatusWake(): Promise<void> {
   //
   // Only one when `G` is zero, which is every non-auto-renewing account: the two collapse to the same
   // moment and scheduling both would just double the fetch.
-  const wakeAtMs =
-    renewalDueAtMs === accessExpiryMs ? [accessExpiryMs] : [renewalDueAtMs, accessExpiryMs];
+  const wakeAtMs = [renewalDueAtMs];
+  if (accessExpiryMs !== renewalDueAtMs) {
+    wakeAtMs.push(accessExpiryMs);
+  }
 
   const now = NetworkTime.now();
   wakeAtMs.forEach(atMs => {

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -402,50 +402,66 @@ function statusFetchIsFloored(): boolean {
 
 // ===== #6 — the single wake at user_expiry =====
 
-let userExpiryWakeId: ReturnType<typeof setTimeout> | null = null;
+let userExpiryWakeIds: Array<ReturnType<typeof setTimeout>> = [];
 
 /**
- * Schedule one status refresh shortly past the renewal date (`E - G`).
+ * Schedule the background status refreshes around the end of a billing period.
  *
- * This is the background half of surfacing grace. Desktop already refetches across the crossing
- * while the Pro page is open (`useKeepProStatusFresh`, trigger #4), but that is screen-scoped: with
- * the page closed nothing re-checks between `E` and the proof loop's wake ~1h before *proof* expiry,
- * so a renewal that failed at `E` would only surface in that final hour. Android has had this wake
- * (`E+30s`) all along; this is Desktop's equivalent.
+ * This is the background half of surfacing grace. The Pro page refetches across the crossing while it is
+ * open, but that is screen-scoped: with the page closed nothing would re-check between the renewal date
+ * and the proof loop's own wake, so a renewal that failed would surface only in that final hour.
  *
- * Only ever armed for a *future* crossing. A crossing already in the past is not replayed on every
- * launch — that would duplicate the startup gate, which is the thing that decides whether a cold
- * start is allowed to fetch at all.
+ * Two instants, at `(E - G) + 30s` and `E + 30s`, collapsing to one when `G` is zero. The second is not
+ * redundant: the proof loop does wake near `E` by construction (the backend issues `proof_expiry` ~1h
+ * past `E`, and `pro_renewal_target` is ~1h before proof expiry), and a proof outcome now writes
+ * `E`/`A`/`G`, which fires the config-change trigger. But that chain is gated on `E` actually changing —
+ * so it covers a renewal that SUCCEEDED and not one that failed, which is the case the grace warning
+ * exists for.
  *
- * ⚠️ Note what this does NOT cover: the later transition at `E` itself, when grace ends and the account
- * genuinely expires. This is a one-shot at the renewal date, so nothing here fires at coverage end. The
- * proof loop wakes near `E` by construction — the backend issues `proof_expiry` ~1h past `E` and
- * `pro_renewal_target` is ~1h before proof expiry — and a proof outcome now writes `E`/`A`/`G`, which
- * fires the config-change trigger. But that path depends on `E` actually changing, so it covers a
- * renewal that SUCCEEDED and not one that failed. See the note on that trigger.
+ * Re-derived from scratch on every call, so a renewal that advances `E` cannot leave a wake armed against
+ * the old horizon.
  */
 export async function scheduleUserExpiryStatusWake(): Promise<void> {
-  if (userExpiryWakeId) {
-    clearTimeout(userExpiryWakeId);
-    userExpiryWakeId = null;
-  }
+  // Always clear before re-deriving. This function is called on startup and after every successful
+  // fetch, so a renewal that advances `E` re-arms both instants against the NEW horizon; leaving a
+  // stale wake armed would fire at an instant that no longer means anything.
+  userExpiryWakeIds.forEach(clearTimeout);
+  userExpiryWakeIds = [];
+
   const accessExpiryMs = await UserConfigWrapperActions.getProAccessExpiry();
   if (!accessExpiryMs) {
     return;
   }
-  // Fires just past the RENEWAL DATE (`E - G`), not past coverage end. `E` is grace-inclusive, so
-  // waking at `E` would arrive after the whole grace window had already elapsed — i.e. after the state
-  // this wake exists to surface had come and gone.
   const gracePeriodMs = await UserConfigWrapperActions.getProGracePeriod();
-  const wakeAtMs = accessExpiryMs - gracePeriodMs + USER_EXPIRY_WAKE_DELAY_MS;
-  const delayMs = wakeAtMs - NetworkTime.now();
-  if (delayMs <= 0) {
-    return;
-  }
-  userExpiryWakeId = setTimeout(() => {
-    // Floored, like every other routine trigger — the wake is a nudge, not a "go right now".
-    window.inboxStore?.dispatch(proBackendDataActions.refreshGetProStatusFromProBackend({}) as any);
-  }, delayMs);
+  const renewalDueAtMs = accessExpiryMs - gracePeriodMs;
+
+  // Two instants, because two distinct transitions matter and neither implies the other:
+  //
+  //   renewal due (E - G)   did the charge succeed, or has it silently failed?
+  //   coverage end (E)      did grace run out without a recovery?
+  //
+  // Only one when `G` is zero, which is every non-auto-renewing account: the two collapse to the same
+  // moment and scheduling both would just double the fetch.
+  const wakeAtMs =
+    renewalDueAtMs === accessExpiryMs ? [accessExpiryMs] : [renewalDueAtMs, accessExpiryMs];
+
+  const now = NetworkTime.now();
+  wakeAtMs.forEach(atMs => {
+    const delayMs = atMs + USER_EXPIRY_WAKE_DELAY_MS - now;
+    if (delayMs <= 0) {
+      // Already past. Not replayed on every launch — that is the startup gate's job, and it is the
+      // thing that decides whether a cold start may fetch at all.
+      return;
+    }
+    userExpiryWakeIds.push(
+      setTimeout(() => {
+        // Floored, like every other routine trigger — a nudge, not a "go right now".
+        window.inboxStore?.dispatch(
+          proBackendDataActions.refreshGetProStatusFromProBackend({}) as any
+        );
+      }, delayMs)
+    );
+  });
 }
 
 // ===== The startup gate =====

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -710,8 +710,16 @@ const fetchGetProStatusFromProBackend = createAsyncThunk(
               // Keep the cached access-expiry (E) fresh from the account horizon (catches a
               // horizon-only change the renewal path wouldn't). The proof itself is (re)obtained by
               // the reconcile loop, triggered below.
+              //
+              // All three are written from the SAME response, which is the only way they are jointly
+              // meaningful: `E + G` is coverage end, so a fresh `E` beside a `G` left over from an
+              // earlier subscription state describes an instant that was never true. `G` is the
+              // ACCOUNT-level `gracePeriodDurationMs` at the response root — not `latestPayment`'s
+              // field of the same name, which is one store's raw declaration and is not gated on
+              // auto-renewal.
               await UserConfigWrapperActions.setProAccessExpiry(state.data.expiryMs);
               await writeProAutoRenewingToConfig(state.data.autoRenewing);
+              await UserConfigWrapperActions.setProGracePeriod(state.data.gracePeriodDurationMs);
               break;
 
             case ProStatus.Never:

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -319,7 +319,23 @@ async function handleClearProProof() {
 // These are a deliberate cross-client contract: Android and iOS name the same values so
 // nobody tunes one platform in isolation. Change them here and the other two clients are wrong.
 
-/** Minimum gap between *routine* status fetches. Drop-on-fresh — see statusFetchIsFloored. */
+/**
+ * Minimum gap between *routine* status fetches. Drop-on-fresh — see statusFetchIsFloored.
+ *
+ * ⚠️ A SCHEDULED WAKE DEPENDS ON THIS NOT BEING CROSSED. `scheduleUserExpiryStatusWake` arms two
+ * instants `G` apart — the renewal date and coverage end — and both emit through the *floored* path, not
+ * the `immediate` one. So when `G < STATUS_FLOOR_MS` the second wake fires and its fetch is dropped.
+ *
+ * In production `G` is at least an hour, so this cannot happen. It happens on a **compressed testing
+ * backend**: the Google test provider sets the grace period to ~10s, and the backend deliberately scales
+ * its whole proof/renewal clock for compressed runs while this client-side constant does not participate
+ * in that compression.
+ *
+ * **The sanctioned escape hatch is an env-var override of this constant, owned by the Pro UI-test work
+ * and deliberately not built here.** If you are adding it, this is the value to hook, and note the
+ * second wake is unlikely to be the only casualty — any client interval shorter than the compressed
+ * equivalent has the same property.
+ */
 const STATUS_FLOOR_MS = 60 * DURATION.SECONDS;
 /** Cold-start fetches are additionally capped to one per this interval, by the startup gate. */
 const STATUS_STARTUP_MIN_INTERVAL_MS = 24 * DURATION.HOURS;
@@ -420,6 +436,19 @@ let userExpiryWakeIds: Array<ReturnType<typeof setTimeout>> = [];
  *
  * Re-derived from scratch on every call, so a renewal that advances `E` cannot leave a wake armed against
  * the old horizon.
+ *
+ * ⚠️ ON A COMPRESSED TESTING BACKEND THE SECOND WAKE WILL NOT FETCH, and the symptom is indistinguishable
+ * from it never having been scheduled — which is why this is written here rather than only at the floor.
+ * Both instants emit through the floored path (`refreshGetProStatusFromProBackend` with no `immediate`),
+ * and they are `G` apart. So whenever `G < STATUS_FLOOR_MS` (60s) the second one is inside the floor
+ * window and its fetch is dropped: the timer fires, nothing happens, and no log line distinguishes that
+ * from an unscheduled wake.
+ *
+ * Production `G` is at least an hour, so this is a test-environment property, not a wake defect. The
+ * Google test provider sets grace to ~10s and the backend scales its whole clock for compressed runs;
+ * this client's fixed floor doesn't. **An env-var override of `STATUS_FLOOR_MS` is the sanctioned escape
+ * hatch, owned by the Pro UI-test work and deliberately not built here** — so don't "fix" it in the
+ * client, and don't make this wake `immediate` to work around it.
  */
 export async function scheduleUserExpiryStatusWake(): Promise<void> {
   // Always clear before re-deriving. This function is called on startup and after every successful

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -349,9 +349,6 @@ async function requestAndApplyProof(): Promise<void> {
  * accepted — the §4 monotonic merge no-ops the late reply). Holds no durable state.
  */
 export async function reconcileProProof(): Promise<void> {
-  if (!getFeatureFlag('proAvailable')) {
-    return;
-  }
   if (reconcileWakeId) {
     clearTimeout(reconcileWakeId);
     reconcileWakeId = null;
@@ -502,10 +499,6 @@ const fetchGetProStatusFromProBackend = createAsyncThunk(
 const refreshGetProStatusFromProBackend = createAsyncThunk(
   'proBackendData/refreshGetProStatus',
   async (opts: WithCallerContext = {}, payloadCreator) => {
-    if (!getFeatureFlag('proAvailable')) {
-      return;
-    }
-
     if (getFeatureFlag('debugServerRequests')) {
       window.log.info(
         `[proBackend/refreshGetProStatusFromProBackend] starting ${new Date().toISOString()}`

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -427,7 +427,7 @@ export async function scheduleUserExpiryStatusWake(): Promise<void> {
   if (!accessExpiryMs) {
     return;
   }
-  const gracePeriodMs = await UserConfigWrapperActions.getProGracePeriod();
+  const gracePeriodMs = (await UserConfigWrapperActions.getProGracePeriod()) ?? 0;
   const coverageEndMs = accessExpiryMs + gracePeriodMs;
 
   // Two instants, because two distinct transitions matter and neither implies the other:
@@ -507,7 +507,7 @@ async function coldStartShouldFetchProStatus(): Promise<boolean> {
   // Measured from coverage end, not from `E`: an account is not treated as lapsed until `E + G`, so
   // measuring the elapsed time from `E` would shorten a renewing account's window by exactly its grace
   // period. `G` is 0 when not auto-renewing, which makes this `E + 30d` for those accounts.
-  const gracePeriodMs = await UserConfigWrapperActions.getProGracePeriod();
+  const gracePeriodMs = (await UserConfigWrapperActions.getProGracePeriod()) ?? 0;
   if (now >= accessExpiryMs + gracePeriodMs + PRO_EXPIRED_CTA_WINDOW_MS) {
     return false;
   }

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -35,7 +35,7 @@ type RequestState<D = unknown> = {
   //
   // Per-run and completion-stamped, which makes it the answer to "has this process confirmed our
   // status (since some threshold)": the floor's never-confirmed-this-process exemption, the home Pro
-  // CTA gate, and the grace warning's `lastFetchedMs >= expiryTimeMs` debounce all read it.
+  // CTA gate, and the grace warning's `lastFetchedMs >= renewalDueAtMs` debounce all read it.
   //
   // ⚠️ Do NOT substitute SettingsKey.proStatusLastFetchAttemptMs for any of those. That one is
   // persisted and stamped on *attempt*, because it backs the 60s floor, whose job is to bound
@@ -107,7 +107,7 @@ type CreateProBackendFetchAsyncThunk<K extends keyof ProBackendDataPayloads> = {
 export type WithCallerContext = { callerContext?: 'recover' };
 
 /**
- * `immediate` means one thing only: bypass the status floor (§4). It does NOT bypass the
+ * `immediate` means one thing only: bypass the status floor. It does NOT bypass the
  * single-flight guard and it does NOT touch the loading state — spinner UI is a separate concern
  * (trigger #3). Named `immediate` rather than `force` on purpose: `force` invited every routine
  * background trigger to pass it, which is how Android's 60s floor ended up dead.
@@ -251,8 +251,27 @@ async function applyProofOutcome(
     }
     // Refresh cached access-expiry from the advisory account_expiry (decoupled from the proof guard,
     // so a mid-period horizon extension is still picked up). Guaranteed present on a success parse.
+    //
+    // `A` and `G` ride along, so every path that writes `E` writes all three from the same response.
+    // This path used to write `E` alone, with two consequences: an account whose expiry came only from a
+    // proof read back as terminal while it was in fact renewing (`A` is presence-only, so unwritten and
+    // false are the same bit), and `E - G` could pair a fresh expiry with a grace learned in a different
+    // billing period.
+    //
+    // ⚠️ All three writes are CONDITIONAL ON PRESENCE, and that is load-bearing rather than defensive.
+    // These are advisory optionals: absent means "the backend did not say", NOT false or zero. Writing a
+    // collapsed `?? false` / `?? 0` would ERASE the key — both are stored presence-only — so against a
+    // backend predating either field, every proof fetch would wipe a correct value learned from
+    // `get_pro_status`. That is strictly worse than not writing at all: today the value merely fails to
+    // be refreshed; collapsed, it would be actively destroyed.
     if (response.accountExpiryMs !== null) {
       await UserConfigWrapperActions.setProAccessExpiry(response.accountExpiryMs);
+    }
+    if (response.accountAutoRenewing !== null) {
+      await writeProAutoRenewingToConfig(response.accountAutoRenewing);
+    }
+    if (response.accountGracePeriodMs !== null) {
+      await UserConfigWrapperActions.setProGracePeriod(response.accountGracePeriodMs);
     }
     return;
   }
@@ -296,17 +315,17 @@ async function handleClearProProof() {
   await UserConfigWrapperActions.setProAccessExpiry(null);
 }
 
-// ===== get_pro_status refresh discipline (SPEC §4) =====
-// These are a deliberate cross-client contract (§9.3): Android and iOS name the same values so
+// ===== get_pro_status refresh discipline =====
+// These are a deliberate cross-client contract: Android and iOS name the same values so
 // nobody tunes one platform in isolation. Change them here and the other two clients are wrong.
 
 /** Minimum gap between *routine* status fetches. Drop-on-fresh — see statusFetchIsFloored. */
 const STATUS_FLOOR_MS = 60 * DURATION.SECONDS;
-/** Cold-start fetches are additionally capped to one per this interval (§4 startup gate). */
+/** Cold-start fetches are additionally capped to one per this interval, by the startup gate. */
 const STATUS_STARTUP_MIN_INTERVAL_MS = 24 * DURATION.HOURS;
 /** #6: one wake past the account horizon, so grace surfaces without the Pro page being open. */
 const USER_EXPIRY_WAKE_DELAY_MS = 30 * DURATION.SECONDS;
-/** The Expiring-CTA window. §4's "E within the CTA window" test uses this same 7 days. */
+/** The Expiring-CTA window. The startup gate's "is E within the CTA window" test uses this too. */
 const PRO_EXPIRING_CTA_WINDOW_MS = 7 * DURATION.DAYS;
 /** The Expired-CTA window. */
 const PRO_EXPIRED_CTA_WINDOW_MS = 30 * DURATION.DAYS;
@@ -369,7 +388,7 @@ function lastStatusFetchAttemptAtMs(): number {
 /**
  * True when a routine status refresh should be *dropped* as too soon.
  *
- * Drop-on-fresh, deliberately NOT re-arm (§4): a floor that rescheduled the skipped fetch would turn
+ * Drop-on-fresh, deliberately NOT re-arm: a floor that rescheduled the skipped fetch would turn
  * the routine triggers into a self-sustaining once/60s poll, and during grace — when `E` sits static
  * and nothing new can arrive from a config change — that poll is pure noise. Dropping is safe
  * because status is display-only and backstopped by many triggers.
@@ -386,7 +405,7 @@ function statusFetchIsFloored(): boolean {
 let userExpiryWakeId: ReturnType<typeof setTimeout> | null = null;
 
 /**
- * Schedule one status refresh shortly past the account horizon (`E`).
+ * Schedule one status refresh shortly past the renewal date (`E - G`).
  *
  * This is the background half of surfacing grace. Desktop already refetches across the crossing
  * while the Pro page is open (`useKeepProStatusFresh`, trigger #4), but that is screen-scoped: with
@@ -397,6 +416,13 @@ let userExpiryWakeId: ReturnType<typeof setTimeout> | null = null;
  * Only ever armed for a *future* crossing. A crossing already in the past is not replayed on every
  * launch — that would duplicate the startup gate, which is the thing that decides whether a cold
  * start is allowed to fetch at all.
+ *
+ * ⚠️ Note what this does NOT cover: the later transition at `E` itself, when grace ends and the account
+ * genuinely expires. This is a one-shot at the renewal date, so nothing here fires at coverage end. The
+ * proof loop wakes near `E` by construction — the backend issues `proof_expiry` ~1h past `E` and
+ * `pro_renewal_target` is ~1h before proof expiry — and a proof outcome now writes `E`/`A`/`G`, which
+ * fires the config-change trigger. But that path depends on `E` actually changing, so it covers a
+ * renewal that SUCCEEDED and not one that failed. See the note on that trigger.
  */
 export async function scheduleUserExpiryStatusWake(): Promise<void> {
   if (userExpiryWakeId) {
@@ -407,7 +433,11 @@ export async function scheduleUserExpiryStatusWake(): Promise<void> {
   if (!accessExpiryMs) {
     return;
   }
-  const wakeAtMs = accessExpiryMs + USER_EXPIRY_WAKE_DELAY_MS;
+  // Fires just past the RENEWAL DATE (`E - G`), not past coverage end. `E` is grace-inclusive, so
+  // waking at `E` would arrive after the whole grace window had already elapsed — i.e. after the state
+  // this wake exists to surface had come and gone.
+  const gracePeriodMs = await UserConfigWrapperActions.getProGracePeriod();
+  const wakeAtMs = accessExpiryMs - gracePeriodMs + USER_EXPIRY_WAKE_DELAY_MS;
   const delayMs = wakeAtMs - NetworkTime.now();
   if (delayMs <= 0) {
     return;
@@ -418,7 +448,7 @@ export async function scheduleUserExpiryStatusWake(): Promise<void> {
   }, delayMs);
 }
 
-// ===== §4 startup gate =====
+// ===== The startup gate =====
 
 /**
  * Whether a *cold start* is allowed to fetch `get_pro_status`.
@@ -458,9 +488,15 @@ async function coldStartShouldFetchProStatus(): Promise<boolean> {
   const autoRenewing = await getProAutoRenewingFromConfig();
 
   if (autoRenewing) {
-    // Comfortably active -> skip. Past `E` -> fetch: we're in or near grace and `grace` itself only
-    // comes back from the backend.
-    return now >= accessExpiryMs;
+    // `E` is coverage end, not the renewal date — the backend folds grace into the stored expiry for
+    // auto-renewing subscriptions. So the renewal falls due at `E - G`, and comparing against `E`
+    // itself would sleep through the entire grace window: exactly the state this gate exists to
+    // surface. Fetch from the renewal date onward.
+    //
+    // `G` is synced alongside `E` precisely so a config-only caller like this one can compute it. Both
+    // are milliseconds here; core stores `G` in seconds and the nodejs wrapper converts.
+    const gracePeriodMs = await UserConfigWrapperActions.getProGracePeriod();
+    return now >= accessExpiryMs - gracePeriodMs;
   }
 
   // Not auto-renewing. Expiring inside the CTA window, or already past `E` (where the fetch is the
@@ -472,25 +508,14 @@ async function coldStartShouldFetchProStatus(): Promise<boolean> {
 /**
  * Read `auto_renewing` (config key `A`) from synced config.
  *
- * ⚠️ Single point of contact with libsession PR #121 — nothing else in the gate reads `A` directly.
+ * `A` is presence-only in core: `set_pro_auto_renewing` uses `set_nonzero_int`, so writing false erases
+ * the key and the getter returns false for both "not auto-renewing" and "never written".
  *
- * ⚠️ `A` is presence-only — core writes it with `set_nonzero_int`, so a `false` ERASES the key. The
- * getter therefore returns `false` for all three of *not auto-renewing*, *never fetched yet*, and
- * *written by a client that predates `A`*, and nothing downstream can tell them apart.
- *
- * An absent `A` reads as `false` here, which is the spec's letter and matches Android and
- * iOS. Practically that puts such a user in gate rows 3/4, so they get the confirm fetch from
- * `E − PRO_EXPIRING_CTA_WINDOW_MS` onward. Reading it as `true` instead looks more optimistic but is
- * strictly worse: it puts them in row 1, and a genuinely non-auto-renewing user would then never get
- * the Expiring-CTA confirm fetch that rows 3/4 exist to produce.
- *
- * ⚠️ Still OPEN with the architect (coordinator's F2): whether `E` present + `A` absent should
- * **bootstrap** a single fetch, so `A` gets populated for a comfortably-active user — who, under any
- * reading, never triggers a startup fetch while comfortably inside `E` and so never writes `A`. That
- * is the gate working as designed rather than a deadlock (`E` also advances from each proof outcome,
- * independently of any status fetch), but it does mean `A` can stay absent indefinitely. Reading
- * `false` does not answer that question — it just means all three clients wait for the answer from
- * the same starting behaviour. This function is the seam; the ruling is one line here.
+ * That ambiguity used to matter, because the proof-success path wrote `E` without `A` — so an account
+ * whose `E` came only from a proof read back as terminal while it was in fact renewing. The backend now
+ * sends `account_auto_renewing` on the proof response and we write `A` from it there too, so every path
+ * that writes `E` also writes `A`. Absent therefore genuinely means not-renewing, and the gate's
+ * `!auto_renewing` rows are correct as written.
  */
 async function getProAutoRenewingFromConfig(): Promise<boolean> {
   return UserConfigWrapperActions.getProAutoRenewing();
@@ -507,7 +532,7 @@ async function getProAutoRenewingFromConfig(): Promise<boolean> {
  * and presence flips on every change.
  *
  * Note the config-change observer watches only `E` and `I`, so an `auto_renewing` change re-derives
- * the display without triggering a fetch (§2, trigger #2).
+ * the display without triggering a fetch — we already have the synced value.
  */
 async function writeProAutoRenewingToConfig(autoRenewing: boolean): Promise<void> {
   await UserConfigWrapperActions.setProAutoRenewing(autoRenewing);
@@ -764,8 +789,8 @@ const refreshGetProStatusFromProBackend = createAsyncThunk(
     // drops the fetch, and nothing resolves the initial loading state, so the Pro screen spins and no
     // CTA fires — both gate on a confirmed fetch. **But the spinner is the symptom, not the reason.**
     // Fixing the spinner some other way does not make this removable; the floor would still be able to
-    // refuse a never-fetched process. (This also replaces §4's "on a cold start loadState is Init so the
-    // floor doesn't apply anyway", which stops being true the moment the timestamp is persisted.)
+    // refuse a never-fetched process. (This also replaces the older "on a cold start the load state is
+    // Init, so the floor doesn't apply anyway", which stops being true once the timestamp is persisted.)
     const noConfirmedStatusThisProcess = state.proBackendData.details.lastFetchedMs === 0;
 
     // Single-flight (above) prevents *concurrent* fetches; the floor prevents *frequent* ones. They

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -42,9 +42,9 @@ type RequestState<D = unknown> = {
   // requests rather than to confirm anything. Similar names, opposite meanings.
   //
   // ⚠️ This field looks redundant next to the persisted one and is not. Deleting it as "subsumed by
-  // the floor" was tried and would have shipped a permanent spinner on the Pro screen: a relaunch
-  // inside 60s hits the floor, the fetch is dropped, and nothing is left to resolve the initial
-  // loading state — which both the spinner and the CTAs gate on.
+  // the floor" ships a permanent spinner on the Pro screen: a relaunch inside 60s hits the floor, the
+  // fetch is dropped, and nothing is left to resolve the initial loading state — which both the spinner
+  // and the CTAs gate on.
   //
   // WHEN DELETING IT BECOMES CORRECT, so this is a test rather than a prohibition: when no consumer
   // needs a *this-process* confirmation any more. Concretely, all three of —
@@ -109,8 +109,8 @@ export type WithCallerContext = { callerContext?: 'recover' };
 /**
  * `immediate` means one thing only: bypass the status floor. It does NOT bypass the
  * single-flight guard and it does NOT touch the loading state — spinner UI is a separate concern
- * (trigger #3). Named `immediate` rather than `force` on purpose: `force` invited every routine
- * background trigger to pass it, which is how Android's 60s floor ended up dead.
+ * (trigger #3). The name is load-bearing: a permissive one like `force` reads as something any
+ * routine background trigger may pass, and a floor that every caller bypasses is dead code.
  *
  * Sanctioned callers, and no others:
  *   #5 manual refresh / recover  — implied by `callerContext: 'recover'`, so a future recover caller
@@ -252,11 +252,11 @@ async function applyProofOutcome(
     // Refresh cached access-expiry from the advisory account_expiry (decoupled from the proof guard,
     // so a mid-period horizon extension is still picked up). Guaranteed present on a success parse.
     //
-    // `A` and `G` ride along, so every path that writes `E` writes all three from the same response.
-    // This path used to write `E` alone, with two consequences: an account whose expiry came only from a
-    // proof read back as terminal while it was in fact renewing (`A` is presence-only, so unwritten and
-    // false are the same bit), and `E + G` could pair a fresh expiry with a grace learned in a different
-    // billing period.
+    // `A` and `G` ride along, and must: every path that writes `E` writes all three from the same
+    // response. Writing `E` alone breaks two things — an account whose expiry came only from a proof
+    // reads back as terminal while it is in fact renewing (`A` is presence-only, so unwritten and false
+    // are the same bit), and `E + G` pairs a fresh expiry with a grace learned in a different billing
+    // period.
     //
     // ⚠️ These writes belong INSIDE the success branch and must stay there. `accountAutoRenewing` and
     // `accountGracePeriodMs` are non-null because core requires them on a successful parse — a response
@@ -315,8 +315,9 @@ async function handleClearProProof() {
 }
 
 // ===== get_pro_status refresh discipline =====
-// These are a deliberate cross-client contract: Android and iOS name the same values so
-// nobody tunes one platform in isolation. Change them here and the other two clients are wrong.
+// Named rather than inlined because these are a cross-client contract, not local tuning: the same
+// quantities carry the same names on the other clients so that one platform cannot be retuned in
+// isolation. A change here needs the same change there, or the clients disagree about the same instant.
 
 /**
  * Minimum gap between *routine* status fetches. Drop-on-fresh — see statusFetchIsFloored.
@@ -330,10 +331,9 @@ async function handleClearProProof() {
  * its whole proof/renewal clock for compressed runs while this client-side constant does not participate
  * in that compression.
  *
- * **The sanctioned escape hatch is an env-var override of this constant, owned by the Pro UI-test work
- * and deliberately not built here.** If you are adding it, this is the value to hook, and note the
- * second wake is unlikely to be the only casualty — any client interval shorter than the compressed
- * equivalent has the same property.
+ * **The sanctioned escape hatch is an env-var override of this constant**, and this is the value to
+ * hook if you are adding one. Note the second wake is unlikely to be the only casualty: any client
+ * interval shorter than its compressed equivalent has the same property.
  */
 const STATUS_FLOOR_MS = 60 * DURATION.SECONDS;
 /** Cold-start fetches are additionally capped to one per this interval, by the startup gate. */
@@ -446,8 +446,8 @@ let userExpiryWakeIds: Array<ReturnType<typeof setTimeout>> = [];
  * Production `G` is at least an hour, so this is a test-environment property, not a wake defect. The
  * Google test provider sets grace to ~10s and the backend scales its whole clock for compressed runs;
  * this client's fixed floor doesn't. **An env-var override of `STATUS_FLOOR_MS` is the sanctioned escape
- * hatch, owned by the Pro UI-test work and deliberately not built here** — so don't "fix" it in the
- * client, and don't make this wake `immediate` to work around it.
+ * hatch** — so don't "fix" it by shortening the floor, and don't make this wake `immediate` to work
+ * around it.
  */
 export async function scheduleUserExpiryStatusWake(): Promise<void> {
   // Always clear before re-deriving. This function is called on startup and after every successful
@@ -500,9 +500,9 @@ export async function scheduleUserExpiryStatusWake(): Promise<void> {
  * Whether a *cold start* is allowed to fetch `get_pro_status`.
  *
  * Startup's only real consumer is the home CTAs — entitlement comes from the proof, the settings
- * screen refreshes on open, and account-expiry awareness is trigger #6. So instead of fetching on
- * every launch (which is what Desktop did, and what hammers the backend for every non-Pro and every
- * comfortably-active user), decide from synced config whether a CTA could plausibly fire.
+ * screen refreshes on open, and account-expiry awareness is trigger #6. Fetching on every launch would
+ * hit the backend for every non-Pro and every comfortably-active user to learn nothing, so decide from
+ * synced config whether a CTA could plausibly fire at all.
  *
  * The rule, keyed on `E` (the paid-through expiry) and never on coverage end:
  *
@@ -557,20 +557,20 @@ async function coldStartShouldFetchProStatus(): Promise<boolean> {
  * `A` is presence-only in core: `set_pro_auto_renewing` uses `set_nonzero_int`, so writing false erases
  * the key and the getter returns false for both "not auto-renewing" and "never written".
  *
- * That ambiguity used to matter, because the proof-success path wrote `E` without `A` — so an account
- * whose `E` came only from a proof read back as terminal while it was in fact renewing. The backend now
- * sends `account_auto_renewing` on the proof response and we write `A` from it there too, so every path
- * that writes `E` also writes `A`. Absent therefore genuinely means not-renewing, and the gate's
- * `!auto_renewing` rows are correct as written.
+ * ⚠️ That ambiguity is harmless only because every path that writes `E` also writes `A`, from the same
+ * response — the status fetch and the proof outcome both do. Absent therefore means not-renewing rather
+ * than unknown, which is what makes the gate's `!auto_renewing` rows sound. A new writer of `E` that
+ * carries no renewing flag would silently reintroduce it: an account renewing under an `E` that came
+ * from that path reads back as terminal.
  */
 async function getProAutoRenewingFromConfig(): Promise<boolean> {
   // `A` cannot outlive the `E` it describes: libsession erases `A` and `G` alongside `E` whenever the
   // expiry is cleared, so a renewing flag with no expiry beside it is not a reachable state. Every
   // caller that clears `E` is handling an account with no entitlement, and none of those is renewing.
   //
-  // The gate reads `E` before calling this, but for its own reason — no expiry means nothing a CTA
-  // could be about — rather than to guard against a stale flag. That guard used to be what held the
-  // invariant up; it no longer is.
+  // ⚠️ The gate happens to read `E` before calling this, but for its own reason — no expiry means
+  // nothing a CTA could be about — so do not read that ordering as the thing upholding the invariant
+  // above. A caller that reads `A` without checking `E` first is equally correct.
   return UserConfigWrapperActions.getProAutoRenewing();
 }
 
@@ -592,8 +592,8 @@ async function writeProAutoRenewingToConfig(autoRenewing: boolean): Promise<void
 }
 
 /**
- * The gated cold-start status refresh (trigger #1). Replaces the unconditional dispatch that used to
- * sit in startup.ts, and arms #6 for this session either way.
+ * The gated cold-start status refresh (trigger #1). Arms #6 for this session whether or not the gate
+ * allows the fetch.
  */
 export async function refreshProStatusOnStartupIfNeeded(): Promise<void> {
   void scheduleUserExpiryStatusWake();
@@ -772,7 +772,7 @@ const fetchGetProStatusFromProBackend = createAsyncThunk(
         // without reconciling, every trigger for the next 60s would be floored and skip its reconcile
         // as well; and when the proof loop is dormant (`pro_renewal_target` null) it has no wake of its
         // own, so a nudge it misses is LOST, not delayed. Moving this inside a data guard as a tidy-up
-        // ("why reconcile when we got nothing back?") is exactly how iOS acquired that bug.
+        // ("why reconcile when we got nothing back?") is what reintroduces it.
         void reconcileProProof();
         return state;
       },
@@ -874,8 +874,8 @@ const refreshGetProStatusFromProBackend = createAsyncThunk(
       // Desktop does not currently need this — the trailing reconcile in the fetch callback runs even
       // on a failed fetch, so nothing arms the floor without reconciling first. But that safety is an
       // invariant a reader has to hold two facts to see, and one plausible tidy-up from breaking (see
-      // the note on that call). Reconciling here makes the coverage unconditional instead, matching
-      // iOS. It costs no network: the reconcile is local and separately paced by COVERED_MS/DARK_*.
+      // the note on that call). Reconciling here makes that coverage unconditional rather than
+      // inferred. It costs no network: the reconcile is local and separately paced by COVERED_MS/DARK_*.
       void reconcileProProof();
       return;
     }

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -31,8 +31,29 @@ type RequestState<D = unknown> = {
   // True if the request has been made
   isEnabled: boolean;
   error: string | null;
-  // When the last successful fetch completed (ms, network time). 0 if we never got one this run.
-  // Used to throttle the opportunistic refresh done when a screen that shows this data is opened.
+  // When the last successful fetch COMPLETED (ms, network time). 0 if we never got one this run.
+  //
+  // Per-run and completion-stamped, which makes it the answer to "has this process confirmed our
+  // status (since some threshold)": the floor's never-confirmed-this-process exemption, the home Pro
+  // CTA gate, and the grace warning's `lastFetchedMs >= expiryTimeMs` debounce all read it.
+  //
+  // ⚠️ Do NOT substitute SettingsKey.proStatusLastFetchAttemptMs for any of those. That one is
+  // persisted and stamped on *attempt*, because it backs the 60s floor, whose job is to bound
+  // requests rather than to confirm anything. Similar names, opposite meanings.
+  //
+  // ⚠️ This field looks redundant next to the persisted one and is not. Deleting it as "subsumed by
+  // the floor" was tried and would have shipped a permanent spinner on the Pro screen: a relaunch
+  // inside 60s hits the floor, the fetch is dropped, and nothing is left to resolve the initial
+  // loading state — which both the spinner and the CTAs gate on.
+  //
+  // WHEN DELETING IT BECOMES CORRECT, so this is a test rather than a prohibition: when no consumer
+  // needs a *this-process* confirmation any more. Concretely, all three of —
+  //   1. the Pro screen's loading state no longer resolves only via a completed fetch,
+  //   2. the home CTAs no longer gate on one (see handleTriggeredCTAs), and
+  //   3. the grace debounce has a persisted completion-stamped value to read AND it has been decided
+  //      that a *previous* process's confirmation may satisfy it.
+  // (3) is the one to be most careful with: accepting a prior process's confirmation for the CTA gate
+  // is exactly the false-expired window that gating startup opened. Until then, keep both values.
   lastFetchedMs: number;
   data: D | null;
 };
@@ -84,6 +105,21 @@ type CreateProBackendFetchAsyncThunk<K extends keyof ProBackendDataPayloads> = {
 };
 
 export type WithCallerContext = { callerContext?: 'recover' };
+
+/**
+ * `immediate` means one thing only: bypass the status floor (§4). It does NOT bypass the
+ * single-flight guard and it does NOT touch the loading state — spinner UI is a separate concern
+ * (trigger #3). Named `immediate` rather than `force` on purpose: `force` invited every routine
+ * background trigger to pass it, which is how Android's 60s floor ended up dead.
+ *
+ * Sanctioned callers, and no others:
+ *   #5 manual refresh / recover  — implied by `callerContext: 'recover'`, so a future recover caller
+ *                                  gets it without having to remember
+ *   #4 the while-open grace poll — a bounded poll with its own cadence and termination
+ *   #7 the post-purchase poll    — N/A on Desktop: no in-app payment
+ *   developer/debug refresh paths
+ */
+export type WithImmediate = { immediate?: boolean };
 
 async function createProBackendFetchAsyncThunk<K extends keyof ProBackendDataPayloads>({
   key,
@@ -260,6 +296,21 @@ async function handleClearProProof() {
   await UserConfigWrapperActions.setProAccessExpiry(null);
 }
 
+// ===== get_pro_status refresh discipline (SPEC §4) =====
+// These are a deliberate cross-client contract (§9.3): Android and iOS name the same values so
+// nobody tunes one platform in isolation. Change them here and the other two clients are wrong.
+
+/** Minimum gap between *routine* status fetches. Drop-on-fresh — see statusFetchIsFloored. */
+const STATUS_FLOOR_MS = 60 * DURATION.SECONDS;
+/** Cold-start fetches are additionally capped to one per this interval (§4 startup gate). */
+const STATUS_STARTUP_MIN_INTERVAL_MS = 24 * DURATION.HOURS;
+/** #6: one wake past the account horizon, so grace surfaces without the Pro page being open. */
+const USER_EXPIRY_WAKE_DELAY_MS = 30 * DURATION.SECONDS;
+/** The Expiring-CTA window. §4's "E within the CTA window" test uses this same 7 days. */
+const PRO_EXPIRING_CTA_WINDOW_MS = 7 * DURATION.DAYS;
+/** The Expired-CTA window. */
+const PRO_EXPIRED_CTA_WINDOW_MS = 30 * DURATION.DAYS;
+
 async function handleExpiryCTAs(
   accessExpiryTsMs: number,
   autoRenewing: boolean,
@@ -267,8 +318,8 @@ async function handleExpiryCTAs(
 ) {
   const now = NetworkTime.now();
 
-  const sevenDaysBeforeExpiry = accessExpiryTsMs - 7 * DURATION.DAYS;
-  const thirtyDaysAfterExpiry = accessExpiryTsMs + 30 * DURATION.DAYS;
+  const sevenDaysBeforeExpiry = accessExpiryTsMs - PRO_EXPIRING_CTA_WINDOW_MS;
+  const thirtyDaysAfterExpiry = accessExpiryTsMs + PRO_EXPIRED_CTA_WINDOW_MS;
 
   const proExpiringSoonCTA = !isUndefined(Storage.get(SettingsKey.proExpiringSoonCTA));
   const proExpiredCTA = !isUndefined(Storage.get(SettingsKey.proExpiredCTA));
@@ -304,6 +355,180 @@ async function handleExpiryCTAs(
 }
 
 let firstFetchProStatusHappened = false;
+
+/**
+ * The status floor's timestamp lives in Storage, not in `details.lastFetchedMs`, because the redux
+ * value is per-run: it resets to 0 on every cold start, which is precisely the path the floor has to
+ * cover. See SettingsKey.proStatusLastFetchAttemptMs, which also spells out why this value is not
+ * interchangeable with the per-run, completion-stamped `details.lastFetchedMs`.
+ */
+function lastStatusFetchAttemptAtMs(): number {
+  return (Storage.get(SettingsKey.proStatusLastFetchAttemptMs) as number | undefined) ?? 0;
+}
+
+/**
+ * True when a routine status refresh should be *dropped* as too soon.
+ *
+ * Drop-on-fresh, deliberately NOT re-arm (§4): a floor that rescheduled the skipped fetch would turn
+ * the routine triggers into a self-sustaining once/60s poll, and during grace — when `E` sits static
+ * and nothing new can arrive from a config change — that poll is pure noise. Dropping is safe
+ * because status is display-only and backstopped by many triggers.
+ *
+ * The *proof* loop is the opposite by design (reconcileProProof reschedules rather than skips),
+ * because a throttled proof acquisition must still eventually happen. Don't unify the two.
+ */
+function statusFetchIsFloored(): boolean {
+  return NetworkTime.now() < lastStatusFetchAttemptAtMs() + STATUS_FLOOR_MS;
+}
+
+// ===== #6 — the single wake at user_expiry =====
+
+let userExpiryWakeId: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Schedule one status refresh shortly past the account horizon (`E`).
+ *
+ * This is the background half of surfacing grace. Desktop already refetches across the crossing
+ * while the Pro page is open (`useKeepProStatusFresh`, trigger #4), but that is screen-scoped: with
+ * the page closed nothing re-checks between `E` and the proof loop's wake ~1h before *proof* expiry,
+ * so a renewal that failed at `E` would only surface in that final hour. Android has had this wake
+ * (`E+30s`) all along; this is Desktop's equivalent.
+ *
+ * Only ever armed for a *future* crossing. A crossing already in the past is not replayed on every
+ * launch — that would duplicate the startup gate, which is the thing that decides whether a cold
+ * start is allowed to fetch at all.
+ */
+export async function scheduleUserExpiryStatusWake(): Promise<void> {
+  if (userExpiryWakeId) {
+    clearTimeout(userExpiryWakeId);
+    userExpiryWakeId = null;
+  }
+  const accessExpiryMs = await UserConfigWrapperActions.getProAccessExpiry();
+  if (!accessExpiryMs) {
+    return;
+  }
+  const wakeAtMs = accessExpiryMs + USER_EXPIRY_WAKE_DELAY_MS;
+  const delayMs = wakeAtMs - NetworkTime.now();
+  if (delayMs <= 0) {
+    return;
+  }
+  userExpiryWakeId = setTimeout(() => {
+    // Floored, like every other routine trigger — the wake is a nudge, not a "go right now".
+    window.inboxStore?.dispatch(proBackendDataActions.refreshGetProStatusFromProBackend({}) as any);
+  }, delayMs);
+}
+
+// ===== §4 startup gate =====
+
+/**
+ * Whether a *cold start* is allowed to fetch `get_pro_status`.
+ *
+ * Startup's only real consumer is the home CTAs — entitlement comes from the proof, the settings
+ * screen refreshes on open, and account-expiry awareness is trigger #6. So instead of fetching on
+ * every launch (which is what Desktop did, and what hammers the backend for every non-Pro and every
+ * comfortably-active user), decide from synced config whether a CTA could plausibly fire.
+ *
+ * The architect's rule, which REPLACES the spec's `E + grace <= now` test — `grace` isn't knowable
+ * until you are already in it, and libsession PR #121 adds `auto_renewing` only, so there is no
+ * `grace` in config to test against:
+ *
+ *   auto_renewing && now <  E                     -> comfortably active, no fetch
+ *   auto_renewing && now >= E                     -> in/near grace, unknowable, FETCH and learn
+ *                                                    `grace` from the response
+ *   !auto_renewing && E within the CTA window     -> expiring, fetch / CTA
+ *   !auto_renewing && now >= E                    -> expired, confirm-fetch before the Expired CTA
+ *
+ * Capped either way at one cold-start fetch per STATUS_STARTUP_MIN_INTERVAL_MS.
+ */
+async function coldStartShouldFetchProStatus(): Promise<boolean> {
+  const accessExpiryMs = await UserConfigWrapperActions.getProAccessExpiry();
+  if (!accessExpiryMs) {
+    // Never had Pro (or `E` was cleared by an outcome that ended entitlement): nothing a CTA could
+    // be about, and the proof loop owns re-entry. This is the bulk of the load the gate removes.
+    return false;
+  }
+
+  const lastStartupFetchMs =
+    (Storage.get(SettingsKey.proStatusLastStartupFetchMs) as number | undefined) ?? 0;
+  if (NetworkTime.now() < lastStartupFetchMs + STATUS_STARTUP_MIN_INTERVAL_MS) {
+    return false;
+  }
+
+  const now = NetworkTime.now();
+  const autoRenewing = await getProAutoRenewingFromConfig();
+
+  if (autoRenewing) {
+    // Comfortably active -> skip. Past `E` -> fetch: we're in or near grace and `grace` itself only
+    // comes back from the backend.
+    return now >= accessExpiryMs;
+  }
+
+  // Not auto-renewing. Expiring inside the CTA window, or already past `E` (where the fetch is the
+  // confirm-before-Expired-CTA step — config can say expired while a renewal that landed on another
+  // device hasn't synced yet).
+  return now >= accessExpiryMs - PRO_EXPIRING_CTA_WINDOW_MS;
+}
+
+/**
+ * Read `auto_renewing` (config key `A`) from synced config.
+ *
+ * ⚠️ Single point of contact with libsession PR #121 — nothing else in the gate reads `A` directly.
+ *
+ * ⚠️ `A` is presence-only — core writes it with `set_nonzero_int`, so a `false` ERASES the key. The
+ * getter therefore returns `false` for all three of *not auto-renewing*, *never fetched yet*, and
+ * *written by a client that predates `A`*, and nothing downstream can tell them apart.
+ *
+ * An absent `A` reads as `false` here, which is the spec's letter and matches Android and
+ * iOS. Practically that puts such a user in gate rows 3/4, so they get the confirm fetch from
+ * `E − PRO_EXPIRING_CTA_WINDOW_MS` onward. Reading it as `true` instead looks more optimistic but is
+ * strictly worse: it puts them in row 1, and a genuinely non-auto-renewing user would then never get
+ * the Expiring-CTA confirm fetch that rows 3/4 exist to produce.
+ *
+ * ⚠️ Still OPEN with the architect (coordinator's F2): whether `E` present + `A` absent should
+ * **bootstrap** a single fetch, so `A` gets populated for a comfortably-active user — who, under any
+ * reading, never triggers a startup fetch while comfortably inside `E` and so never writes `A`. That
+ * is the gate working as designed rather than a deadlock (`E` also advances from each proof outcome,
+ * independently of any status fetch), but it does mean `A` can stay absent indefinitely. Reading
+ * `false` does not answer that question — it just means all three clients wait for the answer from
+ * the same starting behaviour. This function is the seam; the ruling is one line here.
+ */
+async function getProAutoRenewingFromConfig(): Promise<boolean> {
+  return UserConfigWrapperActions.getProAutoRenewing();
+}
+
+/**
+ * Persist `auto_renewing` into synced config, mirroring how each fetch persists `E`. Without the
+ * write side the config field is never populated and the startup gate has nothing to read.
+ *
+ * Unconditional, and deliberately so: libSession already de-dupes a no-change write one layer down
+ * (`assign_if_changed` / `erase` both no-op on a clean config), which is the same property the
+ * unconditional `E` write beside it relies on. A client-side guard would add nothing, and a
+ * *presence*-based one would be actively wrong — `A` is presence-only, so a `false` erases the key
+ * and presence flips on every change.
+ *
+ * Note the config-change observer watches only `E` and `I`, so an `auto_renewing` change re-derives
+ * the display without triggering a fetch (§2, trigger #2).
+ */
+async function writeProAutoRenewingToConfig(autoRenewing: boolean): Promise<void> {
+  await UserConfigWrapperActions.setProAutoRenewing(autoRenewing);
+}
+
+/**
+ * The gated cold-start status refresh (trigger #1). Replaces the unconditional dispatch that used to
+ * sit in startup.ts, and arms #6 for this session either way.
+ */
+export async function refreshProStatusOnStartupIfNeeded(): Promise<void> {
+  void scheduleUserExpiryStatusWake();
+
+  if (!(await coldStartShouldFetchProStatus())) {
+    return;
+  }
+  await Storage.put(SettingsKey.proStatusLastStartupFetchMs, NetworkTime.now());
+  // Not `immediate`: on a cold start nothing has been fetched this run, so the floor is only in play
+  // if a previous run fetched within the last minute — in which case dropping it is correct.
+  window.inboxStore?.dispatch(proBackendDataActions.refreshGetProStatusFromProBackend({}) as any);
+}
+
 // ===== Pro proof renewal reconcile loop (agent-comms/pro-proof-renewal-loop-design.md) =====
 const DARK_STEP_MS = 15 * DURATION.SECONDS;
 const DARK_CAP_MS = 15 * DURATION.MINUTES;
@@ -408,6 +633,7 @@ const fetchGetProStatusFromProBackend = createAsyncThunk(
               // horizon-only change the renewal path wouldn't). The proof itself is (re)obtained by
               // the reconcile loop, triggered below.
               await UserConfigWrapperActions.setProAccessExpiry(state.data.expiryMs);
+              await writeProAutoRenewingToConfig(state.data.autoRenewing);
               break;
 
             case ProStatus.Never:
@@ -447,11 +673,20 @@ const fetchGetProStatusFromProBackend = createAsyncThunk(
 
         if (state.data) {
           await putProStatusInStorage(state.data);
+          // `E` may have moved, so re-aim #6 at the new horizon.
+          void scheduleUserExpiryStatusWake();
         }
         // trigger a UI refresh so our state and Pro rights are up to date without a restart (animated image should stop animating)
         ConvoHub.use().get(UserUtils.getOurPubKeyStrFromCache())?.triggerUIRefresh();
         // A get_pro_status fetch may have changed config (E / prepaid / status) — re-run the proof
         // renewal loop against the fresh state.
+        //
+        // ⚠️ MUST stay outside the `if (state.data)` guards above — it runs on a FAILED fetch too, and
+        // that is load-bearing. The status floor is armed on *attempt*, so if a failure returned here
+        // without reconciling, every trigger for the next 60s would be floored and skip its reconcile
+        // as well; and when the proof loop is dormant (`pro_renewal_target` null) it has no wake of its
+        // own, so a nudge it misses is LOST, not delayed. Moving this inside a data guard as a tidy-up
+        // ("why reconcile when we got nothing back?") is exactly how iOS acquired that bug.
         void reconcileProProof();
         return state;
       },
@@ -498,7 +733,7 @@ const fetchGetProStatusFromProBackend = createAsyncThunk(
 
 const refreshGetProStatusFromProBackend = createAsyncThunk(
   'proBackendData/refreshGetProStatus',
-  async (opts: WithCallerContext = {}, payloadCreator) => {
+  async ({ immediate, ...opts }: WithCallerContext & WithImmediate = {}, payloadCreator) => {
     if (getFeatureFlag('debugServerRequests')) {
       window.log.info(
         `[proBackend/refreshGetProStatusFromProBackend] starting ${new Date().toISOString()}`
@@ -511,11 +746,67 @@ const refreshGetProStatusFromProBackend = createAsyncThunk(
       return;
     }
 
+    // Three separate things can refuse to start a status fetch, and only one of them can refuse in a
+    // process that has never fetched:
+    //
+    //   in-flight    `details.isFetching`                     per-run, so it cannot refuse first time
+    //   unconfirmed  `details.lastFetchedMs`                  per-run, ditto
+    //   TOO SOON     `SettingsKey.proStatusLastFetchAttemptMs` PERSISTED — outlives the process
+    //
+    // ⚠️ THIS EXEMPTION EXISTS BECAUSE OF THE THIRD ONE. The floor reads a timestamp written by a
+    // *previous* run, so without an exemption it can decline the first fetch of a process that has no
+    // status at all — turning a rate limit into a mutex on exactly the cold-start path the startup gate
+    // is about. `lastFetchedMs` is per-run (0 until this process completes a fetch), so it is the right
+    // signal, and it is why the per-run value is kept alongside the persisted one rather than replaced
+    // by it. Cold-start load stays bounded by the 24h startup interval, which is the stronger limit.
+    //
+    // The visible symptom is a permanent spinner: relaunch within 60s of a previous fetch, the floor
+    // drops the fetch, and nothing resolves the initial loading state, so the Pro screen spins and no
+    // CTA fires — both gate on a confirmed fetch. **But the spinner is the symptom, not the reason.**
+    // Fixing the spinner some other way does not make this removable; the floor would still be able to
+    // refuse a never-fetched process. (This also replaces §4's "on a cold start loadState is Init so the
+    // floor doesn't apply anyway", which stops being true the moment the timestamp is persisted.)
+    const noConfirmedStatusThisProcess = state.proBackendData.details.lastFetchedMs === 0;
+
+    // Single-flight (above) prevents *concurrent* fetches; the floor prevents *frequent* ones. They
+    // are not substitutes for each other, so both apply.
+    if (
+      !immediate &&
+      opts.callerContext !== 'recover' &&
+      !noConfirmedStatusThisProcess &&
+      statusFetchIsFloored()
+    ) {
+      if (getFeatureFlag('debugServerRequests')) {
+        window.log.info(
+          `[proBackend/refreshGetProStatusFromProBackend] dropped: within the ${STATUS_FLOOR_MS}ms floor`
+        );
+      }
+      // Still reconcile the proof loop on the way out. Dropping a *status* refresh must never cost a
+      // proof nudge: the loop is dormant when `pro_renewal_target` is null, so it has no wake of its
+      // own and a nudge it misses is lost rather than delayed.
+      //
+      // Desktop does not currently need this — the trailing reconcile in the fetch callback runs even
+      // on a failed fetch, so nothing arms the floor without reconciling first. But that safety is an
+      // invariant a reader has to hold two facts to see, and one plausible tidy-up from breaking (see
+      // the note on that call). Reconciling here makes the coverage unconditional instead, matching
+      // iOS. It costs no network: the reconcile is local and separately paced by COVERED_MS/DARK_*.
+      void reconcileProProof();
+      return;
+    }
+
     if (getFeatureFlag('debugServerRequests')) {
       window.log.info(
         `[proBackend/refreshGetProStatusFromProBackend] triggered refresh at ${new Date().toISOString()}`
       );
     }
+    // Arm the floor on *attempt*, not on success: a failed request costs the backend the same as a
+    // successful one, and recording only on success lets a failing network re-request on every
+    // trigger and every cold launch. Ruled: attempt for both timestamps, no split between the 60s
+    // floor and the 24h gate, on all three clients. The accepted cost is that a launch with no
+    // connectivity burns its startup slot — narrowed by the never-confirmed-this-process exemption
+    // above, which still lets later in-session triggers retry.
+    await Storage.put(SettingsKey.proStatusLastFetchAttemptMs, NetworkTime.now());
+
     const masterPrivKeyHex = await UserUtils.getProMasterKeyHex();
     payloadCreator.dispatch(fetchGetProStatusFromProBackend({ ...opts, masterPrivKeyHex }) as any);
   }
@@ -547,10 +838,21 @@ export const proBackendDataSlice = createSlice({
     },
   },
   extraReducers: builder => {
-    builder.addCase(fetchGetProStatusFromProBackend.rejected, (_state, action) => {
+    builder.addCase(fetchGetProStatusFromProBackend.rejected, (state, action) => {
       window.log.error(
         `[proBackend / fetchGetProStatusFromProBackend] rejected ${action.error.message || action.error} `
       );
+      // Release the single-flight. `isFetching` is set by a dispatched action but cleared only by the
+      // result object landing via `fulfilled`, and the thunk's internal try/catch covers the network
+      // getter only — its `contextHandler`/`callback` run outside it. So a throw in post-processing
+      // rejects here, and without this reset `isFetching` stays true for the rest of the process:
+      // every later status trigger early-returns, which silently disables the floor, the gate and the
+      // #6 wake all at once. `isLoading` sticks the same way, and on a first-ever fetch that is a
+      // permanent spinner on the Pro screen.
+      //
+      // Deliberately does NOT touch `data` or `lastFetchedMs`: a failed fetch must not discard the last
+      // known-good status, and it must not look like a confirmation.
+      state.details = { ...state.details, isFetching: false, isLoading: false, isError: true };
     });
     builder.addCase(fetchGetProStatusFromProBackend.fulfilled, (state, action) => {
       if (getFeatureFlag('debugServerRequests')) {

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -255,12 +255,15 @@ async function applyProofOutcome(
   // Non-ok: the machine slug (error_code) decides.
   switch (response.errorCode) {
     case 'subscription_expired':
-      // The sub genuinely lapsed. Don't wipe a fresh proof a re-subscribe just landed.
+      // Lapsed, so not entitled — the same conclusion as the two outcomes below, and cleared the same
+      // way. A past expiry left in config has nothing left to compute: every window here is derived
+      // from `E`, and a lapse changes the grace and the renewing flag while typically leaving `E`
+      // itself alone, so refreshing only `E` would pair it with a grace the backend has stopped
+      // honouring. Clearing erases `A` and `G` alongside it instead, leaving absent keys rather than
+      // stored zeroes. Don't wipe a fresh proof a re-subscribe just landed.
       if (!haveValidProof()) {
-        if (response.accountExpiryMs !== null) {
-          await UserConfigWrapperActions.setProAccessExpiry(response.accountExpiryMs);
-        }
         await UserConfigWrapperActions.removeProConfig();
+        await UserConfigWrapperActions.setProAccessExpiry(null);
       }
       break;
     case 'not_subscribed':
@@ -483,17 +486,21 @@ export async function scheduleUserExpiryStatusWake(): Promise<void> {
  * Capped either way at one cold-start fetch per STATUS_STARTUP_MIN_INTERVAL_MS.
  */
 async function coldStartShouldFetchProStatus(): Promise<boolean> {
-  const accessExpiryMs = await UserConfigWrapperActions.getProAccessExpiry();
-  if (!accessExpiryMs) {
-    // Never had Pro (or `E` was cleared by an outcome that ended entitlement): nothing a CTA could
-    // be about, and the proof loop owns re-entry. This is the bulk of the load the gate removes.
-    return false;
-  }
-
+  // The interval cap comes first so that it bounds every row below it, including the no-expiry row, which
+  // is keyed on a stored flag rather than on a horizon and would otherwise fetch on every single launch.
   const lastStartupFetchMs =
     (Storage.get(SettingsKey.proStatusLastStartupFetchMs) as number | undefined) ?? 0;
   if (NetworkTime.now() < lastStartupFetchMs + STATUS_STARTUP_MIN_INTERVAL_MS) {
     return false;
+  }
+
+  const accessExpiryMs = await UserConfigWrapperActions.getProAccessExpiry();
+  if (!accessExpiryMs) {
+    // No expiry in config: Pro was never held, or an outcome that ended entitlement cleared it. There is
+    // no window left to compute — every bound below is derived from `E` — so the only thing that can still
+    // want a fetch is an Expired CTA already latched by an earlier fetch. It gates on a status confirmed in
+    // *this* process, so without a fetch here it can never be shown and the flag would sit set forever.
+    return !isUndefined(Storage.get(SettingsKey.proExpiredCTA));
   }
 
   const now = NetworkTime.now();
@@ -533,9 +540,10 @@ async function coldStartShouldFetchProStatus(): Promise<boolean> {
  * `A` is presence-only in core: `set_pro_auto_renewing` uses `set_nonzero_int`, so writing false erases
  * the key and the getter returns false for both "not auto-renewing" and "never written".
  *
- * Harmless only while every path that writes `E` also writes `A` from the same response, and every reader
- * establishes `E` first — an `A` left by an earlier subscription otherwise reads as renewing with no
- * expiry to renew. A new writer or reader has to keep both.
+ * That ambiguity is harmless because an `A` without an `E` beside it is not reachable here: the only two
+ * paths that write `E` — the status fetch and a successful proof — write `A` from the same response, and
+ * every outcome that ends entitlement *clears* `E`, which erases `A` and `G` with it. A new writer of `E`
+ * has to carry the renewing flag, or that stops being true.
  */
 async function getProAutoRenewingFromConfig(): Promise<boolean> {
   return UserConfigWrapperActions.getProAutoRenewing();

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -369,6 +369,21 @@ async function handleExpiryCTAs(
     await Storage.remove(SettingsKey.proExpiredCTA);
   }
 
+  // `status` is the authority on whether the account has lapsed, and it accounts for revocation, which no
+  // date arithmetic here can see: a refund or chargeback reports Expired while the paid term is still in
+  // the future. Keyed on the status alone, so it must run ahead of the date chain below — a revoked
+  // account sits inside the active or expiring window and would be handled as one.
+  if (status === ProStatus.Expired && now < expiredCTADeadlineMs) {
+    if (!proExpiredCTA) {
+      await Storage.put(SettingsKey.proExpiredCTA, true);
+      // Shown again in a later cycle if needed.
+      if (proExpiringSoonCTA) {
+        await Storage.remove(SettingsKey.proExpiringSoonCTA);
+      }
+    }
+    return;
+  }
+
   if (now < sevenDaysBeforeExpiry) {
     // More than 7 days before expiry, remove CTA items if they exist. This means the items were set for a previous cycle of pro access.
     if (proExpiringSoonCTA) {
@@ -381,15 +396,6 @@ async function handleExpiryCTAs(
     // Between 7 days before expiry and expiry, Expiring Soon CTA needs to be marked to be shown if not already. Only shown if not auto-renewing
     if (status === ProStatus.Active && !autoRenewing && !proExpiringSoonCTA) {
       await Storage.put(SettingsKey.proExpiringSoonCTA, true);
-    }
-  } else if (accessExpiryTsMs < now && now < expiredCTADeadlineMs) {
-    // Between expiry and 30 days after expiry, Expired CTA needs to be marked to be shown if not already
-    if (status === ProStatus.Expired && !proExpiredCTA) {
-      await Storage.put(SettingsKey.proExpiredCTA, true);
-      // The expiring soon CTA should be removed if it's set as we want to show it again in the future if needed
-      if (proExpiringSoonCTA) {
-        await Storage.remove(SettingsKey.proExpiringSoonCTA);
-      }
     }
   }
 }

--- a/ts/state/ducks/types/defaultFeatureFlags.ts
+++ b/ts/state/ducks/types/defaultFeatureFlags.ts
@@ -6,7 +6,6 @@ import type {
 } from './releasedFeaturesReduxTypes';
 
 export const defaultProBooleanFeatureFlags = {
-  proAvailable: !isEmpty(process.env.SESSION_PRO),
   proGroupsAvailable: !isEmpty(process.env.SESSION_PRO_GROUPS),
   useTestProBackend: !isEmpty(process.env.TEST_PRO_BACKEND),
   mockCurrentUserHasProPlatformRefundExpired: !isEmpty(

--- a/ts/state/ducks/types/releasedFeaturesReduxTypes.ts
+++ b/ts/state/ducks/types/releasedFeaturesReduxTypes.ts
@@ -18,7 +18,6 @@ type SessionBaseBooleanFeatureFlags = {
   alwaysShowRemainingChars: boolean;
   showPopoverAnchors: boolean;
   debugInputCommands: boolean;
-  proAvailable: boolean;
   proGroupsAvailable: boolean;
   canToggleGiphy: boolean;
   mockCurrentUserHasProPlatformRefundExpired: boolean;

--- a/ts/state/selectors/proBackendData.ts
+++ b/ts/state/selectors/proBackendData.ts
@@ -281,33 +281,38 @@ function processProBackendData({
     ? !mockCancelled
     : (data?.autoRenewing ?? defaultProAccessDetailsSourceData.autoRenew);
 
-  // `expiry_ts` is COVERAGE END, not the date the renewal is due: the backend folds the grace period
-  // into the stored expiry for auto-renewing subscriptions (`_lookup_user_expiry` -> `best_expiry`) and
-  // judges `user_status` against that same value. So the renewal falls due at `E - grace`, and the grace
-  // window — renewal overdue, account still covered — is `E - grace <= now < E`.
+  // `expiry_ts` is the account's TRUE expiry — what the user has paid through — so it is the date to
+  // show, with no arithmetic. Coverage runs a little past it: the backend keeps serving until
+  // `expiry_ts + grace_period_duration` and judges `user_status` against that coverage end rather than
+  // against the expiry it reports. So the grace window — expired, still served — is `[E, E + grace)`.
   //
-  // The subtraction is unconditional and needs no provider branching: the wire sends `grace = 0`
-  // whenever the subscription isn't auto-renewing, so this is `E - 0 == E` for those accounts.
+  // `grace_period_duration` here is the ACCOUNT-level field at the response root. `latestPayment` carries
+  // a field of the same name holding one store's raw declaration, which is NOT gated on auto-renewal — a
+  // subscriber who cancels mid-retry keeps a nonzero value there and reading it would place coverage
+  // weeks late. Root for "how much longer are we served", payment for "what did the store say".
+  //
+  // No provider branching is needed and none should be added: the root value is 0 whenever the
+  // subscription isn't auto-renewing, so this is `E + 0 == E` for those accounts. Stores differ in
+  // whether they state grace separately or fold it into their own expiry, and a client treats what it
+  // receives as correct — a store that folds it in simply sends a later `E` and a window that never opens.
   //
   // Both values here are already milliseconds (the response's own units). Core stores `G` in seconds and
   // the nodejs wrapper converts, so anything reading grace from *config* rather than from a response is
-  // on the other side of that boundary — check which you have before subtracting.
-  const renewalDueAtMs = data ? data.expiryMs - data.gracePeriodDurationMs : 0;
-  // Kept under its original name because it is threaded into the display strings below.
-  const beginAutoRenew = renewalDueAtMs;
+  // on the other side of that boundary — check which you have before adding.
+  const coverageEndMs = expiryTimeMs ? expiryTimeMs + (data?.gracePeriodDurationMs ?? 0) : 0;
 
   let inGracePeriod = mockInGracePeriod;
-  if (beginAutoRenew && !mockInGracePeriod) {
-    // Past the renewal date but still covered. Keyed on `renewalDueAtMs`, not on `expiryTimeMs`: the
-    // latter is coverage end, and `now >= E` inside a branch that requires `now <= E` is satisfiable
-    // only at a single instant — which is why this indicator was previously unreachable and nothing
-    // surfaced an overdue renewal at all.
+  if (expiryTimeMs && !mockInGracePeriod) {
+    // Past the expiry but still covered. The upper bound is coverage end, not the expiry: `now >= E`
+    // and `now < E` cannot both hold, so bounding this by `E` would make the indicator unreachable.
+    // When grace is 0 the window is empty by construction, which is correct — an account with no grace
+    // has no overdue-but-covered state to show.
     //
     // The `lastFetchedMs` term is the debounce: only surface "renewal unsuccessful" off a fetch that
     // COMPLETED at or after the crossing, never off a snapshot predating a renewal that may since have
     // landed. It is per-run and stamped on completion, so a request still in flight cannot satisfy it.
     inGracePeriod =
-      autoRenew && now >= renewalDueAtMs && now < expiryTimeMs && lastFetchedMs >= renewalDueAtMs;
+      autoRenew && now >= expiryTimeMs && now < coverageEndMs && lastFetchedMs >= expiryTimeMs;
   }
 
   // Refund-requested is now a synced config flag (UserProfile key R), not a backend response field.
@@ -330,10 +335,10 @@ function processProBackendData({
       variantString,
       expiryTimeMs,
       expiryTimeDateString: formatDateWithLocale({
-        date: new Date(beginAutoRenew),
+        date: new Date(expiryTimeMs),
         formatStr: 'MMM d, yyyy',
       }),
-      expiryTimeRelativeString: formatRoundedUpTimeUntilTimestamp(beginAutoRenew),
+      expiryTimeRelativeString: formatRoundedUpTimeUntilTimestamp(expiryTimeMs),
       isPlatformRefundAvailable,
       provider,
       providerConstants: getProProviderConstantsWithFallbacks(provider),

--- a/ts/state/selectors/proBackendData.ts
+++ b/ts/state/selectors/proBackendData.ts
@@ -197,6 +197,7 @@ type ProAccessDetails = {
   variant: ProAccessVariant;
   variantString: string;
   expiryTimeMs: number;
+  coverageEndMs: number;
   expiryTimeDateString: string;
   expiryTimeRelativeString: string;
   isPlatformRefundAvailable: boolean;
@@ -329,6 +330,7 @@ function processProBackendData({
       variant,
       variantString,
       expiryTimeMs,
+      coverageEndMs,
       expiryTimeDateString: formatDateWithLocale({
         date: new Date(expiryTimeMs),
         formatStr: 'MMM d, yyyy',

--- a/ts/state/selectors/proBackendData.ts
+++ b/ts/state/selectors/proBackendData.ts
@@ -281,24 +281,19 @@ function processProBackendData({
     ? !mockCancelled
     : (data?.autoRenewing ?? defaultProAccessDetailsSourceData.autoRenew);
 
-  // `expiry_ts` is the account's TRUE expiry — what the user has paid through — so it is the date to
-  // show, with no arithmetic. Coverage runs a little past it: the backend keeps serving until
-  // `expiry_ts + grace_period_duration` and judges `user_status` against that coverage end rather than
-  // against the expiry it reports. So the grace window — expired, still served — is `[E, E + grace)`.
+  // `expiry_ts` is the account's true expiry — what the user has paid through — so it is the date to
+  // show, with no arithmetic. Coverage runs past it: the backend serves until `expiry_ts +
+  // grace_period_duration` and judges `user_status` against that, so the grace window is `[E, E + grace)`.
   //
   // `grace_period_duration` here is the ACCOUNT-level field at the response root. `latestPayment` carries
-  // a field of the same name holding one store's raw declaration, which is NOT gated on auto-renewal — a
-  // subscriber who cancels mid-retry keeps a nonzero value there and reading it would place coverage
-  // weeks late. Root for "how much longer are we served", payment for "what did the store say".
+  // one of the same name holding a store's raw declaration, NOT gated on auto-renewal — a subscriber who
+  // cancels mid-retry keeps a nonzero value there, and reading it would place coverage weeks late.
   //
-  // No provider branching is needed and none should be added: the root value is 0 whenever the
-  // subscription isn't auto-renewing, so this is `E + 0 == E` for those accounts. Stores differ in
-  // whether they state grace separately or fold it into their own expiry, and a client treats what it
-  // receives as correct — a store that folds it in simply sends a later `E` and a window that never opens.
+  // The root value is 0 whenever the subscription isn't auto-renewing, so no provider branching is needed
+  // or wanted: a store that folds grace into its own expiry just sends a later `E`.
   //
-  // Both values here are already milliseconds (the response's own units). Core stores `G` in seconds and
-  // the nodejs wrapper converts, so anything reading grace from *config* rather than from a response is
-  // on the other side of that boundary — check which you have before adding.
+  // Both values are milliseconds here; core stores `G` in seconds and the wrapper converts, so grace read
+  // from *config* is on the other side of that boundary.
   const coverageEndMs = expiryTimeMs ? expiryTimeMs + (data?.gracePeriodDurationMs ?? 0) : 0;
 
   let inGracePeriod = mockInGracePeriod;

--- a/ts/state/selectors/proBackendData.ts
+++ b/ts/state/selectors/proBackendData.ts
@@ -4,6 +4,7 @@ import {
   proBackendDataActions,
   RequestActionArgs,
   WithCallerContext,
+  WithImmediate,
   type ProBackendDataState,
 } from '../ducks/proBackendData';
 import { SettingsKey } from '../../data/settings-key';
@@ -280,14 +281,57 @@ function processProBackendData({
     ? !mockCancelled
     : (data?.autoRenewing ?? defaultProAccessDetailsSourceData.autoRenew);
 
+  // 🔴 THE PREMISE IN THE NEXT PARAGRAPH IS WRONG, AND IS UNDER REVIEW (F8). Marked rather than
+  // rewritten because correcting the behaviour has to land on Android, Desktop and iOS together — all
+  // three wrote this same premise down independently, which is why it read as corroboration instead of
+  // one mistake copied three times.
+  //
+  // What is actually true: the backend folds grace INTO the stored expiry for auto-renewing accounts
+  // (`_lookup_user_expiry` → `best_expiry`) and judges `user_status` against that same value. So
+  // `expiry_ts` is **coverage end, not paid-through**; `now >= E` is the grace *exit*, not its entry;
+  // and the real grace window is `E - grace <= now < E`. Two consequences follow, both live:
+  //   - `inGracePeriod = now >= expiryTimeMs` sits inside an Active branch, and Active requires
+  //     `now <= E` — satisfiable only at a single boundary instant, so the indicator is ~dead code: the
+  //     grace state is unreachable, so nothing surfaces a renewal that is overdue but still covered.
+  //   - `renewingAt = E` renders the renewal date late by one grace period. **Magnitude depends on the
+  //     payment provider**, and Desktop has no in-app payment — every Desktop subscriber bought through
+  //     Apple or Google, so both cases are live here:
+  //       Apple  — the backend supplies the grace itself (~1h), so the date error is cosmetic.
+  //       Google — operator-configured on the base plan, in DAYS, and the backend only learns the real
+  //                value when the user ENTERS grace. So the error is largest exactly while the grace UI
+  //                is on screen, which is the screen whose purpose is that date.
+  //     Both consequences are therefore substantive on Desktop; neither is "just cosmetic".
+  //     (Provider split per the cross-client F8 analysis, traced in the backend. The Google magnitude
+  //     is "operator-configured days" — no specific range is traced, so don't quote one.)
+  // Paid-through IS computable here (`E - gracePeriodDurationMs`, safe unconditionally because the
+  // wire zeroes grace when `!auto_renewing`); it is the *startup gate* that cannot compute it, having
+  // only config. Don't "fix" this line on its own.
+  //
+  // ── the superseded reasoning, kept for the diff it explains ──────────────────────────────────
   // Auto-renew is due AT the paid-through end (`expiryMs`). user_status stays `active` through the
   // grace window (the backend judges coverage against expiry + grace_period_duration), so being past
   // expiry while still active IS the grace period. Subtracting grace here put "renew due" a whole
   // grace period early, so inGracePeriod was perpetually true whenever grace exceeded the period.
-  let beginAutoRenew = 0;
-  if (data) {
-    beginAutoRenew = data.expiryMs;
-  }
+  //
+  // ⚠️ This instant is the boundary contested in F8, isolated here on purpose so a ruling is a
+  // one-line change per client rather than three independent re-derivations landing at different
+  // times. It implements the SPEC's version deliberately — do not pre-apply a local finding here,
+  // because a client quietly disagreeing with the other two about a user-visible date is exactly what
+  // this seam exists to prevent. Android's equivalent is `renewalDueAt()`.
+  //
+  // Android also has a `coverageEndsAt()` (= expiry + gracePeriod). Desktop has NO consumer for it —
+  // `gracePeriodDurationMs` is referenced nowhere in `ts/` — and adding one to mirror Android would be
+  // dead code, which in this repo is where typos live. If F8's ruling needs it, it gets added with its
+  // first consumer.
+  //
+  // ⚠️ And do not compute it as `expiryMs + gracePeriodDurationMs` when that day comes: the backend
+  // ALREADY folds grace into the stored expiry for auto-renewing accounts (`_lookup_user_expiry` →
+  // `best_expiry`, and `user_status` is judged against that same value), so `expiry_ts` IS coverage
+  // end and adding grace again double-counts it. The comment above about the backend judging coverage
+  // against `expiry + grace_period_duration` predates that finding and is under review — see F8.
+  const renewalDueAtMs = data ? data.expiryMs : 0;
+  // Kept under its original name because it is threaded into the display strings below.
+  const beginAutoRenew = renewalDueAtMs;
 
   let inGracePeriod = mockInGracePeriod;
   if (beginAutoRenew && !mockInGracePeriod) {
@@ -389,7 +433,7 @@ export function useProBackendRefetch() {
     setProBackendIsLoading({ key: 'details', result: false });
   };
 
-  const refetch = (args: WithCallerContext = {}) => {
+  const refetch = (args: WithCallerContext & WithImmediate = {}) => {
     if (details.isError || mockFail) {
       void mockRefetchFail();
       return;

--- a/ts/state/selectors/proBackendData.ts
+++ b/ts/state/selectors/proBackendData.ts
@@ -281,64 +281,33 @@ function processProBackendData({
     ? !mockCancelled
     : (data?.autoRenewing ?? defaultProAccessDetailsSourceData.autoRenew);
 
-  // 🔴 THE PREMISE IN THE NEXT PARAGRAPH IS WRONG, AND IS UNDER REVIEW (F8). Marked rather than
-  // rewritten because correcting the behaviour has to land on Android, Desktop and iOS together — all
-  // three wrote this same premise down independently, which is why it read as corroboration instead of
-  // one mistake copied three times.
+  // `expiry_ts` is COVERAGE END, not the date the renewal is due: the backend folds the grace period
+  // into the stored expiry for auto-renewing subscriptions (`_lookup_user_expiry` -> `best_expiry`) and
+  // judges `user_status` against that same value. So the renewal falls due at `E - grace`, and the grace
+  // window — renewal overdue, account still covered — is `E - grace <= now < E`.
   //
-  // What is actually true: the backend folds grace INTO the stored expiry for auto-renewing accounts
-  // (`_lookup_user_expiry` → `best_expiry`) and judges `user_status` against that same value. So
-  // `expiry_ts` is **coverage end, not paid-through**; `now >= E` is the grace *exit*, not its entry;
-  // and the real grace window is `E - grace <= now < E`. Two consequences follow, both live:
-  //   - `inGracePeriod = now >= expiryTimeMs` sits inside an Active branch, and Active requires
-  //     `now <= E` — satisfiable only at a single boundary instant, so the indicator is ~dead code: the
-  //     grace state is unreachable, so nothing surfaces a renewal that is overdue but still covered.
-  //   - `renewingAt = E` renders the renewal date late by one grace period. **Magnitude depends on the
-  //     payment provider**, and Desktop has no in-app payment — every Desktop subscriber bought through
-  //     Apple or Google, so both cases are live here:
-  //       Apple  — the backend supplies the grace itself (~1h), so the date error is cosmetic.
-  //       Google — operator-configured on the base plan, in DAYS, and the backend only learns the real
-  //                value when the user ENTERS grace. So the error is largest exactly while the grace UI
-  //                is on screen, which is the screen whose purpose is that date.
-  //     Both consequences are therefore substantive on Desktop; neither is "just cosmetic".
-  //     (Provider split per the cross-client F8 analysis, traced in the backend. The Google magnitude
-  //     is "operator-configured days" — no specific range is traced, so don't quote one.)
-  // Paid-through IS computable here (`E - gracePeriodDurationMs`, safe unconditionally because the
-  // wire zeroes grace when `!auto_renewing`); it is the *startup gate* that cannot compute it, having
-  // only config. Don't "fix" this line on its own.
+  // The subtraction is unconditional and needs no provider branching: the wire sends `grace = 0`
+  // whenever the subscription isn't auto-renewing, so this is `E - 0 == E` for those accounts.
   //
-  // ── the superseded reasoning, kept for the diff it explains ──────────────────────────────────
-  // Auto-renew is due AT the paid-through end (`expiryMs`). user_status stays `active` through the
-  // grace window (the backend judges coverage against expiry + grace_period_duration), so being past
-  // expiry while still active IS the grace period. Subtracting grace here put "renew due" a whole
-  // grace period early, so inGracePeriod was perpetually true whenever grace exceeded the period.
-  //
-  // ⚠️ This instant is the boundary contested in F8, isolated here on purpose so a ruling is a
-  // one-line change per client rather than three independent re-derivations landing at different
-  // times. It implements the SPEC's version deliberately — do not pre-apply a local finding here,
-  // because a client quietly disagreeing with the other two about a user-visible date is exactly what
-  // this seam exists to prevent. Android's equivalent is `renewalDueAt()`.
-  //
-  // Android also has a `coverageEndsAt()` (= expiry + gracePeriod). Desktop has NO consumer for it —
-  // `gracePeriodDurationMs` is referenced nowhere in `ts/` — and adding one to mirror Android would be
-  // dead code, which in this repo is where typos live. If F8's ruling needs it, it gets added with its
-  // first consumer.
-  //
-  // ⚠️ And do not compute it as `expiryMs + gracePeriodDurationMs` when that day comes: the backend
-  // ALREADY folds grace into the stored expiry for auto-renewing accounts (`_lookup_user_expiry` →
-  // `best_expiry`, and `user_status` is judged against that same value), so `expiry_ts` IS coverage
-  // end and adding grace again double-counts it. The comment above about the backend judging coverage
-  // against `expiry + grace_period_duration` predates that finding and is under review — see F8.
-  const renewalDueAtMs = data ? data.expiryMs : 0;
+  // Both values here are already milliseconds (the response's own units). Core stores `G` in seconds and
+  // the nodejs wrapper converts, so anything reading grace from *config* rather than from a response is
+  // on the other side of that boundary — check which you have before subtracting.
+  const renewalDueAtMs = data ? data.expiryMs - data.gracePeriodDurationMs : 0;
   // Kept under its original name because it is threaded into the display strings below.
   const beginAutoRenew = renewalDueAtMs;
 
   let inGracePeriod = mockInGracePeriod;
   if (beginAutoRenew && !mockInGracePeriod) {
-    // Only surface "renewal unsuccessful" off data we actually fetched at/after the paid-through
-    // end — never off a pre-expiry snapshot that predates a possible renewal. The pro page refetches
-    // at the crossing (and polls through grace), so a stale snapshot resolves rather than sticking.
-    inGracePeriod = autoRenew && now >= expiryTimeMs && lastFetchedMs >= expiryTimeMs;
+    // Past the renewal date but still covered. Keyed on `renewalDueAtMs`, not on `expiryTimeMs`: the
+    // latter is coverage end, and `now >= E` inside a branch that requires `now <= E` is satisfiable
+    // only at a single instant — which is why this indicator was previously unreachable and nothing
+    // surfaced an overdue renewal at all.
+    //
+    // The `lastFetchedMs` term is the debounce: only surface "renewal unsuccessful" off a fetch that
+    // COMPLETED at or after the crossing, never off a snapshot predating a renewal that may since have
+    // landed. It is per-run and stamped on completion, so a request still in flight cannot satisfy it.
+    inGracePeriod =
+      autoRenew && now >= renewalDueAtMs && now < expiryTimeMs && lastFetchedMs >= renewalDueAtMs;
   }
 
   // Refund-requested is now a synced config flag (UserProfile key R), not a backend response field.

--- a/ts/state/startup.ts
+++ b/ts/state/startup.ts
@@ -26,7 +26,10 @@ import type { UserGroupState } from './ducks/userGroups';
 import { initialThemeState } from './theme/ducks/theme';
 import { initialNetworkModalState } from './ducks/networkModal';
 import { initialNetworkDataState, networkDataActions } from './ducks/networkData';
-import { initialProBackendDataState, proBackendDataActions } from './ducks/proBackendData';
+import {
+  initialProBackendDataState,
+  refreshProStatusOnStartupIfNeeded,
+} from './ducks/proBackendData';
 import { MessageQueue } from '../session/sending';
 import { AvatarMigrate } from '../session/utils/job_runners/jobs/AvatarMigrateJob';
 import { handleTriggeredCTAs } from '../components/dialog/SessionCTA';
@@ -170,7 +173,9 @@ export const doAppStartUp = async () => {
     window.log.debug('appStartup: got our fresh swarm, starting polling');
     // trigger any other actions that need to be done after the swarm is ready
     window.inboxStore?.dispatch(networkDataActions.fetchInfoFromSeshServer() as any);
-    window.inboxStore?.dispatch(proBackendDataActions.refreshGetProStatusFromProBackend({}) as any);
+    // Trigger #1, gated: a cold start only fetches get_pro_status when a home CTA could plausibly
+    // fire, and at most once/24h. Also arms the #6 wake at the account horizon for this session.
+    void refreshProStatusOnStartupIfNeeded();
     if (window.inboxStore) {
       const delayedTimeout = getDataFeatureFlag('useLocalDevNet') && isTestIntegration() ? 2000 : 0;
       /**

--- a/ts/test/session/unit/libsession_wrapper/libsession_wrapper_user_profile_test.ts
+++ b/ts/test/session/unit/libsession_wrapper/libsession_wrapper_user_profile_test.ts
@@ -79,6 +79,8 @@ describe('libsession_user_profile', () => {
           // sub-second value would come back floored. Use a second-aligned one to round-trip as-is.
           expiryMs: Math.floor(Date.now() / 1000) * 1000 + 1000,
           revocationTagB64: to_base64(ed25519Seed, base64_variants.ORIGINAL),
+          // Deliberately not 0, to show the read-back below is the format's own value rather than
+          // whatever the setter was handed.
           version: 132,
           signatureHex: to_hex(randombytes_buf(64)),
         },
@@ -98,7 +100,10 @@ describe('libsession_user_profile', () => {
           rotatingPubkeyHex: rotatingPubKeyHex,
           expiryMs: proConfig.proProof.expiryMs,
           revocationTagB64: proConfig.proProof.revocationTagB64,
-          version: proConfig.proProof.version,
+          // The stored credential is one opaque bt-encoded value carrying only `e`, `g`, `r` and `s`,
+          // so no version is written and load forces v0 (= 0). A version can't describe itself across
+          // a per-key merge, so a future format takes a new config key instead of an in-dict marker.
+          version: 0,
           signatureHex: proConfig.proProof.signatureHex,
         },
       };

--- a/ts/types/attachments/VisualAttachment.ts
+++ b/ts/types/attachments/VisualAttachment.ts
@@ -10,10 +10,7 @@ import { GoogleChrome } from '../../util';
 import { isAudio } from '../MIME';
 import { formatTimeDurationMs } from '../../util/i18n/formatting/generics';
 import { isTestIntegration } from '../../shared/env_vars';
-import {
-  getDataFeatureFlag,
-  getFeatureFlag,
-} from '../../state/ducks/types/releasedFeaturesReduxTypes';
+import { getDataFeatureFlag } from '../../state/ducks/types/releasedFeaturesReduxTypes';
 import { processAvatarData } from '../../util/avatar/processAvatarData';
 import type { ProcessedAvatarDataType } from '../../webworker/workers/node/image_processor/image_processor';
 import { ImageProcessor } from '../../webworker/workers/browser/image_processor_interface';
@@ -191,10 +188,7 @@ export const revokeObjectUrl = (objectUrl: string) => {
 };
 
 async function pickFileForReal() {
-  const acceptedImages = ['.png', '.gif', '.jpeg', '.jpg'];
-  if (getFeatureFlag('proAvailable')) {
-    acceptedImages.push('.webp');
-  }
+  const acceptedImages = ['.png', '.gif', '.jpeg', '.jpg', '.webp'];
 
   const [fileHandle] = await (window as any).showOpenFilePicker({
     types: [

--- a/ts/webworker/workers/browser/libsession/libsession_worker_userconfig_interface.ts
+++ b/ts/webworker/workers/browser/libsession/libsession_worker_userconfig_interface.ts
@@ -19,6 +19,7 @@ type CachedUserConfig = {
   refundRequested: AwaitedReturn<UserConfigWrapperActionsCalls['getRefundRequested']>;
   proPrepaid: AwaitedReturn<UserConfigWrapperActionsCalls['getProPrepaid']>;
   proAutoRenewing: AwaitedReturn<UserConfigWrapperActionsCalls['getProAutoRenewing']>;
+  proGracePeriod: AwaitedReturn<UserConfigWrapperActionsCalls['getProGracePeriod']>;
 };
 
 let cachedUserConfig: CachedUserConfig | null = null;
@@ -42,6 +43,7 @@ async function fullRefreshCachedUserConfig() {
   const refundRequested = await UserConfigWrapperActions.getRefundRequested();
   const proPrepaid = await UserConfigWrapperActions.getProPrepaid();
   const proAutoRenewing = await UserConfigWrapperActions.getProAutoRenewing();
+  const proGracePeriod = await UserConfigWrapperActions.getProGracePeriod();
 
   if (!cachedUserConfig) {
     cachedUserConfig = {
@@ -53,6 +55,7 @@ async function fullRefreshCachedUserConfig() {
       refundRequested,
       proPrepaid,
       proAutoRenewing,
+      proGracePeriod,
       profilePic,
       profileUpdatedSeconds,
       priority,
@@ -72,6 +75,7 @@ async function fullRefreshCachedUserConfig() {
   applyUserConfigIfChanged('refundRequested', refundRequested);
   applyUserConfigIfChanged('proPrepaid', proPrepaid);
   applyUserConfigIfChanged('proAutoRenewing', proAutoRenewing);
+  applyUserConfigIfChanged('proGracePeriod', proGracePeriod);
 }
 
 function applyUserConfigIfChanged<T extends keyof CachedUserConfig>(
@@ -206,6 +210,17 @@ export const UserConfigWrapperActions: UserConfigWrapperActionsCalls = {
     ...args: Parameters<UserConfigWrapperActionsCalls['setProAutoRenewing']>
   ) => {
     return callLibsessionWithUserConfigRefresh(['UserConfig', 'setProAutoRenewing', ...args]);
+  },
+  getProGracePeriod: async (
+    ...args: Parameters<UserConfigWrapperActionsCalls['getProGracePeriod']>
+  ) =>
+    callLibSessionWorker(['UserConfig', 'getProGracePeriod', ...args]) as Promise<
+      ReturnType<UserConfigWrapperActionsCalls['getProGracePeriod']>
+    >,
+  setProGracePeriod: async (
+    ...args: Parameters<UserConfigWrapperActionsCalls['setProGracePeriod']>
+  ) => {
+    return callLibsessionWithUserConfigRefresh(['UserConfig', 'setProGracePeriod', ...args]);
   },
 
   generateProMasterKey: async (

--- a/ts/webworker/workers/browser/libsession/libsession_worker_userconfig_interface.ts
+++ b/ts/webworker/workers/browser/libsession/libsession_worker_userconfig_interface.ts
@@ -18,6 +18,7 @@ type CachedUserConfig = {
   proAccessExpiry: AwaitedReturn<UserConfigWrapperActionsCalls['getProAccessExpiry']>;
   refundRequested: AwaitedReturn<UserConfigWrapperActionsCalls['getRefundRequested']>;
   proPrepaid: AwaitedReturn<UserConfigWrapperActionsCalls['getProPrepaid']>;
+  proAutoRenewing: AwaitedReturn<UserConfigWrapperActionsCalls['getProAutoRenewing']>;
 };
 
 let cachedUserConfig: CachedUserConfig | null = null;
@@ -40,6 +41,7 @@ async function fullRefreshCachedUserConfig() {
   const proAccessExpiry = await UserConfigWrapperActions.getProAccessExpiry();
   const refundRequested = await UserConfigWrapperActions.getRefundRequested();
   const proPrepaid = await UserConfigWrapperActions.getProPrepaid();
+  const proAutoRenewing = await UserConfigWrapperActions.getProAutoRenewing();
 
   if (!cachedUserConfig) {
     cachedUserConfig = {
@@ -50,6 +52,7 @@ async function fullRefreshCachedUserConfig() {
       proProfileBitset,
       refundRequested,
       proPrepaid,
+      proAutoRenewing,
       profilePic,
       profileUpdatedSeconds,
       priority,
@@ -68,6 +71,7 @@ async function fullRefreshCachedUserConfig() {
   applyUserConfigIfChanged('proAccessExpiry', proAccessExpiry);
   applyUserConfigIfChanged('refundRequested', refundRequested);
   applyUserConfigIfChanged('proPrepaid', proPrepaid);
+  applyUserConfigIfChanged('proAutoRenewing', proAutoRenewing);
 }
 
 function applyUserConfigIfChanged<T extends keyof CachedUserConfig>(
@@ -191,6 +195,17 @@ export const UserConfigWrapperActions: UserConfigWrapperActionsCalls = {
     ...args: Parameters<UserConfigWrapperActionsCalls['setProAccessExpiry']>
   ) => {
     return callLibsessionWithUserConfigRefresh(['UserConfig', 'setProAccessExpiry', ...args]);
+  },
+  getProAutoRenewing: async (
+    ...args: Parameters<UserConfigWrapperActionsCalls['getProAutoRenewing']>
+  ) =>
+    callLibSessionWorker(['UserConfig', 'getProAutoRenewing', ...args]) as Promise<
+      ReturnType<UserConfigWrapperActionsCalls['getProAutoRenewing']>
+    >,
+  setProAutoRenewing: async (
+    ...args: Parameters<UserConfigWrapperActionsCalls['setProAutoRenewing']>
+  ) => {
+    return callLibsessionWithUserConfigRefresh(['UserConfig', 'setProAutoRenewing', ...args]);
   },
 
   generateProMasterKey: async (

--- a/ts/webworker/workers/browser/libsession_worker_interface.ts
+++ b/ts/webworker/workers/browser/libsession_worker_interface.ts
@@ -470,6 +470,10 @@ export const MetaGroupWrapperActions: MetaGroupWrapperActionsCalls = {
     callLibSessionWorker([`MetaGroupConfig-${groupPk}`, 'push']) as Promise<
       ReturnType<MetaGroupWrapperActionsCalls['push']>
     >,
+  pushForRecovery: async (groupPk: GroupPubkeyType) =>
+    callLibSessionWorker([`MetaGroupConfig-${groupPk}`, 'pushForRecovery']) as Promise<
+      ReturnType<MetaGroupWrapperActionsCalls['pushForRecovery']>
+    >,
   needsDump: async (groupPk: GroupPubkeyType) =>
     callLibSessionWorker([`MetaGroupConfig-${groupPk}`, 'needsDump']) as Promise<
       ReturnType<MetaGroupWrapperActionsCalls['needsDump']>
@@ -641,6 +645,10 @@ export const MetaGroupWrapperActions: MetaGroupWrapperActionsCalls = {
   activeHashes: async (groupPk: GroupPubkeyType) =>
     callLibSessionWorker([`MetaGroupConfig-${groupPk}`, 'activeHashes']) as Promise<
       ReturnType<MetaGroupWrapperActionsCalls['activeHashes']>
+    >,
+  activeHashesByConfig: async (groupPk: GroupPubkeyType) =>
+    callLibSessionWorker([`MetaGroupConfig-${groupPk}`, 'activeHashesByConfig']) as Promise<
+      ReturnType<MetaGroupWrapperActionsCalls['activeHashesByConfig']>
     >,
   loadKeyMessage: async (
     groupPk: GroupPubkeyType,


### PR DESCRIPTION
# Pro: unify the `get_pro_status` refresh discipline (Desktop)

Desktop's half of the cross-client Pro status-refresh unification. Android and iOS carry the matching
changes; the shared constants are named identically in all three so nobody tunes one platform alone.

**Split of concerns this enforces:** entitlement is the *proof* (Loop 1, libsession-timed, unchanged
here). `get_pro_status` is *display + account-expiry awareness* only (Loop 2). Status never drives
proof timing; the proof loop never depends on a status fetch.

## Merge dependencies — one left

| # | Dependency | State |
|---|---|---|
| 1 | `JasonFork/pro-status-sync` — `e5c14a852` | **merged** into `dev` ([#1975](https://github.com/session-foundation/session-desktop/pull/1975)) |
| 2 | `JasonFork/remove-pro-gating` — `bcc9c3373`, removes pre-launch Pro gating | **unmerged** — the only outstanding one |
| 3 | libsession-util [#124](https://github.com/session-foundation/libsession-util/pull/124) — config keys `A` and `G`, the proof-response fields, the clear cascade | **merged** |
| 4 | libsession-util-nodejs [#68](https://github.com/session-foundation/libsession-util-nodejs/pull/68) — the bindings | **merged** |
| 5 | A nodejs release carrying them, and this repo's pin moved to it | **done** — v0.7.0, pinned here |

**(2) is the one that matters for merging.** It is a single commit off `dev` (`8eee47876`) by another
author, replayed into this branch by the rebase, and it is the only commit in this PR's diff not authored
here. Everything below libsession is in place: `#124` is on `dev`, the bindings are released as v0.7.0, and
this branch pins it.

**Typecheck: 0 errors.** This branch pins `libsession_util_nodejs` **v0.7.0**, which carries the config
accessors and proof-response fields it calls. Measured with the real dependency resolved:

| | errors |
|---|---|
| this branch on v0.7.0 | **0** |
| `dev`, typechecked against v0.7.0's types | **2** |

The branch is **two errors better than its base**, and both differences are wiring that v0.7.0's types
require: the userconfig worker interface doesn't declare the four Pro accessors, and `MetaGroupWrapperActions`
is missing `pushForRecovery` / `activeHashesByConfig`. This branch adds all six as plain forwards. Nothing
calls the two MetaGroup ones, and the worker dispatches by string onto the wrapper, so they need no further
plumbing.

⚠️ **Do not read a red CI history on earlier revisions as this branch's doing.** `dev` has never typechecked
at its own declared pin: v0.6.19 is missing `getProPrepaid`, `getProRenewalTarget`, `deriveProRotatingKey`,
`getRefundRequested` and `MESSAGE_CHARACTER_LIMIT_PRO`, all referenced by existing `dev` code. Those failures
were the pin, and they are what the 42-error baseline in earlier revisions of this description was counting.
v0.7.0 is the first pin under which either side compiles.

**Tests: 920 passing, none failing** — and worth stating plainly, because the history looks otherwise. The
suite could not run before this branch: mocha runs compiled JS from `app/`, `build-ts-prod` is
`tsc && build-compile`, and `tsc` was 42 on `dev` at its own pin. Taking it to 0 made the first run possible,
which surfaced one **pre-existing** failure — a pro-config round-trip test asserting that a proof `version`
survives storage, which the format refuses by design (the credential is a single opaque value carrying only
`e`, `g`, `r`, `s`; load forces v0). That test has been wrong since 2026-07-28 and nothing could see it. It is
corrected here to assert what the format guarantees. **This branch did not break it; it made it runnable.**

⚠️ **A green suite is not coverage of this work.** There is no seam to test the refresh discipline through:
the `mock*` feature flags intercept the selector, not the fetch path, so the floor, the startup gate, the
wakes and the `immediate` rule have no test exercising them. An injection point is buildable — the fetch
funnels through a single `ProBackendAPI.getProStatus` call site — and is not built here.

## The unified trigger set, as implemented

| # | Trigger | Desktop |
|---|---|---|
| 1 | App startup | **gated** (was unconditional) |
| 2 | Config sync `E`/`I` changed | watches `I` too now (was `E` only); floored; + proof reconcile |
| 3 | Enter Pro settings | floored (its own broken per-run throttle removed) |
| 4 | While Pro settings open | unchanged; now explicitly floor-exempt |
| 5 | Manual refresh / recover | `immediate` |
| 6 | Wake past the horizon | **added** — two instants, `E+30s` and `(E+G)+30s`, collapsing to one when grace is zero |
| 7 | Post-purchase poll | **N/A** — Desktop has no in-app payment |

## Changes

**Status-refresh floor — new on Desktop.** `refreshGetProStatusFromProBackend` previously had only an
`isFetching` single-flight guard, so there was no minimum interval at all. Adds a 60s floor,
**drop-on-fresh rather than re-arming** (a re-arming floor becomes a self-sustaining once/60s poll
during grace, when `E` is static). The timestamp is persisted in `Storage`, not redux — a per-run value
resets on every launch, which is the exact path the floor has to cover.

Two exemptions, both load-bearing:
- `immediate` — bypasses the floor and nothing else (not single-flight, not the loading state). Named
  `immediate` rather than `force` because `force` invited every routine trigger to pass it, which is
  how Android's floor became dead code. Reserved to manual/recover, the bounded on-enter/while-open grace poll, and dev paths.
- **A process with no confirmed status of its own is never floored.** Replaces the "on cold start the
  load state is `Init`" exemption, which stops being true once the timestamp is persisted. Without it,
  relaunching within 60s of a previous fetch drops the fetch and nothing ever resolves the initial
  loading state — a permanent spinner on the Pro screen and no CTA, since both gate on a confirmed
  fetch.

**Startup gate.** Cold start now fetches only when a home CTA could plausibly fire, computed from synced
config, capped at once/24h. Non-Pro users (no `E`) never fetch. Uses network time so clock skew can't flip
a near-boundary decision.

**`expiry_ts` is the true paid-through expiry, and coverage runs to `E + G`.** The backend reports the
account's own expiry but judges `user_status` against the later instant it stops serving, so
`[E, E + G)` is expired-but-still-served. Two consequences:

- **the displayed date is `E`, with no arithmetic** — it is what the user paid for, and the honest thing to
  show;
- **coverage questions gain `+ G`**: the grace indicator's upper bound, and the second scheduled wake.

The gate is the interesting case: it reads `E` and deliberately **not** `G`. Coverage ends at `E + G`, but
grace and post-coverage both resolve to "fetch" — one to surface "renewal unsuccessful", the other to
surface Expired — so `E` is the only instant that changes the answer, and testing the later boundary would
delay the first fetch without changing an outcome.

No provider branching, and none should be added: the root `grace_period_duration` is 0 whenever the
subscription isn't auto-renewing, so this is `E + 0 == E` for those accounts. Stores differ in whether they
state grace separately or fold it into their own expiry, and a client treats what it receives as correct — a
store that folds it in simply sends a later `E` and a window that never opens.

**The grace value is the account-level one at the response root, not `latestPayment`'s field of the same
name.** The payment-level field is one store's raw declaration and is *not* gated on auto-renewal: a
subscriber who cancels mid-retry keeps a nonzero value in it, so reading it would place coverage weeks past
the truth.

Units: the response's `gracePeriodDurationMs` is already milliseconds; core stores `G` in seconds and the
nodejs wrapper converts, so config-sourced and response-sourced grace are on opposite sides of that
boundary. Both additions here are ms-on-ms.

**Config-change trigger watches `E` + `I`.** A prepaid marker synced from another device's purchase
previously produced no refresh. Does **not** watch `A`: an `auto_renewing` change re-derives the display
from the value just received, so fetching to confirm it would be a pointless round trip.

**The `E`-changed proof nudge is now explicit.** It previously arrived as a side effect — the
config-change handler dispatched a status refresh, and every *completed* fetch ends by calling
`reconcileProProof()`. A floored fetch never reaches that callback, so introducing the floor would have
silently dropped the nudge on precisely the path that needs it (several config pushes at once). Now
called directly from the config-change handler, gated on the `E` comparison. This edge is load-bearing:
with a lapsed account and an expired proof, `pro_renewal_target` returns nothing and the proof loop
sits dormant with no wake, and an advancing `E` is the only thing that can restart it.

**`auto_renewing` written to and read from synced config, from every path that writes `E`.** Written
unconditionally — libsession de-dupes a no-change write, and a *presence*-based guard would be actively
wrong since `A` is presence-only (writing `false` erases the key). Two writers: the `get_pro_status` fetch,
and the proof-success path from the response's `account_auto_renewing`. The second is what makes "`A`
absent means not auto-renewing" sound, and therefore what the gate's `!auto_renewing` rows rest on — see
the merge-blocker note below, because one link of that chain is not in place yet. Read through a single
accessor, the only place in the client that touches `A`.

**Home Pro CTAs now require a status confirmed by this process.** `handleTriggeredCTAs` gated the
Expiring/Expired CTAs on `fromAppStart`, which worked only because startup always fetched — every
non-startup caller was therefore guaranteed a fetch had happened or was in flight. Gating the startup
fetch removed that guarantee and left two callers (opening a conversation, closing the settings modal)
able to display a CTA from a flag a previous run persisted, with nothing confirming it this session —
the false-expired case the guard exists for. Now gated on a real predicate
(`details.lastFetchedMs`, per-run and stamped on completion), computed inside the function so a new
call site cannot inherit an answer by copying a neighbour. `fromAppStart` is retained where it
*enables* the donate CTA: that is a different question and the two must not be collapsed.

**The status fetch's single-flight now releases on failure.** `isFetching` was set by a dispatched action
but cleared only by the result object landing via `fulfilled`, and the thunk's internal try/catch covers
the network getter only — its `contextHandler`/`callback` run outside it. So a throw in post-processing
rejected the thunk with `isFetching` left true for the rest of the process, silently early-returning
every later status trigger and thereby disabling the floor, the startup gate and the `E+30s` wake at
once. `isLoading` stuck the same way, which on a first-ever fetch is a permanent spinner on the Pro
screen. The `rejected` case now resets both, without touching `data` or `lastFetchedMs` — a failed fetch
must neither discard the last known-good status nor look like a confirmation.

**This is a latent defect whose surface this branch widens by one call, not a regression it introduces.**
Three awaited calls (`setProAccessExpiry`, `handleClearProProof`, `handleExpiryCTAs`) were already in that
callback, so the reject path was reachable before; this branch adds a fourth of the same kind
(`writeProAutoRenewingToConfig`). Fixed here because a stuck single-flight *nullifies* the refresh
discipline this PR exists to add, rather than merely coexisting with it.

**Constants named** as a cross-client contract (`STATUS_FLOOR_MS`, `STATUS_STARTUP_MIN_INTERVAL_MS`,
`USER_EXPIRY_WAKE_DELAY_MS`, `PRO_EXPIRING_CTA_WINDOW_MS`, `PRO_EXPIRED_CTA_WINDOW_MS`,
`GRACE_POLL_INTERVAL_MS`, `GRACE_POLL_CROSSING_SLACK_MS`), replacing inline literals.
`GRACE_POLL_INTERVAL_MS === STATUS_FLOOR_MS` is called out in a comment: that equality is *why* the
on-enter/while-open grace poll must bypass the floor rather than be silently halved by it.

**The Expired-CTA window is anchored at coverage end**, not at `E`. The backend reports Expired only once
coverage has ended at `E + G`, so measuring the 30 days from `E` gave a window of `[E + G, E + 30d)` — `30d
- G` long, and empty once `G` reaches 30 days, which a configured store grace period can. The accounts it
shortened were auto-renewing ones in dunning: the ones most likely to recover. Grace comes from the same
response as the expiry, because this runs on every branch of the status switch and only the Active branch
writes `G` to config.

**The cold-start gate is bounded above** at that same instant, `E + G + 30d`. Previously bounded only below,
so an account that lapsed years ago passed the gate on every launch — one fetch per 24h, forever, to decide
whether to raise a CTA whose window had closed. ⚠️ The two deadlines are now equal by construction; moving
one requires moving the other.

**A lapsed subscription clears the expiry rather than refreshing it.** `subscription_expired` re-set `E` from
the failure response while `not_subscribed` and `revoked` both cleared it; all three mean the account is not
entitled. Re-setting was also a live defect: a lapse typically leaves `E` unchanged while grace and the
renewing flag change, so config held a fresh expiry beside a grace the backend had stopped honouring — the Pro
screen showed *"renewal unsuccessful, retrying soon"* for an account already reported Expired, and both the
coverage-end wake and the gate's upper bound were stretched by the stale grace. Clearing `E` erases `A` and
`G` with it, so the end state is absent keys rather than stored zeroes.

**Two edges make that safe, and both are load-bearing.** Clearing `E` removes every horizon the cold-start
gate reasons from, and the Expired CTA is *latched* — written by a status fetch, displayed later, and only
once a fetch has confirmed the status in the current process. So:

- the gate treats a **pending Expired CTA as a reason to fetch** when there is no expiry, or the flag would
  sit set and unshowable forever. The 24h interval cap sits above that row, since it is keyed on stored state
  rather than on a horizon and would otherwise fetch on every launch;
- the clear **nudges a status refresh**, because the config watch that would do it runs on incoming merges and
  a local write reaches no observer. Without it, a proof outcome that is the first to see the lapse raises no
  CTA at all. It goes through the floored path, so a fetch that just ran drops it — correct, since that fetch
  already had the chance to raise it.

**Unchanged deliberately:** the proof acquisition floor (covered 60s / dark 15s→15min) and
`useKeepProStatusFresh`. Desktop is the reference implementation for both. Note the proof loop
*re-arms* where the status floor *drops* — opposite by design, because a throttled proof acquisition
must still eventually happen. They should not be unified.

## Do not merge without reading this — the advisory optionals must not be collapsed

`A` (auto-renewing) and `G` (grace) are written to config from **both** paths that write `E`: the
`get_pro_status` fetch, and the proof-success path from the response's `account_auto_renewing` /
`account_grace_period_duration`. The second is what makes "`A` absent means not auto-renewing" sound —
without it, an account whose expiry arrived only from a proof reads back as terminal while it is renewing —
and what stops `E + G` pairing a fresh expiry with a grace from a different billing period.

**🔴 The two new fields are required on a successful parse, and what protects them is scope rather than a
null check.** Core leaves both at their struct defaults on a *failure* outcome, where `false` and `0` are
indistinguishable from a backend that really said "not renewing, no grace" — and both config keys are stored
presence-only, so writing either would **erase** what a `get_pro_status` fetch had learned. The writes
therefore sit inside the success branch, which is the only place the fields are guaranteed and the only
place they mean anything. The access expiry keeps its own guard: that one is still optional in core, absent
on `not_subscribed` and `revoked`.

A reviewer should treat any read of these two fields outside a success branch as a defect.

**Chain state:** the backend sends both fields; libsession core parses them (merged, on `dev`); the nodejs
wrapper exposes them (dependency 4, second commit); this branch reads them. Nothing here is reachable until
the pin moves — see the typecheck note above, where four of the errors are exactly these two fields.

## Open decisions

**None.** Every question this branch was built around has been ruled: where the grace period sits relative
to the reported expiry (`[E, E + G)`, implemented above), whether an unwritten `auto_renewing` should bootstrap a fetch (resolved at the
source — the proof response now carries the flag), and the grace-warning copy (one message covers the whole
window; the shipped strings already say *"retrying soon"* and *"will remain active"*, so no copy work was
needed).

The debounce mechanism behind that warning is unchanged and is described under Changes: it requires a fetch
that *completed* at or after the expiry, so it cannot fire off a snapshot predating a renewal that may since
have landed.
