### PR TITLE
test(pro): make the Desktop client testable for Session Pro

### DIFF
--- a/ts/components/buttons/panel/PanelButton.tsx
+++ b/ts/components/buttons/panel/PanelButton.tsx
@@ -44,15 +44,17 @@ export function PanelLabelWithDescription({
   title,
   extraInlineNode,
   description,
+  dataTestId,
 }: {
   title: TrArgs;
   extraInlineNode?: ReactNode;
   description?: TrArgs;
+  dataTestId?: SessionDataTestId;
 }) {
   return (
     <StyledPanelLabelWithDescription>
       {/* less space between the label and the description */}
-      <StyledPanelLabel>
+      <StyledPanelLabel data-testid={dataTestId}>
         <Localizer {...title} />
         {extraInlineNode}
       </StyledPanelLabel>

--- a/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
@@ -186,7 +186,9 @@ export function ProHeroImage({
         </HeroImageBgContainer>
       </SectionFlexContainer>
       {heroStatusText ? (
-        <StyledProStatusText $isError={isError}>{heroStatusText}</StyledProStatusText>
+        <StyledProStatusText $isError={isError} data-testid="pro-settings-status-banner">
+          {heroStatusText}
+        </StyledProStatusText>
       ) : null}
       {heroStatusText && heroText ? <SpacerMD /> : null}
       {heroText ? <StyledProHeroText>{heroText}</StyledProHeroText> : null}
@@ -385,6 +387,7 @@ function ProStats() {
     <SectionFlexContainer>
       <PanelLabelWithDescription
         title={{ token: 'proStats' }}
+        dataTestId="pro-settings-stats-header"
         extraInlineNode={
           <SessionTooltip
             content={tr('proStatsTooltip')}
@@ -771,7 +774,10 @@ function ProFeatures({ state }: SectionProps) {
 
   return (
     <SectionFlexContainer>
-      <PanelLabelWithDescription title={{ token: 'proBetaFeatures' }} />
+      <PanelLabelWithDescription
+        title={{ token: 'proBetaFeatures' }}
+        dataTestId="pro-settings-features-header"
+      />
       <PanelButtonGroup containerStyle={{ marginBlock: 'var(--margins-xs)' }}>
         {proFeatures.map((m, i) => {
           return (
@@ -831,7 +837,10 @@ function ManageProCurrentAccess({ state }: SectionProps) {
 
   return (
     <SectionFlexContainer>
-      <PanelLabelWithDescription title={{ token: 'managePro' }} />
+      <PanelLabelWithDescription
+        title={{ token: 'managePro' }}
+        dataTestId="pro-settings-manage-header"
+      />
       <PanelButtonGroup>
         {data.autoRenew ? (
           <PanelIconButton
@@ -908,7 +917,10 @@ function ManageProAccess({ state }: SectionProps) {
 
   return (
     <SectionFlexContainer>
-      <PanelLabelWithDescription title={{ token: 'managePro' }} />
+      <PanelLabelWithDescription
+        title={{ token: 'managePro' }}
+        dataTestId="pro-settings-manage-header"
+      />
       <PanelButtonGroup
         style={
           !isDarkTheme

--- a/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
@@ -1,5 +1,12 @@
 import { isNumber } from 'lodash';
-import { MouseEventHandler, SessionDataTestId, useCallback, useMemo, type ReactNode } from 'react';
+import {
+  MouseEventHandler,
+  SessionDataTestId,
+  useCallback,
+  useEffect,
+  useMemo,
+  type ReactNode,
+} from 'react';
 import useUpdate from 'react-use/lib/useUpdate';
 import styled from 'styled-components';
 import { getAppDispatch } from '../../../../../state/dispatch';
@@ -61,6 +68,9 @@ import {
   useProBackendRefetch,
 } from '../../../../../state/selectors/proBackendData';
 import { formatNumber } from '../../../../../util/i18n/formatting/generics';
+import { NetworkTime } from '../../../../../util/NetworkTime';
+import { DURATION } from '../../../../../session/constants';
+import { proBackendDataActions } from '../../../../../state/ducks/proBackendData';
 
 type ProSettingsModalState = {
   fromCTA?: boolean;
@@ -220,6 +230,46 @@ const useCurrentUserHasExpiredProInternal = useCurrentUserHasExpiredPro;
 const useCurrentNeverHadProInternal = useCurrentNeverHadPro;
 const useIsDarkThemeInternal = useIsDarkTheme;
 const usePinnedConversationsCountInternal = usePinnedConversationsCount;
+
+// Extracted into its own hook so the react compiler compiles a small, clean function rather than
+// choking on a raw useEffect inside the large ProSettings component.
+function useKeepProStatusFresh({
+  expiryTimeMs,
+  autoRenew,
+  userHasExpiredPro,
+  isLoading,
+  isError,
+}: {
+  expiryTimeMs: number;
+  autoRenew: boolean;
+  userHasExpiredPro: boolean;
+  isLoading: boolean;
+  isError: boolean;
+}) {
+  // Keep get_pro_status fresh around the paid-through end while the pro page is open, so the "renewal
+  // unsuccessful" warning reflects reality rather than a pre-expiry snapshot. Without it, a renewal
+  // that lands while the page is open isn't picked up until the page is closed and reopened.
+  useEffect(() => {
+    if (isLoading || isError || userHasExpiredPro || !autoRenew || !expiryTimeMs) {
+      return undefined;
+    }
+    const fire = () =>
+      window.inboxStore?.dispatch(
+        proBackendDataActions.refreshGetProStatusFromProBackend({}) as any
+      );
+    const msUntilExpiry = expiryTimeMs - NetworkTime.now();
+    if (msUntilExpiry > 0) {
+      // Refetch just after the crossing, so a renewal (or a genuine failure) replaces the stale value.
+      const timeoutId = setTimeout(fire, msUntilExpiry + 5 * DURATION.SECONDS);
+      return () => clearTimeout(timeoutId);
+    }
+    // Past expiry and still auto-renewing (grace/renewal window): the renewal can succeed at any
+    // point, so re-check until get_pro_status reports the new expiry (the deps change re-arms the
+    // one-shot above) or the account flips to expired (the guard returns).
+    const intervalId = setInterval(fire, DURATION.MINUTES);
+    return () => clearInterval(intervalId);
+  }, [expiryTimeMs, autoRenew, userHasExpiredPro, isLoading, isError]);
+}
 
 function ProNonProContinueButton({ state }: SectionProps) {
   const { returnToThisModalAction, centerAlign, afterCloseAction } = state;
@@ -436,6 +486,14 @@ function ProSettings({ state }: SectionProps) {
   const userNeverHadPro = useCurrentNeverHadProInternal();
   const { data, isLoading, isError } = useProBackendProStatusInternal();
   const backendErrorButtons = useBackendErrorDialogButtons();
+
+  useKeepProStatusFresh({
+    expiryTimeMs: data.expiryTimeMs,
+    autoRenew: data.autoRenew,
+    userHasExpiredPro,
+    isLoading,
+    isError,
+  });
 
   const forceRefresh = useUpdate();
 

--- a/ts/react.d.ts
+++ b/ts/react.d.ts
@@ -134,6 +134,8 @@ declare module 'react' {
     | 'preferences'
     | 'donate';
 
+  type ProSettingsSections = 'stats' | 'manage' | 'features';
+
   type ProFeatureItems =
     | 'longer-messages'
     | 'more-pins'
@@ -305,6 +307,9 @@ declare module 'react' {
 
     // Pro settings
     | `${ProFeatureItems}-pro-settings-menu-item`
+    | `pro-settings-${ProSettingsSections}-header`
+    // Both the "checking" and the "backend unavailable" messages render into this one slot.
+    | 'pro-settings-status-banner'
 
     // timer options
     | DisappearTimeOptionDataTestId

--- a/ts/session/apis/file_server_api/FileServerApi.ts
+++ b/ts/session/apis/file_server_api/FileServerApi.ts
@@ -44,7 +44,13 @@ export const uploadFileToFsWithOnionV4 = async (
     return null;
   }
 
-  const target = process.env.POTATO_FS ? 'POTATO' : 'DEFAULT';
+  // TEST wins over POTATO: a run that configured a local file server meant it, and falling through to
+  // a remote one would put the upload somewhere the test cannot reach.
+  const target = FS.isTestFileServerConfigured()
+    ? 'TEST'
+    : process.env.POTATO_FS
+      ? 'POTATO'
+      : 'DEFAULT';
 
   const result = await OnionSending.sendBinaryViaOnionV4ToFileServer({
     abortSignal: new AbortController().signal,

--- a/ts/session/apis/file_server_api/FileServerTarget.ts
+++ b/ts/session/apis/file_server_api/FileServerTarget.ts
@@ -1,3 +1,5 @@
+import { crypto_sign_ed25519_pk_to_curve25519, from_hex, to_hex } from 'libsodium-wrappers-sumo';
+
 import { SERVER_HOSTS } from '..';
 import { assertUnreachable } from '../../../types/sqlSharedTypes';
 
@@ -10,7 +12,102 @@ type FileServerConfigType = {
 // not exported/included in the SERVER_HOSTS as this is for testing only
 const POTATO_FS_HOST = 'potatofiles.getsession.org';
 
-const FILE_SERVERS: Record<'DEFAULT' | 'POTATO', FileServerConfigType> = {
+// Host used when no test file server is configured, so an unconfigured TEST target still can't
+// resolve to anything real. Not in SERVER_HOSTS (testing only).
+const TEST_FS_UNCONFIGURED = 'test-file-server-not-configured.invalid';
+
+/**
+ * A local file server, supplied through the environment.
+ *
+ * Without this every upload goes to the production file server over an onion path, which no test can
+ * redirect — the same shape as the Pro backend before it gained TEST_PRO_BACKEND_*, and this mirrors
+ * that deliberately rather than inventing a second pattern.
+ *
+ *   TEST_FILE_SERVER_URL    e.g. http://192.168.139.2:8000
+ *   TEST_FILE_SERVER_ED_PK  the server's Ed25519 pubkey
+ *
+ * Only those two. The X25519 key the onion request encrypts to is **derived** from the Ed25519 one
+ * rather than configured: the server has one keypair and prints both representations of it, so asking
+ * for the second invites a mismatched pair that fails halfway through an exchange.
+ *
+ * Use an address the SNODES can reach rather than localhost: requests arrive over an onion path, so
+ * the host is resolved inside the snode containers.
+ *
+ * The env read happens once at module load; the key derivation is deferred (see `testTarget`).
+ */
+const testFromEnv = ((): { url: string; edPk: string } | null => {
+  const value = (name: string) => (process.env[name] ?? '').trim();
+  const url = value('TEST_FILE_SERVER_URL').replace(/\/$/, '');
+  const edPk = value('TEST_FILE_SERVER_ED_PK').toLowerCase();
+
+  if (!url && !edPk) {
+    return null;
+  }
+  // One without the other is always a mistake, and silently ignoring it would send the upload to
+  // production while the run looks configured.
+  if (!url || !edPk) {
+    throw new Error(
+      'TEST_FILE_SERVER_URL and TEST_FILE_SERVER_ED_PK must be set together ' +
+        `(got url="${url}", edPk="${edPk}")`
+    );
+  }
+  if (!/^https?:\/\/[^/\s]+$/.test(url)) {
+    throw new Error(`TEST_FILE_SERVER_URL must look like http://host:port (got "${url}")`);
+  }
+  if (!/^[0-9a-f]{64}$/.test(edPk)) {
+    throw new Error(
+      `TEST_FILE_SERVER_ED_PK must be a 64-character hex Ed25519 pubkey (got "${edPk}")`
+    );
+  }
+  return { url, edPk };
+})();
+
+/**
+ * The TEST target, with the X25519 key derived on first use.
+ *
+ * Deferred rather than computed alongside `testFromEnv` because the conversion needs libsodium, which
+ * is only usable after `sodium.ready` — module evaluation can happen before that. Everything that
+ * reads this does so at runtime, and `Object.keys` (which builds FILE_SERVER_TARGETS) does not invoke
+ * getters, so nothing forces it early.
+ */
+let testTargetCache: FileServerConfigType | null = null;
+
+/**
+ * 64 hex characters is not enough to be an Ed25519 key — an X25519 key looks identical — and the
+ * conversion is the only thing that can tell them apart. Left to libsodium it surfaces as a bare
+ * "invalid key" from a stack with no mention of the variable that caused it.
+ */
+function deriveXPkOrThrow(edPk: string) {
+  try {
+    return to_hex(crypto_sign_ed25519_pk_to_curve25519(from_hex(edPk)));
+  } catch (e) {
+    throw new Error(
+      `TEST_FILE_SERVER_ED_PK is not a valid Ed25519 pubkey: "${edPk}" cannot be converted to ` +
+        `X25519 ("${e.message}"). Note an X25519 key is also 64 hex characters, so check you took ` +
+        `the server's Ed25519 key and not its X25519 one.`
+    );
+  }
+}
+
+function testTarget(): FileServerConfigType {
+  if (!testTargetCache) {
+    testTargetCache = {
+      // Falls back to an unresolvable host with empty keys when unconfigured, so this target stays
+      // inert rather than silently pointing at the default file server.
+      url: testFromEnv?.url ?? `https://${TEST_FS_UNCONFIGURED}`,
+      edPk: testFromEnv?.edPk ?? '',
+      xPk: testFromEnv ? deriveXPkOrThrow(testFromEnv.edPk) : '',
+    };
+  }
+  return testTargetCache;
+}
+
+/** Whether a test file server is configured, i.e. whether the TEST target is usable. */
+function isTestFileServerConfigured() {
+  return testFromEnv !== null;
+}
+
+const FILE_SERVERS: Record<'DEFAULT' | 'POTATO' | 'TEST', FileServerConfigType> = {
   DEFAULT: {
     url: `http://${SERVER_HOSTS.DEFAULT_FILE_SERVER}`,
     xPk: '09324794aa9c11948189762d198c618148e9136ac9582068180661208927ef34',
@@ -20,6 +117,11 @@ const FILE_SERVERS: Record<'DEFAULT' | 'POTATO', FileServerConfigType> = {
     url: `http://${POTATO_FS_HOST}`,
     edPk: 'ff86dcd4b26d1bfec944c59859494248626d6428efc12168749d65a1b92f5e28',
     xPk: 'fc097b06821c98a2db75ce02e521cef5fd9d3446e42e81d843c4c8c4e9260f48',
+  },
+  // A getter, so the X25519 derivation in testTarget() happens on first read rather than at module
+  // load, where libsodium may not be ready yet.
+  get TEST() {
+    return testTarget();
   },
 };
 
@@ -38,6 +140,15 @@ function fileUrlToFileTarget(url: string): FILE_SERVER_TARGET_TYPE {
   for (let index = 0; index < FILE_SERVER_TARGETS.length; index++) {
     const target = FILE_SERVER_TARGETS[index];
     switch (target) {
+      case 'TEST':
+        // Matched against whatever TEST resolved to — the configured host, or the unresolvable
+        // placeholder when there is none. An exact host match rather than `includes`, because a
+        // configured test host is an arbitrary address (often a bare IP:port) and a substring test on
+        // one of those matches far too much.
+        if (parsedUrl.host === new URL(FILE_SERVERS.TEST.url).host) {
+          return 'TEST';
+        }
+        break;
       case 'POTATO':
         if (parsedUrl.host.includes(POTATO_FS_HOST)) {
           return 'POTATO';
@@ -57,6 +168,7 @@ function fileUrlToFileTarget(url: string): FILE_SERVER_TARGET_TYPE {
 
 export const FS = {
   isDefaultFileServer,
+  isTestFileServerConfigured,
   FILE_SERVERS,
   fileUrlToFileTarget,
 };

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -232,14 +232,19 @@ async function applyProofOutcome(
       }
       break;
     case 'not_subscribed':
-      // Clear the (absent) credential but leave pro_prepaid so a pending purchase keeps polling.
+      // Clear the (absent) credential AND the access-expiry (E), but leave pro_prepaid so a pending
+      // purchase keeps polling. Clearing E is required: libsession's renewal target now fires on
+      // "future E but no proof", so a stale future E left here would spin.
       if (!haveValidProof()) {
         await UserConfigWrapperActions.removeProConfig();
+        await UserConfigWrapperActions.setProAccessExpiry(null);
       }
       break;
     case 'revoked':
-      // Terminal: revocation must kill even an unexpired proof (bypasses the downgrade guard). No E.
+      // Terminal: revocation kills even an unexpired proof (bypasses the downgrade guard). With the
+      // proof gone we must also clear E, or the renewal target (future E, no proof) would spin.
       await UserConfigWrapperActions.removeProConfig();
+      await UserConfigWrapperActions.setProAccessExpiry(null);
       break;
     default:
       // Unrecognized error_code: fail closed, non-destructively — treat as transient (no write/clear).

--- a/ts/state/ducks/types/defaultFeatureFlags.ts
+++ b/ts/state/ducks/types/defaultFeatureFlags.ts
@@ -1,8 +1,10 @@
 import { isEmpty } from 'lodash';
 import { isTestIntegration, isTestNet } from '../../../shared/env_vars';
-import type {
-  SessionBooleanFeatureFlags,
-  SessionDataFeatureFlags,
+import { ProStatus } from '../../../session/apis/pro_backend_api/types';
+import {
+  MockProAccessExpiryOptions,
+  type SessionBooleanFeatureFlags,
+  type SessionDataFeatureFlags,
 } from './releasedFeaturesReduxTypes';
 
 export const defaultProBooleanFeatureFlags = {
@@ -71,20 +73,95 @@ function getMockNetworkPageNodeCount() {
   }
 }
 
+/**
+ * An unrecognised value for a mock env var must not degrade to "no override". A typo would then
+ * surface as a failed assertion about the app, several steps from its cause, rather than as a
+ * setup error — so these throw.
+ */
+function invalidMockEnvVar(name: string, value: string, allowed: Array<string>): never {
+  const message = `${name}: "${value}" is not one of ${allowed.join(' | ')}`;
+  // eslint-disable-next-line no-console
+  console.error(message);
+  window?.log?.error(message);
+  throw new Error(message);
+}
+
+/**
+ * The Pro status the app should project, from the environment.
+ *
+ * The slugs are libsession's own (`ProStatus`) plus `useactual`, which is the shared vocabulary the
+ * iOS and Android harnesses also take, so one value in a cross-platform test config drives all
+ * three clients. `useactual` is spelled out rather than left to an unset variable so a config can
+ * say "no override" explicitly.
+ *
+ * Note for whoever maps the shared `active` token onto Desktop: on all three clients `active` means
+ * active *and not auto-renewing*, so the harness must pass SESSION_USER_HAS_PRO_CANCELLED alongside
+ * this. Deliberately not coupled here — this flag projects the status and nothing else, and having
+ * it silently move autoRenew would surprise every non-test reader of `mockProCurrentStatus`.
+ */
+function getMockProCurrentStatus(): ProStatus | null {
+  const envVar = process.env.SESSION_PRO_CURRENT_STATUS?.trim();
+  if (!envVar) {
+    return null;
+  }
+  const known = [ProStatus.Never, ProStatus.Active, ProStatus.Expired] as Array<ProStatus>;
+  if (known.includes(envVar)) {
+    return envVar;
+  }
+  if (envVar === 'useactual') {
+    return null;
+  }
+  return invalidMockEnvVar('SESSION_PRO_CURRENT_STATUS', envVar, [...known, 'useactual']);
+}
+
+/**
+ * Named rather than numeric, because the enum's numbering is an implementation detail that
+ * reorders whenever a case is inserted — an environment pinned to `2` would silently start
+ * meaning a different duration.
+ */
+function getMockProAccessExpiry(): MockProAccessExpiryOptions | null {
+  const envVar = process.env.SESSION_PRO_ACCESS_EXPIRY?.trim();
+  if (!envVar) {
+    return null;
+  }
+  const option = MockProAccessExpiryOptions[envVar as keyof typeof MockProAccessExpiryOptions];
+  if (typeof option === 'number') {
+    return option;
+  }
+  return invalidMockEnvVar(
+    'SESSION_PRO_ACCESS_EXPIRY',
+    envVar,
+    Object.keys(MockProAccessExpiryOptions).filter(k => Number.isNaN(Number(k)))
+  );
+}
+
+/**
+ * Path to an image for the test-integration avatar picker to return.
+ *
+ * Only emptiness is checked here — whether the file exists and is a usable image is settled in
+ * `pickFileForTestIntegration`, which owns the accepted-extension list. Duplicating that list here
+ * would give two sources of truth for one rule, and the picker's error is raised the moment a test
+ * uploads, which is loud enough.
+ */
+function getFakeAvatarPickerFile(): string | null {
+  return process.env.SESSION_FAKE_AVATAR_PICKER_FILE?.trim() || null;
+}
+
 export const defaultAvatarPickerColor = '#0000ff'; // defaults to blue
 
 export const defaultProDataFeatureFlags = {
   mockMessageProFeatures: null,
-  mockProCurrentStatus: null,
+  mockProCurrentStatus: getMockProCurrentStatus(),
   mockProPaymentProvider: null,
   mockProAccessVariant: null,
-  mockProAccessExpiry: null,
+  mockProAccessExpiry: getMockProAccessExpiry(),
   mockProLongerMessagesSent: null,
   mockProPinnedConversations: null,
   mockProBadgesSent: null,
   mockProGroupsUpgraded: null,
   mockNetworkPageNodeCount: getMockNetworkPageNodeCount(),
   fakeAvatarPickerColor: defaultAvatarPickerColor,
+  fakeAvatarPickerFile: getFakeAvatarPickerFile(),
 } as const;
 
 export const defaultDataFeatureFlags = {

--- a/ts/state/ducks/types/releasedFeaturesReduxTypes.ts
+++ b/ts/state/ducks/types/releasedFeaturesReduxTypes.ts
@@ -83,6 +83,9 @@ export type SessionDataFeatureFlags = {
   mockProGroupsUpgraded: number | null;
   mockNetworkPageNodeCount: number | null;
   fakeAvatarPickerColor: string | null; // defaults to defaultAvatarPickerColor
+  // Absolute path to an image the test-integration avatar picker returns instead of the generated
+  // solid colour. The only way a test can supply an animated avatar, or any specific content.
+  fakeAvatarPickerFile: string | null;
 };
 
 export type SessionBooleanFeatureFlagKeys = keyof SessionBooleanFeatureFlags;

--- a/ts/state/selectors/proBackendData.ts
+++ b/ts/state/selectors/proBackendData.ts
@@ -280,14 +280,21 @@ function processProBackendData({
     ? !mockCancelled
     : (data?.autoRenewing ?? defaultProAccessDetailsSourceData.autoRenew);
 
+  // Auto-renew is due AT the paid-through end (`expiryMs`). user_status stays `active` through the
+  // grace window (the backend judges coverage against expiry + grace_period_duration), so being past
+  // expiry while still active IS the grace period. Subtracting grace here put "renew due" a whole
+  // grace period early, so inGracePeriod was perpetually true whenever grace exceeded the period.
   let beginAutoRenew = 0;
   if (data) {
-    beginAutoRenew = data.expiryMs - data.gracePeriodDurationMs;
+    beginAutoRenew = data.expiryMs;
   }
 
   let inGracePeriod = mockInGracePeriod;
   if (beginAutoRenew && !mockInGracePeriod) {
-    inGracePeriod = autoRenew && now >= beginAutoRenew && now < expiryTimeMs;
+    // Only surface "renewal unsuccessful" off data we actually fetched at/after the paid-through
+    // end — never off a pre-expiry snapshot that predates a possible renewal. The pro page refetches
+    // at the crossing (and polls through grace), so a stale snapshot resolves rather than sticking.
+    inGracePeriod = autoRenew && now >= expiryTimeMs && lastFetchedMs >= expiryTimeMs;
   }
 
   // Refund-requested is now a synced config flag (UserProfile key R), not a backend response field.

--- a/ts/state/selectors/proBackendData.ts
+++ b/ts/state/selectors/proBackendData.ts
@@ -280,17 +280,13 @@ function processProBackendData({
     ? !mockCancelled
     : (data?.autoRenewing ?? defaultProAccessDetailsSourceData.autoRenew);
 
-  // Auto-renew is due AT the paid-through end (`expiryMs`). user_status stays `active` through the
-  // grace window (the backend judges coverage against expiry + grace_period_duration), so being past
-  // expiry while still active IS the grace period. Subtracting grace here put "renew due" a whole
-  // grace period early, so inGracePeriod was perpetually true whenever grace exceeded the period.
-  let beginAutoRenew = 0;
-  if (data) {
-    beginAutoRenew = data.expiryMs;
-  }
-
+  // Auto-renew is due AT the paid-through end (`expiryMs`), which is `expiryTimeMs` above. user_status
+  // stays `active` through the grace window (the backend judges coverage against expiry +
+  // grace_period_duration), so being past expiry while still active IS the grace period. Subtracting
+  // grace here put "renew due" a whole grace period early, so inGracePeriod was perpetually true
+  // whenever grace exceeded the period.
   let inGracePeriod = mockInGracePeriod;
-  if (beginAutoRenew && !mockInGracePeriod) {
+  if (expiryTimeMs && !mockInGracePeriod) {
     // Only surface "renewal unsuccessful" off data we actually fetched at/after the paid-through
     // end — never off a pre-expiry snapshot that predates a possible renewal. The pro page refetches
     // at the crossing (and polls through grace), so a stale snapshot resolves rather than sticking.
@@ -317,10 +313,10 @@ function processProBackendData({
       variantString,
       expiryTimeMs,
       expiryTimeDateString: formatDateWithLocale({
-        date: new Date(beginAutoRenew),
+        date: new Date(expiryTimeMs),
         formatStr: 'MMM d, yyyy',
       }),
-      expiryTimeRelativeString: formatRoundedUpTimeUntilTimestamp(beginAutoRenew),
+      expiryTimeRelativeString: formatRoundedUpTimeUntilTimestamp(expiryTimeMs),
       isPlatformRefundAvailable,
       provider,
       providerConstants: getProProviderConstantsWithFallbacks(provider),

--- a/ts/types/attachments/VisualAttachment.ts
+++ b/ts/types/attachments/VisualAttachment.ts
@@ -2,6 +2,7 @@
 /* global document, URL, Blob */
 
 import { dataURLToBlob } from 'blob-util';
+import { existsSync, readFileSync } from 'fs';
 import { toLogFormat } from './Errors';
 
 import { DecryptedAttachmentsManager } from '../../session/crypto/DecryptedAttachmentsManager';
@@ -190,11 +191,30 @@ export const revokeObjectUrl = (objectUrl: string) => {
   URL.revokeObjectURL(objectUrl);
 };
 
-async function pickFileForReal() {
-  const acceptedImages = ['.png', '.gif', '.jpeg', '.jpg'];
+const AVATAR_MIME_BY_EXTENSION = {
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.webp': 'image/webp',
+} as const;
+
+type AvatarExtension = keyof typeof AVATAR_MIME_BY_EXTENSION;
+
+/**
+ * `.webp` is only offered when Pro is available, because it is the animated format — an animated
+ * avatar is a Pro feature.
+ */
+function acceptedAvatarExtensions(): Array<AvatarExtension> {
+  const accepted: Array<AvatarExtension> = ['.png', '.gif', '.jpeg', '.jpg'];
   if (getFeatureFlag('proAvailable')) {
-    acceptedImages.push('.webp');
+    accepted.push('.webp');
   }
+  return accepted;
+}
+
+async function pickFileForReal() {
+  const acceptedImages = acceptedAvatarExtensions();
 
   const [fileHandle] = await (window as any).showOpenFilePicker({
     types: [
@@ -231,7 +251,39 @@ function hexToRgb(hex: string) {
   };
 }
 
+/**
+ * The generated avatar is a solid colour and therefore never animated, so a test could not reach
+ * anything gated on `isAnimated` — nor assert anything about avatar content, since every avatar in
+ * every test was the same square. `fakeAvatarPickerFile` substitutes a real image from disk.
+ */
+function pickFileFromDisk(path: string) {
+  const accepted = acceptedAvatarExtensions();
+  const extension = accepted.find(ext => path.toLowerCase().endsWith(ext));
+
+  // Throwing rather than falling back to the generated avatar: a silent fallback would surface as a
+  // test asserting the wrong image, several steps from the typo that caused it.
+  if (!extension) {
+    const webpHint = getFeatureFlag('proAvailable') ? '' : ' (.webp needs SESSION_PRO)';
+    throw new Error(
+      `fakeAvatarPickerFile: "${path}" must end in one of ${accepted.join(', ')}${webpHint}`
+    );
+  }
+  if (!existsSync(path)) {
+    throw new Error(`fakeAvatarPickerFile: no file at "${path}"`);
+  }
+
+  const buffer = readFileSync(path);
+  return new File([buffer], `fakeAvatarPickerFile${extension}`, {
+    type: AVATAR_MIME_BY_EXTENSION[extension],
+  });
+}
+
 async function pickFileForTestIntegration() {
+  const fakeAvatarPickerFile = getDataFeatureFlag('fakeAvatarPickerFile');
+  if (fakeAvatarPickerFile) {
+    return pickFileFromDisk(fakeAvatarPickerFile);
+  }
+
   const fakeAvatarPickerColor = getDataFeatureFlag('fakeAvatarPickerColor');
   const blueAvatarDetails = await ImageProcessor.testIntegrationFakeAvatar(
     maxAvatarDetails.maxSidePlanReupload,


### PR DESCRIPTION
Makes the Desktop client testable for Session Pro, so the regression suite can cover the same fifteen
Pro specs on Desktop that already run on iOS and Android. **All fifteen now pass on Desktop.**

> [!NOTE]
> Based on #1974 rather than `dev`, so only the four commits below belong to this PR. GitHub will
> retarget it to `dev` automatically once #1974 merges.

### What's here

| commit | why |
|---|---|
| `feat(pro)` test ids | The Pro settings screen had no addressable handle on its section headers or the hero status text, so no test could assert the subscribed / expired / checking / error states. |
| `test(pro)` env plumbing | `mockProCurrentStatus`, `mockProAccessExpiry` and the avatar picker were debug-menu only. A Playwright run could not launch the app into a Pro state, and the test-integration picker always returned a generated solid-colour JPEG — so `isNewAvatarAnimated` was permanently false and the animated-display-picture branch was unreachable. |
| `fix(pro)` mocked expiry | The displayed expiry strings were computed from a local `beginAutoRenew` fed only by `data.expiryMs`, so the mocked access expiry never changed what the screen shows. Kept separate so it can be reverted without the test-support wiring. |
| `test(fileserver)` redirect | The file server target was hardcoded to production, so every upload a test performed went to `filev2.getsession.org` over an onion path. |

### Behaviour for real users

Only the `fix(pro)` commit touches a non-test path, and it is unchanged for real data: `beginAutoRenew`
equalled `expiryTimeMs` for every real input, and with no mock set `expiryTimeMs` reduces to
`data?.expiryMs ?? 0` where `expiryMs` is a required number. The one observable difference is a
pro-status cache written before `expiryMs` existed, which rendered `Invalid Date` and now renders
`Jan 1, 1970` — both wrong, and the grace-period guard is false either way.

Everything else is reached only from env vars that are unset in normal use.

### Evidence

- `tsc` on the merged tree: **0 before, 0 after** (`dev` @ v0.6.19 has a ~42-error baseline; #1974's pin bump to v0.6.21 is what clears it)
- `pnpm build` green; all ids confirmed **in the rendered DOM** of a running Electron app, across all four Pro states
- The full Desktop Pro suite: **15/15**
- Redirecting the file server took the two avatar-upload specs from ~1.3 min each to 2.8s and 18.3s, and the suite from 7.2 min to ~2.0 min

### Not fixed here, deliberately

`ProHeroImage` guards on `heroStatusText`, which is a JSX element and therefore truthy even when
`HeroStatusText` returns `null`. That makes `pro-settings-status-banner` render (empty) in every state,
and also makes the neighbouring `<SpacerMD />` unconditional — so the success state renders a spacer
that looks unintended. Raised separately rather than folded in, since it is a visual change and this
branch is test-support.
