### PR TITLE
Pro: show hero copy in every Pro status, not just never-subscribed and fromCTA

### DIFF
--- a/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
@@ -1095,15 +1095,17 @@ function PageHero({ state }: SectionProps) {
     }
   };
 
+  const heroTextToken = isPro
+    ? 'proThanksForSupporting'
+    : proExpired
+      ? 'proAccessRenewStart'
+      : 'proFullestPotential';
+
   return (
     <ProHeroImage
       onClick={handleClick}
       heroStatusText={<HeroStatusText isError={isError} isLoading={isLoading} isPro={isPro} />}
-      heroText={
-        isPro || (proExpired && !state.fromCTA) ? null : (
-          <Localizer token={proExpired ? 'proAccessRenewStart' : 'proFullestPotential'} />
-        )
-      }
+      heroText={<Localizer token={heroTextToken} />}
       isError={isError}
       noColors={proExpired && !state.fromCTA}
     />


### PR DESCRIPTION
The Pro settings hero rendered heroText only for never-subscribed users, and for expired users arriving from a CTA. Expired users reaching the page any other way, and active subscribers, saw the image with nothing under it.

Pick the token from the status alone; active gets the new proThanksForSupporting. noColors keeps its own (proExpired && !fromCTA) test, so the greyed-out expired hero is unchanged.

Bumps ts/localization to e2f30c5, which is where the three strings landed from Crowdin — without it proThanksForSupporting is not in the token union and this does not typecheck.