### PR TITLE
fix: prevent duplicate attachment sends

### DIFF
--- a/ts/components/conversation/composition/CompositionBox.tsx
+++ b/ts/components/conversation/composition/CompositionBox.tsx
@@ -67,6 +67,7 @@ import { updateOutgoingLightBoxOptions } from '../../../state/ducks/modalDialog'
 import { isEnterKey, isEscapeKey } from '../../../util/keyboardShortcuts';
 import type { CommunityInvitation } from '../../../session/messages/outgoing/visibleMessage/VisibleMessage';
 import { SessionGifPanel } from './gif/SessionGifPanel';
+import { createMessageSendGuard } from './messageSendGuard';
 
 export interface ReplyingToMessageProps {
   convoId: string;
@@ -243,6 +244,7 @@ class CompositionBoxInner extends Component<Props, State> {
   private readonly emojiPanel: RefObject<HTMLDivElement | null>;
   private readonly emojiPanelButton: any;
   private readonly showGifsButtonRef: RefObject<HTMLButtonElement | null>;
+  private readonly messageSendGuard = createMessageSendGuard();
   private linkPreviewAbortController?: AbortController;
 
   constructor(props: Props) {
@@ -640,7 +642,16 @@ class CompositionBoxInner extends Component<Props, State> {
     return text.length > 0;
   }
 
-  private async onSendMessage() {
+  private onSendMessage() {
+    const { selectedConversationKey } = this.props;
+    if (!selectedConversationKey) {
+      return this.sendCurrentMessage();
+    }
+
+    return this.messageSendGuard(selectedConversationKey, () => this.sendCurrentMessage());
+  }
+
+  private async sendCurrentMessage() {
     const {
       selectedConversationKey,
       selectedConversation,

--- a/ts/components/conversation/composition/messageSendGuard.ts
+++ b/ts/components/conversation/composition/messageSendGuard.ts
@@ -1,0 +1,16 @@
+export function createMessageSendGuard() {
+  const conversationsSending = new Set<string>();
+
+  return async (conversationKey: string, sendMessage: () => Promise<void>) => {
+    if (conversationsSending.has(conversationKey)) {
+      return;
+    }
+
+    conversationsSending.add(conversationKey);
+    try {
+      await sendMessage();
+    } finally {
+      conversationsSending.delete(conversationKey);
+    }
+  };
+}

--- a/ts/test/session/unit/components/conversation/messageSendGuard_test.ts
+++ b/ts/test/session/unit/components/conversation/messageSendGuard_test.ts
@@ -1,0 +1,80 @@
+import chai from 'chai';
+
+import { createMessageSendGuard } from '../../../../../components/conversation/composition/messageSendGuard';
+
+const { expect } = chai;
+
+describe('createMessageSendGuard', () => {
+  it('ignores another send to the same conversation while one is in progress', async () => {
+    const sendMessage = createMessageSendGuard();
+    let resolveFirstSend!: () => void;
+    let sendCount = 0;
+
+    const firstSend = sendMessage(
+      'conversation-a',
+      () =>
+        new Promise<void>(resolve => {
+          sendCount += 1;
+          resolveFirstSend = resolve;
+        })
+    );
+    await sendMessage('conversation-a', async () => {
+      sendCount += 1;
+    });
+
+    expect(sendCount).to.equal(1);
+
+    resolveFirstSend();
+    await firstSend;
+    await sendMessage('conversation-a', async () => {
+      sendCount += 1;
+    });
+
+    expect(sendCount).to.equal(2);
+  });
+
+  it('allows sends to different conversations at the same time', async () => {
+    const sendMessage = createMessageSendGuard();
+    let resolveFirstSend!: () => void;
+    let secondSendCompleted = false;
+
+    const firstSend = sendMessage(
+      'conversation-a',
+      () =>
+        new Promise<void>(resolve => {
+          resolveFirstSend = resolve;
+        })
+    );
+    await sendMessage('conversation-b', async () => {
+      secondSendCompleted = true;
+    });
+
+    expect(secondSendCompleted).to.equal(true);
+
+    resolveFirstSend();
+    await firstSend;
+  });
+
+  it('allows another send after a failure', async () => {
+    const sendMessage = createMessageSendGuard();
+    const failure = new Error('send failed');
+    let caught: unknown;
+
+    try {
+      await sendMessage('conversation-a', async () => {
+        throw failure;
+      });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).to.equal(failure);
+
+    let didRetry = false;
+    await sendMessage('conversation-a', async () => {
+      didRetry = true;
+    });
+
+    expect(didRetry).to.equal(true);
+  });
+});


### PR DESCRIPTION
### Contributor checklist:

- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`dev`](https://github.com/session-foundation/session-desktop/tree/dev) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/session-foundation/session-desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Fixes #336

This picks up the approach proposed in oxen-io/session-desktop#3100, which was never merged, and adds focused regression coverage

Repeated Enter presses or send button clicks are now ignored while the current send is still processing attachments

The guard always releases after success or failure, so retrying still works

Tests:
- added coverage for concurrent sends and guard release after success or failure
- `pnpm ready`