### PR TITLE
Pro: split access from display, and stop upselling an active plan

### DIFF
--- a/ts/components/buttons/panel/PanelButton.tsx
+++ b/ts/components/buttons/panel/PanelButton.tsx
@@ -44,15 +44,17 @@ export function PanelLabelWithDescription({
   title,
   extraInlineNode,
   description,
+  dataTestId,
 }: {
   title: TrArgs;
   extraInlineNode?: ReactNode;
   description?: TrArgs;
+  dataTestId?: SessionDataTestId;
 }) {
   return (
     <StyledPanelLabelWithDescription>
       {/* less space between the label and the description */}
-      <StyledPanelLabel>
+      <StyledPanelLabel data-testid={dataTestId}>
         <Localizer {...title} />
         {extraInlineNode}
       </StyledPanelLabel>

--- a/ts/components/conversation/ContactName/ContactName.tsx
+++ b/ts/components/conversation/ContactName/ContactName.tsx
@@ -14,7 +14,7 @@ import { tr } from '../../../localization/localeTools';
 import { isUsAnySogsFromCache } from '../../../session/apis/open_group_api/sogsv3/knownBlindedkeys';
 import type { ContactNameContext } from './ContactNameContext';
 import { useProBadgeOnClickCb } from '../../menuAndSettingsHooks/useProBadgeOnClickCb';
-import { useCurrentUserHasProAccess, useShowProBadgeFor } from '../../../hooks/useHasPro';
+import { useCurrentUserHasPro, useShowProBadgeFor } from '../../../hooks/useHasPro';
 import { ProIconButton } from '../../buttons/ProButton';
 import { useMessageIdFromContext } from '../../../contexts/MessageIdContext';
 import { useMessageDirection } from '../../../state/selectors';
@@ -229,7 +229,11 @@ export const ContactName = ({
   const realName = useConversationRealName(pubkey);
   const nickname = useNickname(pubkey);
   const isPrivate = useIsPrivate(pubkey);
-  const currentUserHasPro = useCurrentUserHasProAccess();
+  // DISPLAY, not ACCESS: this only decides whether tapping someone else's badge invites us to buy
+  // Pro. The gate reads ACCESS; the thing that explains or sells the gate reads DISPLAY, so a user
+  // whose plan reads active is never upsold — and one in the overhang, whose plan has lapsed while
+  // the proof still works, is.
+  const currentUserHasPro = useCurrentUserHasPro();
 
   const msgId = useMessageIdFromContext();
 

--- a/ts/components/conversation/ContactName/ContactName.tsx
+++ b/ts/components/conversation/ContactName/ContactName.tsx
@@ -14,7 +14,7 @@ import { tr } from '../../../localization/localeTools';
 import { isUsAnySogsFromCache } from '../../../session/apis/open_group_api/sogsv3/knownBlindedkeys';
 import type { ContactNameContext } from './ContactNameContext';
 import { useProBadgeOnClickCb } from '../../menuAndSettingsHooks/useProBadgeOnClickCb';
-import { useCurrentUserHasPro, useShowProBadgeFor } from '../../../hooks/useHasPro';
+import { useShowProBadgeFor } from '../../../hooks/useHasPro';
 import { ProIconButton } from '../../buttons/ProButton';
 import { useMessageIdFromContext } from '../../../contexts/MessageIdContext';
 import { useMessageDirection } from '../../../state/selectors';
@@ -233,7 +233,6 @@ export const ContactName = ({
   // Pro. The gate reads ACCESS; the thing that explains or sells the gate reads DISPLAY, so a user
   // whose plan reads active is never upsold — and one in the overhang, whose plan has lapsed while
   // the proof still works, is.
-  const currentUserHasPro = useCurrentUserHasPro();
 
   const msgId = useMessageIdFromContext();
 
@@ -272,7 +271,6 @@ export const ContactName = ({
       userHasPro,
       isMe,
       contactNameContext,
-      currentUserHasPro,
       isBlinded: PubKey.isBlinded(pubkey),
     },
   });

--- a/ts/components/conversation/ContactName/ContactName.tsx
+++ b/ts/components/conversation/ContactName/ContactName.tsx
@@ -14,7 +14,7 @@ import { tr } from '../../../localization/localeTools';
 import { isUsAnySogsFromCache } from '../../../session/apis/open_group_api/sogsv3/knownBlindedkeys';
 import type { ContactNameContext } from './ContactNameContext';
 import { useProBadgeOnClickCb } from '../../menuAndSettingsHooks/useProBadgeOnClickCb';
-import { useCurrentUserHasPro, useShowProBadgeFor } from '../../../hooks/useHasPro';
+import { useCurrentUserHasProAccess, useShowProBadgeFor } from '../../../hooks/useHasPro';
 import { ProIconButton } from '../../buttons/ProButton';
 import { useMessageIdFromContext } from '../../../contexts/MessageIdContext';
 import { useMessageDirection } from '../../../state/selectors';
@@ -229,7 +229,7 @@ export const ContactName = ({
   const realName = useConversationRealName(pubkey);
   const nickname = useNickname(pubkey);
   const isPrivate = useIsPrivate(pubkey);
-  const currentUserHasPro = useCurrentUserHasPro();
+  const currentUserHasPro = useCurrentUserHasProAccess();
 
   const msgId = useMessageIdFromContext();
 

--- a/ts/components/conversation/composition/CharacterCount.tsx
+++ b/ts/components/conversation/composition/CharacterCount.tsx
@@ -6,6 +6,7 @@ import { StyledCTA } from '../../basic/StyledCTA';
 import { formatNumber } from '../../../util/i18n/formatting/generics';
 import { tr } from '../../../localization/localeTools';
 import { useCurrentUserHasPro } from '../../../hooks/useHasPro';
+import { currentUserProofIsValid } from '../../../session/utils/ProAccess';
 import { ProIconButton } from '../../buttons/ProButton';
 import { useProBadgeOnClickCb } from '../../menuAndSettingsHooks/useProBadgeOnClickCb';
 
@@ -54,11 +55,13 @@ function ProCta() {
 export function CharacterCount({ text }: CharacterCountProps) {
   const alwaysShowFlag = getFeatureFlagMemo('alwaysShowRemainingChars');
 
-  const currentUserHasPro = useCurrentUserHasPro();
-
   const codepointCount = [...text].length;
 
-  const charLimit = currentUserHasPro
+  // How many characters we may send is ACCESS, not DISPLAY: the recipient decides what to keep by
+  // validating the proof we attach, so counting against the Pro limit without one would promise an
+  // allowance every recipient will truncate. Read live rather than from redux — this re-renders on
+  // each keystroke, so it stays current on its own.
+  const charLimit = currentUserProofIsValid()
     ? LIBSESSION_CONSTANTS.MESSAGE_CHARACTER_LIMIT_PRO
     : LIBSESSION_CONSTANTS.MESSAGE_CHARACTER_LIMIT_STANDARD;
 

--- a/ts/components/conversation/composition/CharacterCount.tsx
+++ b/ts/components/conversation/composition/CharacterCount.tsx
@@ -5,8 +5,7 @@ import { SessionTooltip } from '../../SessionTooltip';
 import { StyledCTA } from '../../basic/StyledCTA';
 import { formatNumber } from '../../../util/i18n/formatting/generics';
 import { tr } from '../../../localization/localeTools';
-import { useCurrentUserHasPro } from '../../../hooks/useHasPro';
-import { currentUserProofIsValid } from '../../../session/utils/ProAccess';
+import { useCurrentUserHasPro, useCurrentUserHasProAccess } from '../../../hooks/useHasPro';
 import { ProIconButton } from '../../buttons/ProButton';
 import { useProBadgeOnClickCb } from '../../menuAndSettingsHooks/useProBadgeOnClickCb';
 
@@ -59,9 +58,11 @@ export function CharacterCount({ text }: CharacterCountProps) {
 
   // How many characters we may send is ACCESS, not DISPLAY: the recipient decides what to keep by
   // validating the proof we attach, so counting against the Pro limit without one would promise an
-  // allowance every recipient will truncate. Read live rather than from redux — this re-renders on
-  // each keystroke, so it stays current on its own.
-  const charLimit = currentUserProofIsValid()
+  // allowance every recipient will truncate. Subscribed rather than called, because this is a render —
+  // the send path itself calls the function directly, which is what actually has to be current.
+  const currentUserHasProAccess = useCurrentUserHasProAccess();
+
+  const charLimit = currentUserHasProAccess
     ? LIBSESSION_CONSTANTS.MESSAGE_CHARACTER_LIMIT_PRO
     : LIBSESSION_CONSTANTS.MESSAGE_CHARACTER_LIMIT_STANDARD;
 

--- a/ts/components/conversation/composition/CharacterCount.tsx
+++ b/ts/components/conversation/composition/CharacterCount.tsx
@@ -5,7 +5,7 @@ import { SessionTooltip } from '../../SessionTooltip';
 import { StyledCTA } from '../../basic/StyledCTA';
 import { formatNumber } from '../../../util/i18n/formatting/generics';
 import { tr } from '../../../localization/localeTools';
-import { useCurrentUserHasPro, useCurrentUserHasProAccess } from '../../../hooks/useHasPro';
+import { useCurrentUserHasProAccess } from '../../../hooks/useHasPro';
 import { ProIconButton } from '../../buttons/ProButton';
 import { useProBadgeOnClickCb } from '../../menuAndSettingsHooks/useProBadgeOnClickCb';
 
@@ -32,11 +32,9 @@ const StyledRemainingNumber = styled.span<{ $pastLimit: boolean }>`
 `;
 
 function ProCta() {
-  const currentUserHasPro = useCurrentUserHasPro();
-
   const proBadgeCb = useProBadgeOnClickCb({
     context: 'character-count',
-    args: { currentUserHasPro },
+    args: {},
   });
 
   if (!proBadgeCb.show || !proBadgeCb.cb) {

--- a/ts/components/conversation/composition/CompositionBox.tsx
+++ b/ts/components/conversation/composition/CompositionBox.tsx
@@ -60,6 +60,7 @@ import { showSessionCTA } from '../../dialog/SessionCTA';
 import type { ProcessedLinkPreviewThumbnailType } from '../../../webworker/workers/node/image_processor/image_processor';
 import { CTAVariant } from '../../dialog/cta/types';
 import { selectWeAreProUser } from '../../../hooks/useHasPro';
+import { currentUserProofIsValid } from '../../../session/utils/ProAccess';
 import { closeContextMenus } from '../../../util/contextMenu';
 import type { MessageAttributes } from '../../../models/messageType';
 import { updateOutgoingLightBoxOptions } from '../../../state/ducks/modalDialog';
@@ -660,7 +661,13 @@ class CompositionBoxInner extends Component<Props, State> {
 
     this.linkPreviewAbortController?.abort();
 
-    const charLimit = hasPro
+    // The limit is ACCESS — read live, at the moment of sending, because that is when it has to be
+    // true. `hasPro` below is DISPLAY, and is only used to pick which explanation the user gets: a
+    // plan that reads active but holds no usable proof should be told the message is too long, not
+    // invited to buy what it already has.
+    const weCanSendProLength = currentUserProofIsValid();
+
+    const charLimit = weCanSendProLength
       ? LIBSESSION_CONSTANTS.MESSAGE_CHARACTER_LIMIT_PRO
       : LIBSESSION_CONSTANTS.MESSAGE_CHARACTER_LIMIT_STANDARD;
 

--- a/ts/components/conversation/right-panel/overlay/message-info/components/MessageInfo.tsx
+++ b/ts/components/conversation/right-panel/overlay/message-info/components/MessageInfo.tsx
@@ -36,7 +36,6 @@ import { Localizer } from '../../../../../basic/Localizer';
 import { LucideIcon } from '../../../../../icon/LucideIcon';
 import { LUCIDE_ICONS_UNICODE } from '../../../../../icon/lucide';
 import { useProBadgeOnClickCb } from '../../../../../menuAndSettingsHooks/useProBadgeOnClickCb';
-import { useCurrentUserHasPro } from '../../../../../../hooks/useHasPro';
 import { ProIconButton } from '../../../../../buttons/ProButton';
 import { assertUnreachable } from '../../../../../../types/sqlSharedTypes';
 import { ProMessageFeature } from '../../../../../../models/proMessageFeature';
@@ -203,13 +202,11 @@ function ProMessageFeaturesDetails({ messageId }: { messageId: string }) {
   // Pro. The gate reads ACCESS; the thing that explains or sells the gate reads DISPLAY, so a user
   // whose plan reads active is never upsold — and one in the overhang, whose plan has lapsed while
   // the proof still works, is.
-  const currentUserHasPro = useCurrentUserHasPro();
-
   const messageSentWithProFeat = useMessageSentWithProFeatures(messageId);
 
   const showPro = useProBadgeOnClickCb({
     context: 'message-info-sent-with-pro',
-    args: { messageSentWithProFeat, currentUserHasPro },
+    args: { messageSentWithProFeat },
   });
 
   if (!showPro.show || !messageSentWithProFeat?.length) {

--- a/ts/components/conversation/right-panel/overlay/message-info/components/MessageInfo.tsx
+++ b/ts/components/conversation/right-panel/overlay/message-info/components/MessageInfo.tsx
@@ -35,7 +35,7 @@ import { Localizer } from '../../../../../basic/Localizer';
 import { LucideIcon } from '../../../../../icon/LucideIcon';
 import { LUCIDE_ICONS_UNICODE } from '../../../../../icon/lucide';
 import { useProBadgeOnClickCb } from '../../../../../menuAndSettingsHooks/useProBadgeOnClickCb';
-import { useCurrentUserHasProAccess } from '../../../../../../hooks/useHasPro';
+import { useCurrentUserHasPro } from '../../../../../../hooks/useHasPro';
 import { ProIconButton } from '../../../../../buttons/ProButton';
 import { assertUnreachable } from '../../../../../../types/sqlSharedTypes';
 import { ProMessageFeature } from '../../../../../../models/proMessageFeature';
@@ -178,7 +178,11 @@ function proFeatureToTrKey(proFeature: ProMessageFeature) {
 }
 
 function ProMessageFeaturesDetails({ messageId }: { messageId: string }) {
-  const currentUserHasPro = useCurrentUserHasProAccess();
+  // DISPLAY, not ACCESS: this only decides whether tapping someone else's badge invites us to buy
+  // Pro. The gate reads ACCESS; the thing that explains or sells the gate reads DISPLAY, so a user
+  // whose plan reads active is never upsold — and one in the overhang, whose plan has lapsed while
+  // the proof still works, is.
+  const currentUserHasPro = useCurrentUserHasPro();
 
   const messageSentWithProFeat = useMessageSentWithProFeatures(messageId);
 

--- a/ts/components/conversation/right-panel/overlay/message-info/components/MessageInfo.tsx
+++ b/ts/components/conversation/right-panel/overlay/message-info/components/MessageInfo.tsx
@@ -35,7 +35,7 @@ import { Localizer } from '../../../../../basic/Localizer';
 import { LucideIcon } from '../../../../../icon/LucideIcon';
 import { LUCIDE_ICONS_UNICODE } from '../../../../../icon/lucide';
 import { useProBadgeOnClickCb } from '../../../../../menuAndSettingsHooks/useProBadgeOnClickCb';
-import { useCurrentUserHasPro } from '../../../../../../hooks/useHasPro';
+import { useCurrentUserHasProAccess } from '../../../../../../hooks/useHasPro';
 import { ProIconButton } from '../../../../../buttons/ProButton';
 import { assertUnreachable } from '../../../../../../types/sqlSharedTypes';
 import { ProMessageFeature } from '../../../../../../models/proMessageFeature';
@@ -178,7 +178,7 @@ function proFeatureToTrKey(proFeature: ProMessageFeature) {
 }
 
 function ProMessageFeaturesDetails({ messageId }: { messageId: string }) {
-  const currentUserHasPro = useCurrentUserHasPro();
+  const currentUserHasPro = useCurrentUserHasProAccess();
 
   const messageSentWithProFeat = useMessageSentWithProFeatures(messageId);
 

--- a/ts/components/dialog/EditProfilePictureModal.tsx
+++ b/ts/components/dialog/EditProfilePictureModal.tsx
@@ -237,7 +237,7 @@ export const EditProfilePictureModal = ({ conversationId }: EditProfilePictureMo
       //
       // TODO: an ACCEPTED trade, not an oversight. With an active plan and no usable proof this refuses
       // the animated upload and says nothing, because every string that exists here offers a purchase
-      // and there is none for "your plan is active but we cannot verify it yet". Ruled deliberately so
+      // and there is none for "your plan is active but we cannot verify it yet". Accepted deliberately so
       // the two-value split was not blocked on a translation round for an edge case. When that copy
       // exists, show it here — do NOT resolve this by putting the upsell back.
       if (!planReadsActive) {

--- a/ts/components/dialog/EditProfilePictureModal.tsx
+++ b/ts/components/dialog/EditProfilePictureModal.tsx
@@ -235,12 +235,9 @@ export const EditProfilePictureModal = ({ conversationId }: EditProfilePictureMo
     if (!weHavePro && isNewAvatarAnimated && !isCommunity) {
       // The refusal is ACCESS and unconditional. Whether we explain it by offering Pro is DISPLAY.
       //
-      // Blocked on copy, and an accepted trade rather than an oversight. With an active plan and no
-      // usable proof this refuses the animated upload and says nothing, because every string that
-      // exists here offers a purchase and there is none for "your plan is active but we cannot verify
-      // it yet". Accepted deliberately so the two-value split was not held up by a translation round
-      // for an edge case. When that string lands, show it here — do NOT resolve this by putting the
-      // upsell back.
+      // With an active plan and no usable proof, the refusal is silent: every string available here
+      // offers a purchase, and there is none for a plan that is already active. Reaching for the upsell
+      // anyway would sell a subscription the user is already paying for.
       if (!planReadsActive) {
         dispatch(
           updateSessionCTA({

--- a/ts/components/dialog/EditProfilePictureModal.tsx
+++ b/ts/components/dialog/EditProfilePictureModal.tsx
@@ -235,11 +235,12 @@ export const EditProfilePictureModal = ({ conversationId }: EditProfilePictureMo
     if (!weHavePro && isNewAvatarAnimated && !isCommunity) {
       // The refusal is ACCESS and unconditional. Whether we explain it by offering Pro is DISPLAY.
       //
-      // TODO: an ACCEPTED trade, not an oversight. With an active plan and no usable proof this refuses
-      // the animated upload and says nothing, because every string that exists here offers a purchase
-      // and there is none for "your plan is active but we cannot verify it yet". Accepted deliberately so
-      // the two-value split was not blocked on a translation round for an edge case. When that copy
-      // exists, show it here — do NOT resolve this by putting the upsell back.
+      // Blocked on copy, and an accepted trade rather than an oversight. With an active plan and no
+      // usable proof this refuses the animated upload and says nothing, because every string that
+      // exists here offers a purchase and there is none for "your plan is active but we cannot verify
+      // it yet". Accepted deliberately so the two-value split was not held up by a translation round
+      // for an edge case. When that string lands, show it here — do NOT resolve this by putting the
+      // upsell back.
       if (!planReadsActive) {
         dispatch(
           updateSessionCTA({

--- a/ts/components/dialog/EditProfilePictureModal.tsx
+++ b/ts/components/dialog/EditProfilePictureModal.tsx
@@ -43,7 +43,7 @@ import {
   useUpdateConversationDetailsModal,
 } from '../../state/selectors/modal';
 import { CTAVariant } from './cta/types';
-import { useCurrentUserHasPro } from '../../hooks/useHasPro';
+import { useCurrentUserHasProAccess } from '../../hooks/useHasPro';
 
 const StyledAvatarContainer = styled.div`
   cursor: pointer;
@@ -137,7 +137,7 @@ export const EditProfilePictureModal = ({ conversationId }: EditProfilePictureMo
 
   const isMe = useIsMe(conversationId);
   const isCommunity = useIsPublic(conversationId);
-  const weHavePro = useCurrentUserHasPro() && isMe;
+  const weHavePro = useCurrentUserHasProAccess() && isMe;
 
   const avatarPath = useAvatarPath(conversationId) || '';
 

--- a/ts/components/dialog/EditProfilePictureModal.tsx
+++ b/ts/components/dialog/EditProfilePictureModal.tsx
@@ -137,6 +137,10 @@ export const EditProfilePictureModal = ({ conversationId }: EditProfilePictureMo
 
   const isMe = useIsMe(conversationId);
   const isCommunity = useIsPublic(conversationId);
+  // ACCESS because uploading an animated avatar is a capability. ⚠️ The same read also chooses the CTA
+  // variant and triggers the upgrade prompt below, both of which are explanations and should be DISPLAY;
+  // splitting them needs copy for "your plan is active but we cannot verify it yet", which does not
+  // exist. Knowingly one read doing two jobs — do not flatten it to a single value either way.
   const weHavePro = useCurrentUserHasProAccess() && isMe;
 
   const avatarPath = useAvatarPath(conversationId) || '';

--- a/ts/components/dialog/EditProfilePictureModal.tsx
+++ b/ts/components/dialog/EditProfilePictureModal.tsx
@@ -43,7 +43,7 @@ import {
   useUpdateConversationDetailsModal,
 } from '../../state/selectors/modal';
 import { CTAVariant } from './cta/types';
-import { useCurrentUserHasProAccess } from '../../hooks/useHasPro';
+import { useCurrentUserHasPro, useCurrentUserHasProAccess } from '../../hooks/useHasPro';
 
 const StyledAvatarContainer = styled.div`
   cursor: pointer;
@@ -137,11 +137,10 @@ export const EditProfilePictureModal = ({ conversationId }: EditProfilePictureMo
 
   const isMe = useIsMe(conversationId);
   const isCommunity = useIsPublic(conversationId);
-  // ACCESS because uploading an animated avatar is a capability. ⚠️ The same read also chooses the CTA
-  // variant and triggers the upgrade prompt below, both of which are explanations and should be DISPLAY;
-  // splitting them needs copy for "your plan is active but we cannot verify it yet", which does not
-  // exist. Knowingly one read doing two jobs — do not flatten it to a single value either way.
+  // ACCESS gates the capability: uploading an animated avatar needs a usable proof, whatever the plan
+  // says. DISPLAY decides only what we tell the user about it — see both uses below.
   const weHavePro = useCurrentUserHasProAccess() && isMe;
+  const planReadsActive = useCurrentUserHasPro() && isMe;
 
   const avatarPath = useAvatarPath(conversationId) || '';
 
@@ -180,7 +179,9 @@ export const EditProfilePictureModal = ({ conversationId }: EditProfilePictureMo
     context: 'edit-profile-pic',
     args: {
       cta: {
-        variant: weHavePro
+        // DISPLAY: this badge explains the feature rather than granting it, so it describes the plan.
+        // A user mid-overhang (plan lapsed, proof still valid) is correctly offered the upgrade.
+        variant: planReadsActive
           ? CTAVariant.PRO_ANIMATED_DISPLAY_PICTURE_ACTIVATED
           : CTAVariant.PRO_ANIMATED_DISPLAY_PICTURE,
         afterActionButtonCallback,
@@ -232,14 +233,25 @@ export const EditProfilePictureModal = ({ conversationId }: EditProfilePictureMo
      * All of those are taken care of as part of the `isProUser` check in the conversation model
      */
     if (!weHavePro && isNewAvatarAnimated && !isCommunity) {
-      dispatch(
-        updateSessionCTA({
-          variant: CTAVariant.PRO_ANIMATED_DISPLAY_PICTURE,
-          afterActionButtonCallback,
-          actionButtonNextModalAfterCloseCallback,
-        })
+      // The refusal is ACCESS and unconditional. Whether we explain it by offering Pro is DISPLAY.
+      //
+      // TODO: an ACCEPTED trade, not an oversight. With an active plan and no usable proof this refuses
+      // the animated upload and says nothing, because every string that exists here offers a purchase
+      // and there is none for "your plan is active but we cannot verify it yet". Ruled deliberately so
+      // the two-value split was not blocked on a translation round for an edge case. When that copy
+      // exists, show it here — do NOT resolve this by putting the upsell back.
+      if (!planReadsActive) {
+        dispatch(
+          updateSessionCTA({
+            variant: CTAVariant.PRO_ANIMATED_DISPLAY_PICTURE,
+            afterActionButtonCallback,
+            actionButtonNextModalAfterCloseCallback,
+          })
+        );
+      }
+      window.log.debug(
+        `Attempted to upload an animated profile picture without pro! upsell shown: ${!planReadsActive}`
       );
-      window.log.debug('Attempted to upload an animated profile picture without pro!');
       return;
     }
 

--- a/ts/components/dialog/SessionCTA.tsx
+++ b/ts/components/dialog/SessionCTA.tsx
@@ -487,18 +487,23 @@ export const useShowSessionCTACbWithVariant = () => {
 };
 
 /**
- * Whether *this process* holds a `get_pro_status` it confirmed itself.
+ * Whether a Pro status has been confirmed in this run — a completed fetch, or the mocked equivalent.
  *
- * `details.lastFetchedMs` is per-run and stamped on completion, so it answers "may we act on the Pro
- * status we hold". Read off the store rather than threaded in as a parameter, so a new call site cannot
- * inherit an answer by copying a neighbour.
+ * Per-run rather than persisted: a stored status says what the backend last reported, not what it
+ * reports now, and the expiry CTAs are irreversible once shown. A launch whose status fetch is skipped
+ * or fails has confirmed nothing, however recently a previous launch did.
  *
- * Not read via the proBackendData selectors: they import the duck, and the duck imports this module.
+ * Lives here rather than in the Pro duck because the duck already depends on this module, and the
+ * dependency has to run one way.
  */
-function haveConfirmedProStatusThisProcess(): boolean {
-  const lastFetchedMs = (window.inboxStore?.getState() as StateType | undefined)?.proBackendData
-    ?.details?.lastFetchedMs;
-  return !!lastFetchedMs;
+let proStatusConfirmedThisRun = false;
+
+/**
+ * Record that a Pro status has been confirmed. Must be called before anything that can display a CTA
+ * derived from it, since the guard below reads this at the moment of display.
+ */
+export function markProStatusConfirmedThisRun() {
+  proStatusConfirmedThisRun = true;
 }
 
 export async function handleTriggeredCTAs(dispatch: Dispatch<any>, fromAppStart: boolean) {
@@ -512,7 +517,12 @@ export async function handleTriggeredCTAs(dispatch: Dispatch<any>, fromAppStart:
   const mayShowProCTA = haveConfirmedProStatusThisProcess();
 
   if (Storage.get(SettingsKey.proExpiringSoonCTA)) {
-    if (!mayShowProCTA) {
+    // An expiry CTA states something about the account, and showing it clears the mark, so it cannot be
+    // taken back. It therefore waits for a status confirmed in this run rather than for a moment that is
+    // merely past startup: a launch that skips or fails the status fetch knows nothing newer than the
+    // stored mark, and any later trigger — a conversation change, opening settings — would otherwise
+    // display it off that.
+    if (!proAvailable || !proStatusConfirmedThisRun) {
       return;
     }
     dispatch(
@@ -522,7 +532,7 @@ export async function handleTriggeredCTAs(dispatch: Dispatch<any>, fromAppStart:
     );
     await Storage.put(SettingsKey.proExpiringSoonCTA, false);
   } else if (Storage.get(SettingsKey.proExpiredCTA)) {
-    if (!mayShowProCTA) {
+    if (!proAvailable || !proStatusConfirmedThisRun) {
       return;
     }
     dispatch(

--- a/ts/components/dialog/SessionCTA.tsx
+++ b/ts/components/dialog/SessionCTA.tsx
@@ -506,6 +506,20 @@ export function markProStatusConfirmedThisRun() {
   proStatusConfirmedThisRun = true;
 }
 
+/**
+ * Whether a Pro settings screen is open.
+ *
+ * These CTAs are raised by a DATA event — the first confirmed status of the run — so unlike a CTA raised
+ * from a view they can land wherever the user happens to be, including on the one screen that already
+ * states the plan and offers the same action. Raising it there talks over a better answer, so it waits;
+ * the mark is not cleared, and the next trigger shows it somewhere it adds something.
+ */
+function aProSettingsScreenIsOpen(): boolean {
+  const page = window.inboxStore?.getState().modals.userSettingsModal?.userSettingsPage;
+
+  return page === 'pro' || page === 'proNonOriginating';
+}
+
 export async function handleTriggeredCTAs(dispatch: Dispatch<any>, fromAppStart: boolean) {
   // The Pro CTAs must never fire off an unconfirmed status: the flags are persisted, so a previous run's
   // "expired" verdict outlives the entitlement it described, and showing it after an out-of-band renewal
@@ -522,7 +536,7 @@ export async function handleTriggeredCTAs(dispatch: Dispatch<any>, fromAppStart:
     // merely past startup: a launch that skips or fails the status fetch knows nothing newer than the
     // stored mark, and any later trigger — a conversation change, opening settings — would otherwise
     // display it off that.
-    if (!proAvailable || !proStatusConfirmedThisRun) {
+    if (!proAvailable || !proStatusConfirmedThisRun || aProSettingsScreenIsOpen()) {
       return;
     }
     dispatch(
@@ -532,7 +546,7 @@ export async function handleTriggeredCTAs(dispatch: Dispatch<any>, fromAppStart:
     );
     await Storage.put(SettingsKey.proExpiringSoonCTA, false);
   } else if (Storage.get(SettingsKey.proExpiredCTA)) {
-    if (!proAvailable || !proStatusConfirmedThisRun) {
+    if (!proAvailable || !proStatusConfirmedThisRun || aProSettingsScreenIsOpen()) {
       return;
     }
     dispatch(

--- a/ts/components/dialog/SessionCTA.tsx
+++ b/ts/components/dialog/SessionCTA.tsx
@@ -3,7 +3,6 @@ import { Dispatch, useMemo, type ReactNode } from 'react';
 import styled from 'styled-components';
 import type { CSSProperties } from 'styled-components';
 import { getAppDispatch } from '../../state/dispatch';
-import type { StateType } from '../../state/reducer';
 import {
   type SessionCTAState,
   updateSessionCTA,
@@ -528,7 +527,6 @@ export async function handleTriggeredCTAs(dispatch: Dispatch<any>, fromAppStart:
   //
   // `fromAppStart` is still needed below, where it *enables* the donate CTA rather than suppressing a
   // Pro one. Those are different questions and must not be collapsed into one flag.
-  const mayShowProCTA = haveConfirmedProStatusThisProcess();
 
   if (Storage.get(SettingsKey.proExpiringSoonCTA)) {
     // An expiry CTA states something about the account, and showing it clears the mark, so it cannot be
@@ -536,7 +534,7 @@ export async function handleTriggeredCTAs(dispatch: Dispatch<any>, fromAppStart:
     // merely past startup: a launch that skips or fails the status fetch knows nothing newer than the
     // stored mark, and any later trigger — a conversation change, opening settings — would otherwise
     // display it off that.
-    if (!proAvailable || !proStatusConfirmedThisRun || aProSettingsScreenIsOpen()) {
+    if (!proStatusConfirmedThisRun || aProSettingsScreenIsOpen()) {
       return;
     }
     dispatch(
@@ -546,7 +544,7 @@ export async function handleTriggeredCTAs(dispatch: Dispatch<any>, fromAppStart:
     );
     await Storage.put(SettingsKey.proExpiringSoonCTA, false);
   } else if (Storage.get(SettingsKey.proExpiredCTA)) {
-    if (!proAvailable || !proStatusConfirmedThisRun || aProSettingsScreenIsOpen()) {
+    if (!proStatusConfirmedThisRun || aProSettingsScreenIsOpen()) {
       return;
     }
     dispatch(

--- a/ts/components/dialog/conversationSettings/ConversationTitleDialog.tsx
+++ b/ts/components/dialog/conversationSettings/ConversationTitleDialog.tsx
@@ -1,4 +1,4 @@
-import { useCurrentUserHasProAccess, useShowProBadgeFor } from '../../../hooks/useHasPro';
+import { useCurrentUserHasPro, useShowProBadgeFor } from '../../../hooks/useHasPro';
 import {
   useIsPublic,
   useIsClosedGroup,
@@ -27,7 +27,11 @@ function useOnTitleClickCb(conversationId: string, editable: boolean) {
 }
 
 function ProBadge({ conversationId }: WithConvoId) {
-  const weArePro = useCurrentUserHasProAccess();
+  // DISPLAY, not ACCESS: this only decides whether tapping someone else's badge invites us to buy
+  // Pro. The gate reads ACCESS; the thing that explains or sells the gate reads DISPLAY, so a user
+  // whose plan reads active is never upsold — and one in the overhang, whose plan has lapsed while
+  // the proof still works, is.
+  const weArePro = useCurrentUserHasPro();
 
   const showProBadgeForUser = useShowProBadgeFor(conversationId);
   const isMe = useIsMe(conversationId);

--- a/ts/components/dialog/conversationSettings/ConversationTitleDialog.tsx
+++ b/ts/components/dialog/conversationSettings/ConversationTitleDialog.tsx
@@ -1,4 +1,4 @@
-import { useCurrentUserHasPro, useShowProBadgeFor } from '../../../hooks/useHasPro';
+import { useShowProBadgeFor } from '../../../hooks/useHasPro';
 import {
   useIsPublic,
   useIsClosedGroup,
@@ -31,7 +31,6 @@ function ProBadge({ conversationId }: WithConvoId) {
   // Pro. The gate reads ACCESS; the thing that explains or sells the gate reads DISPLAY, so a user
   // whose plan reads active is never upsold — and one in the overhang, whose plan has lapsed while
   // the proof still works, is.
-  const weArePro = useCurrentUserHasPro();
 
   const showProBadgeForUser = useShowProBadgeFor(conversationId);
   const isMe = useIsMe(conversationId);
@@ -39,7 +38,7 @@ function ProBadge({ conversationId }: WithConvoId) {
 
   const onProClickCb = useProBadgeOnClickCb({
     context: 'conversation-title-dialog',
-    args: { userHasPro: showProBadgeForUser, currentUserHasPro: weArePro, isMe, isGroupV2 },
+    args: { userHasPro: showProBadgeForUser, isMe, isGroupV2 },
   });
 
   if (!onProClickCb.show) {

--- a/ts/components/dialog/conversationSettings/ConversationTitleDialog.tsx
+++ b/ts/components/dialog/conversationSettings/ConversationTitleDialog.tsx
@@ -1,4 +1,4 @@
-import { useCurrentUserHasPro, useShowProBadgeFor } from '../../../hooks/useHasPro';
+import { useCurrentUserHasProAccess, useShowProBadgeFor } from '../../../hooks/useHasPro';
 import {
   useIsPublic,
   useIsClosedGroup,
@@ -27,7 +27,7 @@ function useOnTitleClickCb(conversationId: string, editable: boolean) {
 }
 
 function ProBadge({ conversationId }: WithConvoId) {
-  const weArePro = useCurrentUserHasPro();
+  const weArePro = useCurrentUserHasProAccess();
 
   const showProBadgeForUser = useShowProBadgeFor(conversationId);
   const isMe = useIsMe(conversationId);

--- a/ts/components/dialog/debug/FeatureFlags.tsx
+++ b/ts/components/dialog/debug/FeatureFlags.tsx
@@ -965,7 +965,6 @@ export const ProDebugSection = ({
         ]}
         forceUpdate={forceUpdate}
         unsetOption={{ label: 'Use the actual proof', value: null }}
-        visibleWithBooleanFlag="proAvailable"
       />
       <i>
         Status above is what the plan DISPLAYS; proof here is what the app may DO. They are separate

--- a/ts/components/dialog/debug/FeatureFlags.tsx
+++ b/ts/components/dialog/debug/FeatureFlags.tsx
@@ -8,6 +8,7 @@ import {
   getDataFeatureFlag,
   getFeatureFlag,
   MockProAccessExpiryOptions,
+  MockProProofOptions,
   SessionDataFeatureFlags,
   getDataFeatureFlagMemo,
   type SessionDataFeatureFlagKeys,
@@ -955,6 +956,22 @@ export const ProDebugSection = ({
         forceUpdate={forceUpdate}
         unsetOption={{ label: 'Select Current Status', value: null }}
       />
+      <FlagEnumDropdownInput
+        label="Proof (access)"
+        flag="mockProProof"
+        options={[
+          { label: 'Holds a valid proof', value: MockProProofOptions.Valid },
+          { label: 'Holds no usable proof', value: MockProProofOptions.None },
+        ]}
+        forceUpdate={forceUpdate}
+        unsetOption={{ label: 'Use the actual proof', value: null }}
+        visibleWithBooleanFlag="proAvailable"
+      />
+      <i>
+        Status above is what the plan DISPLAYS; proof here is what the app may DO. They are separate
+        on purpose — active-with-no-proof is the state where a long message is accepted and then
+        truncated for the recipient.
+      </i>
       {proBooleanFlags.map(props => (
         <FlagToggle {...props} key={props.flag} forceUpdate={forceUpdate} />
       ))}

--- a/ts/components/dialog/user-settings/components.tsx
+++ b/ts/components/dialog/user-settings/components.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { Avatar, AvatarSize } from '../../avatar/Avatar';
 import { Flex } from '../../basic/Flex';
 import { useProBadgeOnClickCb } from '../../menuAndSettingsHooks/useProBadgeOnClickCb';
-import { useCurrentUserHasExpiredPro, useCurrentUserHasPro } from '../../../hooks/useHasPro';
+import { useCurrentUserHasExpiredPro } from '../../../hooks/useHasPro';
 import { ProIconButton } from '../../buttons/ProButton';
 import { AvatarQrCodeButton } from '../../buttons/avatar/AvatarQrCodeButton';
 import { createButtonOnKeyDownForClickEventHandler } from '../../../util/keyboardShortcuts';
@@ -110,12 +110,11 @@ const StyledName = styled.div`
 export const ProfileName = (props: { profileName: string; onClick: () => void }) => {
   const { profileName, onClick } = props;
 
-  const currentUserHasPro = useCurrentUserHasPro();
   const currentUserHasExpiredPro = useCurrentUserHasExpiredPro();
 
   const showPro = useProBadgeOnClickCb({
     context: 'show-our-profile-dialog',
-    args: { currentUserHasPro, currentUserHasExpiredPro, providedCb: onClick },
+    args: { providedCb: onClick },
   });
   const onKeyDown = createButtonOnKeyDownForClickEventHandler(onClick);
 

--- a/ts/components/dialog/user-settings/components/SettingsChevronBasic.tsx
+++ b/ts/components/dialog/user-settings/components/SettingsChevronBasic.tsx
@@ -1,5 +1,5 @@
 import type { SettingsChevron } from 'react';
-import { PanelButtonTextWithSubText } from '../../../buttons/panel/PanelButton';
+import { PanelButtonText, PanelButtonTextWithSubText } from '../../../buttons/panel/PanelButton';
 import { PanelChevronButton } from '../../../buttons/panel/PanelChevronButton';
 import type { TrArgs } from '../../../../localization/localeTools';
 
@@ -12,7 +12,8 @@ export function SettingsChevronBasic({
   loading,
 }: {
   text: TrArgs;
-  subText: TrArgs;
+  /** Omit to render the row with no second line at all, rather than a placeholder standing in for one. */
+  subText?: TrArgs;
   subTextColor?: string;
   baseDataTestId: SettingsChevron;
   onClick: (() => Promise<void>) | (() => void);
@@ -21,13 +22,17 @@ export function SettingsChevronBasic({
   return (
     <PanelChevronButton
       textElement={
-        <PanelButtonTextWithSubText
-          text={text}
-          subText={subText}
-          subTextColorOverride={subTextColor}
-          textDataTestId={`${baseDataTestId}-settings-text`}
-          subTextDataTestId={`${baseDataTestId}-settings-sub-text`}
-        />
+        subText ? (
+          <PanelButtonTextWithSubText
+            text={text}
+            subText={subText}
+            subTextColorOverride={subTextColor}
+            textDataTestId={`${baseDataTestId}-settings-text`}
+            subTextDataTestId={`${baseDataTestId}-settings-sub-text`}
+          />
+        ) : (
+          <PanelButtonText text={text} textDataTestId={`${baseDataTestId}-settings-text`} />
+        )
       }
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       onClick={onClick}

--- a/ts/components/dialog/user-settings/pages/DefaultSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/DefaultSettingsPage.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import styled from 'styled-components';
-import useMount from 'react-use/lib/useMount';
 import { getAppDispatch } from '../../../../state/dispatch';
 import { useOurConversationUsername, useOurAvatarPath } from '../../../../hooks/useParamSelector';
 import { UserUtils, ToastUtils } from '../../../../session/utils';
@@ -37,7 +36,6 @@ import { UserSettingsModalContainer } from '../components/UserSettingsModalConta
 import { useCurrentUserHasExpiredPro, useCurrentUserHasPro } from '../../../../hooks/useHasPro';
 import { APP_URL } from '../../../../session/constants';
 import { useUserSettingsCloseAction } from './userSettingsHooks';
-import { useProBackendRefetch } from '../../../../state/selectors/proBackendData';
 import { focusVisibleBoxShadowOutsetStr } from '../../../../styles/focusVisible';
 import { createButtonOnKeyDownForClickEventHandler } from '../../../../util/keyboardShortcuts';
 import { useDebugMode } from '../../../../state/selectors/debug';
@@ -319,7 +317,6 @@ const SessionInfo = () => {
 export const DefaultSettingPage = (modalState: UserSettingsModalState) => {
   const dispatch = getAppDispatch();
   const closeAction = useUserSettingsCloseAction(modalState);
-  const refetch = useProBackendRefetch();
 
   const profileName = useOurConversationUsername() || '';
   const [enlargedImage, setEnlargedImage] = useState(false);
@@ -337,15 +334,6 @@ export const DefaultSettingPage = (modalState: UserSettingsModalState) => {
     window.clipboard.writeText(us);
     ToastUtils.pushCopiedToClipBoard();
   }
-
-  useMount(() => {
-    // Trigger #3: opportunistic refresh when opening the settings, floored (cached-if-fresh).
-    //
-    // Unthrottled on purpose: the status floor owns the 60s bound, and it is persisted, so it holds
-    // across the relaunches that a per-run throttle here would be defeated by. A second throttle would
-    // only give two answers to the same question.
-    void refetch();
-  });
 
   return (
     <UserSettingsModalContainer

--- a/ts/components/dialog/user-settings/pages/user-pro/ProNonOriginatingPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProNonOriginatingPage.tsx
@@ -112,6 +112,13 @@ function useProStoresList(): string {
 
 function ProStatusTextUpdate() {
   const { data } = useProBackendProStatusLocal();
+
+  // Both strings below are a date and nothing else, so with no date there is no sentence to render.
+  // Absent beats a sentence with a hole in it, and beats a date we would have had to invent.
+  if (!data.expiryTimeMs) {
+    return null;
+  }
+
   return data.autoRenew ? (
     <Localizer
       token="proAccessActivatedAutoShort"

--- a/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
@@ -581,7 +581,7 @@ function ProSettings({ state }: SectionProps) {
     return null;
   }
 
-  let subText: TrArgs;
+  let subText: TrArgs | undefined;
   if (isError) {
     subText = { token: 'errorLoadingProAccess' };
   } else if (isLoading) {
@@ -591,17 +591,18 @@ function ProSettings({ state }: SectionProps) {
     // suppressed by the no-date case. It is the message that is most correct when a fetch is struggling.
     subText = { token: 'proRenewalUnsuccessful' };
   } else if (!data.expiryTimeMs) {
-    // No date yet — only a status response carries one. Say we are still finding out rather than
-    // render "expiring in " with a hole where the time should be.
+    // No date, so no second line. Every string available here is about when access ends, and inventing
+    // one from a missing value produces a plausible-looking lie rather than an obvious gap: "expiring in
+    // " with a hole in it, or "expires in 0 minutes". iOS and Android both render nothing here for the
+    // same reason.
     //
-    // ⚠️ This reads "still finding out" from the ABSENCE of a date, so it assumes every plan that exists
-    // has one. That holds for the periodic plans, but libsession's plan grammar already includes a
-    // `lifetime` unit (planCount 0), which `planPeriodToString` renders as "Lifetime" a few rows up. If a
-    // lifetime account ever reports an expiry of 0 rather than a far-future instant, this branch is
-    // permanent and the row sits on "loading…" forever beside a plan name that is perfectly healthy.
-    // Whoever wires lifetime up needs a third case here — no expiry BECAUSE there is none — distinct
-    // from no expiry YET.
-    subText = { token: 'proAccessLoadingEllipsis' };
+    // "Still loading" would be the same mistake in a quieter form — it asserts that a date is on its way,
+    // which is true while a fetch is in flight and false for a plan that simply has no expiry.
+    // libsession's plan grammar already includes a `lifetime` unit (planCount 0), which
+    // `planPeriodToString` renders as "Lifetime" a few rows up; the backend cannot issue one yet, and
+    // what `account_expiry_ts` would carry for a perpetual entitlement is not specified. Rendering
+    // nothing is correct either way, which is why this needs no case of its own.
+    subText = undefined;
   } else if (data.autoRenew) {
     subText = { token: 'proAutoRenewTime', time: data.expiryTimeRelativeString };
   } else {

--- a/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
@@ -593,6 +593,14 @@ function ProSettings({ state }: SectionProps) {
   } else if (!data.expiryTimeMs) {
     // No date yet — only a status response carries one. Say we are still finding out rather than
     // render "expiring in " with a hole where the time should be.
+    //
+    // ⚠️ This reads "still finding out" from the ABSENCE of a date, so it assumes every plan that exists
+    // has one. That holds for the periodic plans, but libsession's plan grammar already includes a
+    // `lifetime` unit (planCount 0), which `planPeriodToString` renders as "Lifetime" a few rows up. If a
+    // lifetime account ever reports an expiry of 0 rather than a far-future instant, this branch is
+    // permanent and the row sits on "loading…" forever beside a plan name that is perfectly healthy.
+    // Whoever wires lifetime up needs a third case here — no expiry BECAUSE there is none — distinct
+    // from no expiry YET.
     subText = { token: 'proAccessLoadingEllipsis' };
   } else if (data.autoRenew) {
     subText = { token: 'proAutoRenewTime', time: data.expiryTimeRelativeString };

--- a/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
@@ -191,7 +191,9 @@ export function ProHeroImage({
         </StyledProStatusText>
       ) : null}
       {heroStatusText && heroText ? <SpacerMD /> : null}
-      {heroText ? <StyledProHeroText>{heroText}</StyledProHeroText> : null}
+      {heroText ? (
+        <StyledProHeroText data-testid="pro-settings-description">{heroText}</StyledProHeroText>
+      ) : null}
     </SectionFlexContainer>
   );
 }

--- a/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
@@ -259,7 +259,7 @@ function useKeepProStatusFresh({
   isLoading: boolean;
   isError: boolean;
 }) {
-  // Keep get_pro_status fresh around the paid-through end while the pro page is open, so the "renewal
+  // Keep get_pro_status fresh around the payment-due instant while the pro page is open, so the "renewal
   // unsuccessful" warning reflects reality rather than a pre-expiry snapshot. Without it, a renewal
   // that lands while the page is open isn't picked up until the page is closed and reopened.
   useEffect(() => {

--- a/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
@@ -186,7 +186,9 @@ export function ProHeroImage({
         </HeroImageBgContainer>
       </SectionFlexContainer>
       {heroStatusText ? (
-        <StyledProStatusText $isError={isError}>{heroStatusText}</StyledProStatusText>
+        <StyledProStatusText $isError={isError} data-testid="pro-settings-status-banner">
+          {heroStatusText}
+        </StyledProStatusText>
       ) : null}
       {heroStatusText && heroText ? <SpacerMD /> : null}
       {heroText ? <StyledProHeroText>{heroText}</StyledProHeroText> : null}
@@ -416,6 +418,7 @@ function ProStats() {
     <SectionFlexContainer>
       <PanelLabelWithDescription
         title={{ token: 'proStats' }}
+        dataTestId="pro-settings-stats-header"
         extraInlineNode={
           <SessionTooltip
             content={tr('proStatsTooltip')}
@@ -803,7 +806,10 @@ function ProFeatures({ state }: SectionProps) {
 
   return (
     <SectionFlexContainer>
-      <PanelLabelWithDescription title={{ token: 'proBetaFeatures' }} />
+      <PanelLabelWithDescription
+        title={{ token: 'proBetaFeatures' }}
+        dataTestId="pro-settings-features-header"
+      />
       <PanelButtonGroup containerStyle={{ marginBlock: 'var(--margins-xs)' }}>
         {proFeatures.map((m, i) => {
           return (
@@ -863,7 +869,10 @@ function ManageProCurrentAccess({ state }: SectionProps) {
 
   return (
     <SectionFlexContainer>
-      <PanelLabelWithDescription title={{ token: 'managePro' }} />
+      <PanelLabelWithDescription
+        title={{ token: 'managePro' }}
+        dataTestId="pro-settings-manage-header"
+      />
       <PanelButtonGroup>
         {data.autoRenew ? (
           <PanelIconButton
@@ -940,7 +949,10 @@ function ManageProAccess({ state }: SectionProps) {
 
   return (
     <SectionFlexContainer>
-      <PanelLabelWithDescription title={{ token: 'managePro' }} />
+      <PanelLabelWithDescription
+        title={{ token: 'managePro' }}
+        dataTestId="pro-settings-manage-header"
+      />
       <PanelButtonGroup
         style={
           !isDarkTheme

--- a/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
@@ -7,6 +7,7 @@ import {
   useMemo,
   type ReactNode,
 } from 'react';
+import useMount from 'react-use/lib/useMount';
 import useUpdate from 'react-use/lib/useUpdate';
 import styled from 'styled-components';
 import { getAppDispatch } from '../../../../../state/dispatch';
@@ -1142,6 +1143,14 @@ export function ProSettingsPage(modalState: {
   const dispatch = getAppDispatch();
   const backAction = useUserSettingsBackAction(modalState);
   const closeAction = useUserSettingsCloseAction(modalState);
+  const refetch = useProBackendRefetch();
+
+  // Confirm our status on reaching this screen, so what it shows is not an arbitrarily old snapshot.
+  // Deliberately not `immediate`: the thunk's persisted floor is what keeps repeatedly reopening the
+  // page from repeatedly hitting the backend, and this is the trigger that floor exists to bound.
+  useMount(() => {
+    refetch();
+  });
 
   const returnToThisModalAction = useCallback(() => {
     dispatch(userSettingsModal(modalState));

--- a/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
@@ -584,7 +584,13 @@ function ProSettings({ state }: SectionProps) {
   } else if (isLoading) {
     subText = { token: 'proAccessLoadingEllipsis' };
   } else if (data.inGracePeriod) {
+    // Deliberately ahead of the two branches below: this one needs no date, so it must not be
+    // suppressed by the no-date case. It is the message that is most correct when a fetch is struggling.
     subText = { token: 'proRenewalUnsuccessful' };
+  } else if (!data.expiryTimeMs) {
+    // No date yet — only a status response carries one. Say we are still finding out rather than
+    // render "expiring in " with a hole where the time should be.
+    subText = { token: 'proAccessLoadingEllipsis' };
   } else if (data.autoRenew) {
     subText = { token: 'proAutoRenewTime', time: data.expiryTimeRelativeString };
   } else {

--- a/ts/components/leftpane/ActionsPanel.tsx
+++ b/ts/components/leftpane/ActionsPanel.tsx
@@ -60,7 +60,7 @@ import {
 import { useDebugKey } from '../../hooks/useDebugKey';
 import { UpdateProRevocationList } from '../../session/utils/job_runners/jobs/UpdateProRevocationListJob';
 import { getIsAppFocused } from '../../state/selectors/section';
-import { evaluateStartupProStatusFetch } from '../../state/ducks/proBackendData';
+import { refreshProStatusOnStartupIfNeeded } from '../../state/ducks/proBackendData';
 import { SettingsKey } from '../../data/settings-key';
 import { useKeyboardShortcut } from '../../hooks/useKeyboardShortcut';
 import { KbdShortcut } from '../../util/keyboardShortcuts';
@@ -143,6 +143,10 @@ function usePeriodicFetchRevocationList() {
  * anything, so this cannot turn into a fetch per focus.
  */
 function useProStatusGateOnAppFocus() {
+  // The startup caller suppresses the gate when the mocks have already answered for this run; on this
+  // path there is no such caller, so the check belongs here. Without it a focus event lets a real
+  // response land on top of a mocked CTA decision, which is the case the startup suppression exists for.
+  const proStatusMocked = getFeatureFlagMemo('mockProBackendSuccess');
   const isAppFocused = useSelector(getIsAppFocused);
   const wasAppFocused = useRef(isAppFocused);
 
@@ -150,11 +154,11 @@ function useProStatusGateOnAppFocus() {
     const regainedFocus = isAppFocused && !wasAppFocused.current;
     wasAppFocused.current = isAppFocused;
 
-    if (!regainedFocus) {
+    if (proStatusMocked || !regainedFocus) {
       return;
     }
-    void evaluateStartupProStatusFetch();
-  }, [isAppFocused]);
+    void refreshProStatusOnStartupIfNeeded();
+  }, [isAppFocused, proStatusMocked]);
 }
 
 function useKeyboardShortcutsModalKeyboardShortcut() {

--- a/ts/components/leftpane/ActionsPanel.tsx
+++ b/ts/components/leftpane/ActionsPanel.tsx
@@ -59,7 +59,6 @@ import {
 } from '../../state/ducks/types/releasedFeaturesReduxTypes';
 import { useDebugKey } from '../../hooks/useDebugKey';
 import { UpdateProRevocationList } from '../../session/utils/job_runners/jobs/UpdateProRevocationListJob';
-import { getIsProAvailableMemo } from '../../hooks/useIsProAvailable';
 import { getIsAppFocused } from '../../state/selectors/section';
 import { evaluateStartupProStatusFetch } from '../../state/ducks/proBackendData';
 import { SettingsKey } from '../../data/settings-key';
@@ -144,7 +143,6 @@ function usePeriodicFetchRevocationList() {
  * anything, so this cannot turn into a fetch per focus.
  */
 function useProStatusGateOnAppFocus() {
-  const proAvailable = getIsProAvailableMemo();
   const isAppFocused = useSelector(getIsAppFocused);
   const wasAppFocused = useRef(isAppFocused);
 
@@ -152,11 +150,11 @@ function useProStatusGateOnAppFocus() {
     const regainedFocus = isAppFocused && !wasAppFocused.current;
     wasAppFocused.current = isAppFocused;
 
-    if (!proAvailable || !regainedFocus) {
+    if (!regainedFocus) {
       return;
     }
     void evaluateStartupProStatusFetch();
-  }, [isAppFocused, proAvailable]);
+  }, [isAppFocused]);
 }
 
 function useKeyboardShortcutsModalKeyboardShortcut() {

--- a/ts/components/leftpane/ActionsPanel.tsx
+++ b/ts/components/leftpane/ActionsPanel.tsx
@@ -1,5 +1,5 @@
 import { ipcRenderer } from 'electron';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { debounce } from 'lodash';
 
 import { useSelector } from 'react-redux';
@@ -59,6 +59,9 @@ import {
 } from '../../state/ducks/types/releasedFeaturesReduxTypes';
 import { useDebugKey } from '../../hooks/useDebugKey';
 import { UpdateProRevocationList } from '../../session/utils/job_runners/jobs/UpdateProRevocationListJob';
+import { getIsProAvailableMemo } from '../../hooks/useIsProAvailable';
+import { getIsAppFocused } from '../../state/selectors/section';
+import { evaluateStartupProStatusFetch } from '../../state/ducks/proBackendData';
 import { SettingsKey } from '../../data/settings-key';
 import { useKeyboardShortcut } from '../../hooks/useKeyboardShortcut';
 import { KbdShortcut } from '../../util/keyboardShortcuts';
@@ -125,6 +128,35 @@ function usePeriodicFetchRevocationList() {
     // Note: we tick every 15 minutes in prod, but the job won't be added unless it needs to
     isDevProd() ? 15 * DURATION.SECONDS : 15 * DURATION.MINUTES
   );
+}
+
+/**
+ * Re-evaluate the cold-launch Pro status gate whenever the app regains focus.
+ *
+ * Desktop is left running for days, so "at launch" can be a long time ago. The expiring-soon CTA arms
+ * seven days before the access expiry and nothing else fires before that window opens, so a subscriber
+ * who crosses into it while the window sits in the background would not be warned until a cold start.
+ *
+ * Focus rather than `activate`: `activate` only fires on macOS and only re-shows the window, which
+ * raises focus anyway, so focus is the event that covers every platform and every way back in.
+ *
+ * The gate itself decides whether anything happens — inside the interval it declines before reading
+ * anything, so this cannot turn into a fetch per focus.
+ */
+function useProStatusGateOnAppFocus() {
+  const proAvailable = getIsProAvailableMemo();
+  const isAppFocused = useSelector(getIsAppFocused);
+  const wasAppFocused = useRef(isAppFocused);
+
+  useEffect(() => {
+    const regainedFocus = isAppFocused && !wasAppFocused.current;
+    wasAppFocused.current = isAppFocused;
+
+    if (!proAvailable || !regainedFocus) {
+      return;
+    }
+    void evaluateStartupProStatusFetch();
+  }, [isAppFocused, proAvailable]);
 }
 
 function useKeyboardShortcutsModalKeyboardShortcut() {
@@ -259,6 +291,7 @@ export const ActionsPanel = () => {
   useDebugFocusScope();
   useUpdateBadgeCount();
   usePeriodicFetchRevocationList();
+  useProStatusGateOnAppFocus();
   useKeyboardShortcutsModalKeyboardShortcut();
   useUserSettingsModalKeyboardShortcut();
   useNewConversationKeyboardShortcut();

--- a/ts/components/menuAndSettingsHooks/UseTogglePinConversationHandler.tsx
+++ b/ts/components/menuAndSettingsHooks/UseTogglePinConversationHandler.tsx
@@ -75,12 +75,8 @@ export function useTogglePinConversationHandler(id: string) {
   // explain the refusal by offering Pro, and that is DISPLAY: a plan reading active must not be sold a
   // subscription it is already paying for.
   //
-  // Blocked on copy, and an accepted trade rather than an oversight. In the active-plan-with-no-usable-
-  // proof state this refuses the pin and says nothing at all, because the only copy that exists here is
-  // upsell copy and there is no string for "your plan is active but we cannot verify it yet". Accepted
-  // deliberately rather than missed, so that the two-value split was not held up by a translation round
-  // for an edge case. When that string lands, show it here — do NOT resolve this by putting the upsell
-  // back.
+  // Which leaves the active-plan-with-no-usable-proof state refused silently: the only copy available
+  // here is upsell copy, and there is none for a plan that is already active.
   if (planReadsActive) {
     return () => {
       window.log.debug(

--- a/ts/components/menuAndSettingsHooks/UseTogglePinConversationHandler.tsx
+++ b/ts/components/menuAndSettingsHooks/UseTogglePinConversationHandler.tsx
@@ -10,7 +10,7 @@ import {
 import { useShowSessionCTACbWithVariant } from '../dialog/SessionCTA';
 import { Constants } from '../../session';
 import { useIsMessageRequestOverlayShown } from '../../state/selectors/section';
-import { useCurrentUserHasPro } from '../../hooks/useHasPro';
+import { useCurrentUserHasProAccess } from '../../hooks/useHasPro';
 import { CTAVariant } from '../dialog/cta/types';
 import { getPinnedConversationsCount } from '../../state/selectors/conversations';
 
@@ -41,7 +41,7 @@ function usePinnedConversationCount() {
 }
 
 // NOTE: [react-compiler] this convinces the compiler the hook is static
-const useHasProInternal = useCurrentUserHasPro;
+const useHasProInternal = useCurrentUserHasProAccess;
 const useIsPinnedInternal = useIsPinned;
 const useCTACallbackInternal = useShowSessionCTACbWithVariant;
 

--- a/ts/components/menuAndSettingsHooks/UseTogglePinConversationHandler.tsx
+++ b/ts/components/menuAndSettingsHooks/UseTogglePinConversationHandler.tsx
@@ -77,7 +77,7 @@ export function useTogglePinConversationHandler(id: string) {
   //
   // TODO: an ACCEPTED trade, not an oversight. In the active-plan-with-no-usable-proof state this
   // refuses the pin and says nothing at all, because the only copy that exists here is upsell copy and
-  // there is no string for "your plan is active but we cannot verify it yet". Ruled deliberately rather
+  // there is no string for "your plan is active but we cannot verify it yet". Accepted deliberately rather
   // than missed, so that the two-value split was not blocked on a translation round for an edge case.
   // When that copy exists, show it here — do NOT resolve this by putting the upsell back.
   if (planReadsActive) {

--- a/ts/components/menuAndSettingsHooks/UseTogglePinConversationHandler.tsx
+++ b/ts/components/menuAndSettingsHooks/UseTogglePinConversationHandler.tsx
@@ -40,6 +40,10 @@ function usePinnedConversationCount() {
   return useSelector(getPinnedConversationsCount);
 }
 
+// ACCESS because pinning past the standard limit is a capability, not a plan state — someone with no
+// usable proof genuinely must not pin. ⚠️ The same read also picks the upsell below, which by the
+// gate/explanation rule should be DISPLAY; splitting them needs copy that does not exist yet, so this is
+// knowingly one read doing two jobs. Do not "tidy" it to a single value in either direction.
 // NOTE: [react-compiler] this convinces the compiler the hook is static
 const useHasProInternal = useCurrentUserHasProAccess;
 const useIsPinnedInternal = useIsPinned;

--- a/ts/components/menuAndSettingsHooks/UseTogglePinConversationHandler.tsx
+++ b/ts/components/menuAndSettingsHooks/UseTogglePinConversationHandler.tsx
@@ -75,11 +75,12 @@ export function useTogglePinConversationHandler(id: string) {
   // explain the refusal by offering Pro, and that is DISPLAY: a plan reading active must not be sold a
   // subscription it is already paying for.
   //
-  // TODO: an ACCEPTED trade, not an oversight. In the active-plan-with-no-usable-proof state this
-  // refuses the pin and says nothing at all, because the only copy that exists here is upsell copy and
-  // there is no string for "your plan is active but we cannot verify it yet". Accepted deliberately rather
-  // than missed, so that the two-value split was not blocked on a translation round for an edge case.
-  // When that copy exists, show it here — do NOT resolve this by putting the upsell back.
+  // Blocked on copy, and an accepted trade rather than an oversight. In the active-plan-with-no-usable-
+  // proof state this refuses the pin and says nothing at all, because the only copy that exists here is
+  // upsell copy and there is no string for "your plan is active but we cannot verify it yet". Accepted
+  // deliberately rather than missed, so that the two-value split was not held up by a translation round
+  // for an edge case. When that string lands, show it here — do NOT resolve this by putting the upsell
+  // back.
   if (planReadsActive) {
     return () => {
       window.log.debug(

--- a/ts/components/menuAndSettingsHooks/UseTogglePinConversationHandler.tsx
+++ b/ts/components/menuAndSettingsHooks/UseTogglePinConversationHandler.tsx
@@ -10,7 +10,7 @@ import {
 import { useShowSessionCTACbWithVariant } from '../dialog/SessionCTA';
 import { Constants } from '../../session';
 import { useIsMessageRequestOverlayShown } from '../../state/selectors/section';
-import { useCurrentUserHasProAccess } from '../../hooks/useHasPro';
+import { useCurrentUserHasPro, useCurrentUserHasProAccess } from '../../hooks/useHasPro';
 import { CTAVariant } from '../dialog/cta/types';
 import { getPinnedConversationsCount } from '../../state/selectors/conversations';
 
@@ -40,12 +40,12 @@ function usePinnedConversationCount() {
   return useSelector(getPinnedConversationsCount);
 }
 
-// ACCESS because pinning past the standard limit is a capability, not a plan state — someone with no
-// usable proof genuinely must not pin. ⚠️ The same read also picks the upsell below, which by the
-// gate/explanation rule should be DISPLAY; splitting them needs copy that does not exist yet, so this is
-// knowingly one read doing two jobs. Do not "tidy" it to a single value in either direction.
+// ACCESS gates the pin: pinning past the standard limit is a capability, and someone holding no usable
+// proof genuinely must not do it whatever their plan says. DISPLAY decides only whether we then offer to
+// sell them something — see the split at the end of the hook.
 // NOTE: [react-compiler] this convinces the compiler the hook is static
 const useHasProInternal = useCurrentUserHasProAccess;
+const usePlanReadsActiveInternal = useCurrentUserHasPro;
 const useIsPinnedInternal = useIsPinned;
 const useCTACallbackInternal = useShowSessionCTACbWithVariant;
 
@@ -54,6 +54,7 @@ export function useTogglePinConversationHandler(id: string) {
   const isPinned = useIsPinnedInternal(id);
   const pinnedConversationsCount = usePinnedConversationCount();
   const hasPro = useHasProInternal();
+  const planReadsActive = usePlanReadsActiveInternal();
   const handleShowProDialog = useCTACallbackInternal();
 
   const showPinUnpin = useShowPinUnpin(id);
@@ -68,6 +69,23 @@ export function useTogglePinConversationHandler(id: string) {
     pinnedConversationsCount < Constants.CONVERSATION.MAX_PINNED_CONVERSATIONS_STANDARD
   ) {
     return () => conversation?.togglePinned();
+  }
+
+  // Refused either way — the gate above is ACCESS and has already decided. What differs is whether we
+  // explain the refusal by offering Pro, and that is DISPLAY: a plan reading active must not be sold a
+  // subscription it is already paying for.
+  //
+  // TODO: an ACCEPTED trade, not an oversight. In the active-plan-with-no-usable-proof state this
+  // refuses the pin and says nothing at all, because the only copy that exists here is upsell copy and
+  // there is no string for "your plan is active but we cannot verify it yet". Ruled deliberately rather
+  // than missed, so that the two-value split was not blocked on a translation round for an edge case.
+  // When that copy exists, show it here — do NOT resolve this by putting the upsell back.
+  if (planReadsActive) {
+    return () => {
+      window.log.debug(
+        '[pro] pin refused: no usable Pro proof, and the plan reads active so no upsell is shown'
+      );
+    };
   }
 
   return () =>

--- a/ts/components/menuAndSettingsHooks/useProBadgeOnClickCb.tsx
+++ b/ts/components/menuAndSettingsHooks/useProBadgeOnClickCb.tsx
@@ -120,6 +120,16 @@ function proFeatureToVariant(proFeature: ProMessageFeature): CTAVariant {
  *
  * Depending on the context provided, different arguments are needed.
  *
+ * ⚠️ `currentUserHasPro` means a DIFFERENT thing per branch, and the argument name does not say which.
+ * Some branches ask whether we may use a Pro feature (ACCESS — the proof); others ask only whether to
+ * invite us to buy one (DISPLAY — the plan's state). The two are allowed to disagree: during the
+ * overhang a lapsed plan still has a working proof, and a freshly restored account has an active plan
+ * with no usable proof yet.
+ *
+ * So the caller has to decide which question its context is asking, and this hook cannot check that for
+ * it. Passing "whichever Pro boolean was already in scope" is how six Desktop surfaces came to offer an
+ * upgrade to users whose plan was already active. If you are adding a context, write down which of the
+ * two it needs and why, next to the call.
  */
 export function useProBadgeOnClickCb(
   opts: ProBadgeContext

--- a/ts/components/menuAndSettingsHooks/useProBadgeOnClickCb.tsx
+++ b/ts/components/menuAndSettingsHooks/useProBadgeOnClickCb.tsx
@@ -130,6 +130,11 @@ function proFeatureToVariant(proFeature: ProMessageFeature): CTAVariant {
  * Passing whichever Pro boolean happens to be in scope will compile and read plausibly while offering an
  * upgrade to someone whose plan is already active. A new context should say which value it needs, and
  * why, at the call.
+ *
+ * As it stands every branch below reads this to decide whether to *sell* — show the upsell, or make the
+ * badge inert because there is nothing left to sell — which is DISPLAY, and DISPLAY is what the callers
+ * pass. Nothing here gates a capability. A branch that did would need ACCESS instead, and adding one
+ * without saying so is how the two quietly get crossed.
  */
 export function useProBadgeOnClickCb(
   opts: ProBadgeContext

--- a/ts/components/menuAndSettingsHooks/useProBadgeOnClickCb.tsx
+++ b/ts/components/menuAndSettingsHooks/useProBadgeOnClickCb.tsx
@@ -131,10 +131,9 @@ function proFeatureToVariant(proFeature: ProMessageFeature): CTAVariant {
  * upgrade to someone whose plan is already active. A new context should say which value it needs, and
  * why, at the call.
  *
- * As it stands every branch below reads this to decide whether to *sell* — show the upsell, or make the
- * badge inert because there is nothing left to sell — which is DISPLAY, and DISPLAY is what the callers
- * pass. Nothing here gates a capability. A branch that did would need ACCESS instead, and adding one
- * without saying so is how the two quietly get crossed.
+ * Every branch below reads it to decide whether to *sell* — show the upsell, or make the badge inert
+ * because there is nothing left to sell — so DISPLAY is the value they all want. A branch that gated a
+ * capability would need ACCESS instead, and adding one without saying so is how the two get crossed.
  */
 export function useProBadgeOnClickCb(
   opts: ProBadgeContext

--- a/ts/components/menuAndSettingsHooks/useProBadgeOnClickCb.tsx
+++ b/ts/components/menuAndSettingsHooks/useProBadgeOnClickCb.tsx
@@ -126,10 +126,10 @@ function proFeatureToVariant(proFeature: ProMessageFeature): CTAVariant {
  * overhang a lapsed plan still has a working proof, and a freshly restored account has an active plan
  * with no usable proof yet.
  *
- * So the caller has to decide which question its context is asking, and this hook cannot check that for
- * it. Passing "whichever Pro boolean was already in scope" is how six Desktop surfaces came to offer an
- * upgrade to users whose plan was already active. If you are adding a context, write down which of the
- * two it needs and why, next to the call.
+ * Only the context knows which of the two it is asking, so this hook cannot check the caller's choice.
+ * Passing whichever Pro boolean happens to be in scope will compile and read plausibly while offering an
+ * upgrade to someone whose plan is already active. A new context should say which value it needs, and
+ * why, at the call.
  */
 export function useProBadgeOnClickCb(
   opts: ProBadgeContext

--- a/ts/components/menuAndSettingsHooks/useProBadgeOnClickCb.tsx
+++ b/ts/components/menuAndSettingsHooks/useProBadgeOnClickCb.tsx
@@ -4,12 +4,11 @@ import { SessionCTAState, updateSessionCTA } from '../../state/ducks/modalDialog
 import { assertUnreachable } from '../../types/sqlSharedTypes';
 import type { ContactNameContext } from '../conversation/ContactName/ContactNameContext';
 import { useShowSessionCTACbWithVariant } from '../dialog/SessionCTA';
+import { useCurrentUserHasExpiredPro, useCurrentUserHasPro } from '../../hooks/useHasPro';
 import { CTAVariant } from '../dialog/cta/types';
 
 type WithUserHasPro = { userHasPro: boolean };
 type WithMessageSentWithProFeat = { messageSentWithProFeat: Array<ProMessageFeature> | null };
-type WithCurrentUserHasPro = { currentUserHasPro: boolean };
-type WithCurrentUserHasExpiredPro = { currentUserHasExpiredPro: boolean };
 
 type WithIsMe = { isMe: boolean };
 type WithContactNameContext = { contactNameContext: ContactNameContext };
@@ -20,27 +19,17 @@ type WithProCTA = { cta: SessionCTAState };
 
 type ProBadgeContext =
   | { context: 'edit-profile-pic'; args: WithProCTA }
-  | {
-      context: 'show-our-profile-dialog';
-      args: WithCurrentUserHasPro & WithCurrentUserHasExpiredPro & WithProvidedCb;
-    }
+  | { context: 'show-our-profile-dialog'; args: WithProvidedCb }
   | {
       context: 'conversation-title-dialog'; // the title in the conversation settings ConversationSettingsHeader/UserProfileDialog
-      args: WithUserHasPro & WithCurrentUserHasPro & WithIsMe & WithIsGroupV2;
+      args: WithUserHasPro & WithIsMe & WithIsGroupV2;
     }
-  | { context: 'character-count'; args: WithCurrentUserHasPro }
+  | { context: 'character-count'; args: Record<string, never> }
   | { context: 'conversation-header-title'; args: WithUserHasPro & WithIsMe } // the title in the conversation header (i.e. title of the main screen of the app)
-  | {
-      context: 'message-info-sent-with-pro';
-      args: WithCurrentUserHasPro & WithMessageSentWithProFeat;
-    }
+  | { context: 'message-info-sent-with-pro'; args: WithMessageSentWithProFeat }
   | {
       context: 'contact-name';
-      args: WithUserHasPro &
-        WithIsMe &
-        WithCurrentUserHasPro &
-        WithContactNameContext &
-        WithIsBlinded;
+      args: WithUserHasPro & WithIsMe & WithContactNameContext & WithIsBlinded;
     };
 
 /**
@@ -120,26 +109,26 @@ function proFeatureToVariant(proFeature: ProMessageFeature): CTAVariant {
  *
  * Depending on the context provided, different arguments are needed.
  *
- * ⚠️ `currentUserHasPro` means a DIFFERENT thing per branch, and the argument name does not say which.
- * Some branches ask whether we may use a Pro feature (ACCESS — the proof); others ask only whether to
- * invite us to buy one (DISPLAY — the plan's state). The two are allowed to disagree: during the
- * overhang a lapsed plan still has a working proof, and a freshly restored account has an active plan
- * with no usable proof yet.
+ * Our own Pro state is read here rather than passed in. Every branch below uses it to decide whether to
+ * *sell* — show the upsell, or make the badge inert because there is nothing left to sell — so DISPLAY
+ * is the value they all want, and the branch that needs it is the only thing that knows that. A caller
+ * cannot supply the wrong one if it does not supply one at all.
  *
- * Only the context knows which of the two it is asking, so this hook cannot check the caller's choice.
- * Passing whichever Pro boolean happens to be in scope will compile and read plausibly while offering an
- * upgrade to someone whose plan is already active. A new context should say which value it needs, and
- * why, at the call.
+ * The distinction is worth holding onto: ACCESS (the proof) is what we may DO, DISPLAY (the plan's
+ * state) is what we are IN, and they disagree in both directions — a lapsed plan keeps a working proof
+ * through the overhang, and a freshly restored account has an active plan with no usable proof yet. A
+ * branch added here that gates a capability rather than selling one wants `useCurrentUserHasProAccess`,
+ * and should read it beside that branch for the same reason.
  *
- * Every branch below reads it to decide whether to *sell* — show the upsell, or make the badge inert
- * because there is nothing left to sell — so DISPLAY is the value they all want. A branch that gated a
- * capability would need ACCESS instead, and adding one without saying so is how the two get crossed.
+ * `userHasPro` stays an argument: it describes the other participant, so it varies per conversation.
  */
 export function useProBadgeOnClickCb(
   opts: ProBadgeContext
 ): ShowTagWithCb | ShowTagNoCb | DoNotShowTag {
   const dispatch = getAppDispatch();
   const handleShowProInfoModal = useShowSessionCTACbWithVariant();
+  const currentUserHasPro = useCurrentUserHasPro();
+  const currentUserHasExpiredPro = useCurrentUserHasExpiredPro();
 
   const { context, args } = opts;
 
@@ -151,7 +140,7 @@ export function useProBadgeOnClickCb(
   }
 
   if (context === 'show-our-profile-dialog') {
-    if (args.currentUserHasPro || args.currentUserHasExpiredPro) {
+    if (currentUserHasPro || currentUserHasExpiredPro) {
       // if the current user already has or had pro, we want to show the badge, but use a custom callback
       // i.e. it won't open the CTA but allow to edit our name
       return { show: true, cb: args.providedCb };
@@ -173,7 +162,7 @@ export function useProBadgeOnClickCb(
     // - else:
     //   - if a single pro feature was used with this message: open the CTA corresponding to that one
     //   - if multiple pro features were used with this message: open the GENERIC CTA
-    return args.currentUserHasPro
+    return currentUserHasPro
       ? showNoCb
       : {
           show: true,
@@ -215,7 +204,7 @@ export function useProBadgeOnClickCb(
       };
     }
 
-    if (args.currentUserHasPro) {
+    if (currentUserHasPro) {
       // if we also have pro and this is a private conversation, clicking on the badge doesn't do anything
       return showNoCb;
     }
@@ -225,7 +214,7 @@ export function useProBadgeOnClickCb(
 
   if (context === 'character-count') {
     // if we already have pro, there is no point showing the `Upgrade to do more with Pro`
-    if (args.currentUserHasPro) {
+    if (currentUserHasPro) {
       return doNotShow;
     }
     // FOMO
@@ -260,7 +249,7 @@ export function useProBadgeOnClickCb(
       // in the message info screen, the badge should be shown if the corresponding user has pro and
       // - not be clickable if we also have pro
       // - be clickable if we do not have pro and open the generic CTA
-      if (args.currentUserHasPro) {
+      if (currentUserHasPro) {
         return showNoCb;
       }
 

--- a/ts/hooks/useHasPro.ts
+++ b/ts/hooks/useHasPro.ts
@@ -21,17 +21,49 @@ export function selectWeAreProUser(state: StateType) {
   return selectOurProStatus(state) === ProStatus.Active;
 }
 
+/**
+ * ACCESS, for rendering: whether our proof currently entitles us to use Pro features.
+ *
+ * This subscribes to the value recomputed at each change source (config change, revocation update,
+ * proof expiry). Anything that GRANTS rather than renders — the send path, the compose limit — must
+ * call `currentUserProofIsValid()` directly instead, so the decision is made at the moment it matters.
+ *
+ * Distinct from `selectWeAreProUser`, which is DISPLAY. They are meant to disagree: during the overhang
+ * on a proof that outlives its plan, this stays true while the plan reads expired.
+ */
+export function selectWeHaveProAccess(state: StateType) {
+  // Already mock-adjusted: `refreshProAccess` stores the output of `currentUserProofIsValid()`, which
+  // applies the mock itself. Do not re-apply it here.
+  return state.proAccess.valid;
+}
+
 function useCurrentUserProStatus() {
   return useSelector(selectOurProStatus);
 }
 
 /**
- * Returns true if pro is available, and the current user has pro (active, not expired)
+ * DISPLAY: returns true if pro is available and the plan currently reads as active.
+ *
+ * For "may we use a Pro feature", use {@link useCurrentUserHasProAccess} instead — this one goes false
+ * the moment the plan reads expired, even while a valid proof is still entitling the user to the
+ * features.
  */
 export function useCurrentUserHasPro() {
   const status = useCurrentUserProStatus();
 
   return status === ProStatus.Active;
+}
+
+/**
+ * ACCESS: returns true if pro is available and our proof currently entitles us to Pro features.
+ *
+ * The right hook for any surface that represents a capability — a badge we assert to others, an
+ * animated avatar, a gate on a Pro-only action.
+ */
+export function useCurrentUserHasProAccess() {
+  const haveAccess = useSelector(selectWeHaveProAccess);
+
+  return isProAvailable && haveAccess;
 }
 
 /**
@@ -64,8 +96,10 @@ function useShowProBadgeForOther(convoId?: string) {
 }
 
 export function useShowProBadgeFor(convoId?: string) {
-  // the current user pro badge is always shown if we have a valid pro
-  const currentUserHasPro = useCurrentUserHasPro();
+  // Our own badge is ACCESS, not DISPLAY: it asserts to other people something they will verify against
+  // the proof we attach. Showing it off the plan's status would badge us during the window where the
+  // plan reads active but no usable proof exists, and hide it during the overhang where one does.
+  const currentUserHasPro = useCurrentUserHasProAccess();
   // the other user pro badge is shown if they have a valid pro proof and pro badge feature enabled
   const otherUserHasPro = useShowProBadgeForOther(convoId);
 

--- a/ts/hooks/useHasPro.ts
+++ b/ts/hooks/useHasPro.ts
@@ -1,6 +1,5 @@
 import { useSelector } from 'react-redux';
 import { proStatusWithMock } from '../state/ducks/types/proMocks';
-import { getDataFeatureFlagMemo } from '../state/ducks/types/releasedFeaturesReduxTypes';
 import {
   defaultProAccessDetailsSourceData,
   getProBackendCurrentUserStatus,
@@ -61,9 +60,7 @@ export function useCurrentUserHasPro() {
  * animated avatar, a gate on a Pro-only action.
  */
 export function useCurrentUserHasProAccess() {
-  const haveAccess = useSelector(selectWeHaveProAccess);
-
-  return isProAvailable && haveAccess;
+  return useSelector(selectWeHaveProAccess);
 }
 
 /**

--- a/ts/hooks/useHasPro.ts
+++ b/ts/hooks/useHasPro.ts
@@ -1,4 +1,5 @@
 import { useSelector } from 'react-redux';
+import { proStatusWithMock } from '../state/ducks/types/proMocks';
 import { getDataFeatureFlagMemo } from '../state/ducks/types/releasedFeaturesReduxTypes';
 import {
   defaultProAccessDetailsSourceData,
@@ -10,12 +11,9 @@ import type { StateType } from '../state/reducer';
 
 export function selectOurProStatus(state: StateType) {
   const proBackendCurrentUserStatus = getProBackendCurrentUserStatus(state);
-  const mockCurrentStatus = getDataFeatureFlagMemo('mockProCurrentStatus');
 
-  return (
-    mockCurrentStatus ??
-    proBackendCurrentUserStatus ??
-    defaultProAccessDetailsSourceData.currentStatus
+  return proStatusWithMock(
+    proBackendCurrentUserStatus ?? defaultProAccessDetailsSourceData.currentStatus
   );
 }
 

--- a/ts/models/conversation.ts
+++ b/ts/models/conversation.ts
@@ -150,11 +150,9 @@ import type { LastMessageStatusType } from '../state/ducks/types';
 import { OutgoingUserProfile } from '../types/message';
 import { privateSet, privateSetKey } from './modelFriends';
 import { ProFeatures, ProMessageFeature } from './proMessageFeature';
-import {
-  getCachedUserConfig,
-  UserConfigWrapperActions,
-} from '../webworker/workers/browser/libsession/libsession_worker_userconfig_interface';
+import { UserConfigWrapperActions } from '../webworker/workers/browser/libsession/libsession_worker_userconfig_interface';
 import { ProRevocationCache } from '../session/revocation_list/pro_revocation_list';
+import { currentUserProofIsValid } from '../session/utils/ProAccess';
 import { uuidV4 } from '../util/uuid';
 import { pushQuotedMessageToStoreIfNeeded } from '../receiver/queuedJob';
 
@@ -790,17 +788,9 @@ export class ConversationModel extends Model<ConversationAttributes> {
     }
 
     if (this.isMe()) {
-      // The logic for the pro proof for ourselves is coming from libsession.
-      const proProof = getCachedUserConfig().proConfig?.proProof;
-      if (!proProof) {
-        return false;
-      }
-      if (ProRevocationCache.isB64HashEffectivelyRevoked(proProof.revocationTagB64)) {
-        // `false` because the proof is not valid (revoked)
-        return false;
-      }
-      // if now() is before the proof's expiry, it is not expired yet
-      return NetworkTime.nowTs().isBeforeMs({ ms: proProof.expiryMs });
+      // Our own entitlement is ACCESS, and there is one function for it — the send path asks the same
+      // question and must not be able to answer it differently.
+      return currentUserProofIsValid();
     }
 
     const proDetails = this.dbContactProDetails();

--- a/ts/react.d.ts
+++ b/ts/react.d.ts
@@ -134,6 +134,8 @@ declare module 'react' {
     | 'preferences'
     | 'donate';
 
+  type ProSettingsSections = 'stats' | 'manage' | 'features';
+
   type ProFeatureItems =
     | 'longer-messages'
     | 'more-pins'
@@ -305,6 +307,9 @@ declare module 'react' {
 
     // Pro settings
     | `${ProFeatureItems}-pro-settings-menu-item`
+    | `pro-settings-${ProSettingsSections}-header`
+    // Both the "checking" and the "backend unavailable" messages render into this one slot.
+    | 'pro-settings-status-banner'
 
     // timer options
     | DisappearTimeOptionDataTestId

--- a/ts/react.d.ts
+++ b/ts/react.d.ts
@@ -310,6 +310,9 @@ declare module 'react' {
     | `pro-settings-${ProSettingsSections}-header`
     // Both the "checking" and the "backend unavailable" messages render into this one slot.
     | 'pro-settings-status-banner'
+    // The hero copy, which differs per status. Shared with the non-originating page, whose hero
+    // renders the same slot; a locator reads the text through the id to tell the states apart.
+    | 'pro-settings-description'
 
     // timer options
     | DisappearTimeOptionDataTestId

--- a/ts/receiver/configMessage.ts
+++ b/ts/receiver/configMessage.ts
@@ -61,7 +61,7 @@ import {
   getCachedUserConfig,
   UserConfigWrapperActions,
 } from '../webworker/workers/browser/libsession/libsession_worker_userconfig_interface';
-import { proBackendDataActions, reconcileProProof } from '../state/ducks/proBackendData';
+import { reconcileProProof } from '../state/ducks/proBackendData';
 
 type IncomingUserResult = {
   needsPush: boolean;

--- a/ts/receiver/configMessage.ts
+++ b/ts/receiver/configMessage.ts
@@ -152,22 +152,10 @@ async function mergeUserConfigsWithIncomingUpdates(
           //
           // Note: those `?? 0` is here because android sets it to 0 even if it should be unset.
           const proAccessExpiryBefore = (await UserConfigWrapperActions.getProAccessExpiry()) ?? 0;
-          const proPrepaidBefore = (await UserConfigWrapperActions.getProPrepaid()) ?? 0;
           hashesMerged = await UserConfigWrapperActions.merge(toMerge);
           const proAccessExpiryAfter = (await UserConfigWrapperActions.getProAccessExpiry()) ?? 0;
-          const proPrepaidAfter = (await UserConfigWrapperActions.getProPrepaid()) ?? 0;
 
           const accessExpiryChanged = proAccessExpiryBefore !== proAccessExpiryAfter;
-          const prepaidChanged = proPrepaidBefore !== proPrepaidAfter;
-
-          if (accessExpiryChanged || prepaidChanged) {
-            window.log.debug(
-              `[mergeConfigsWithInboxUpdates] pro config changed (proAccessExpiry ${proAccessExpiryBefore} -> ${proAccessExpiryAfter}, proPrepaid ${proPrepaidBefore} -> ${proPrepaidAfter}). Refreshing our pro status.`
-            );
-            window.inboxStore?.dispatch(
-              proBackendDataActions.refreshGetProStatusFromProBackend({}) as any
-            );
-          }
 
           if (accessExpiryChanged) {
             // The `E`-changed proof nudge, called directly rather than left to the status fetch above

--- a/ts/receiver/configMessage.ts
+++ b/ts/receiver/configMessage.ts
@@ -144,11 +144,11 @@ async function mergeUserConfigsWithIncomingUpdates(
       // the GenericWrapperActions
       switch (variant) {
         case 'UserConfig': {
-          // Watches both the access expiry (`E`) and the prepaid marker (`I`). `I` matters on its own:
-          // another device's purchase syncs a prepaid marker before `E` moves, which is exactly when we
-          // want to re-read our status. `auto_renewing` is deliberately not watched — a change there
-          // re-derives the display from the value we just received, so fetching would confirm what we
-          // were already told.
+          // Watches both the access expiry and the prepaid marker. The prepaid marker matters on its
+          // own: another device's purchase syncs one before the expiry moves, which is exactly when we
+          // want to re-read our status. The auto-renewing flag is deliberately not watched — a change
+          // there re-derives the display from the value we just received, so fetching would confirm what
+          // we were already told.
           //
           // Note: those `?? 0` is here because android sets it to 0 even if it should be unset.
           const proAccessExpiryBefore = (await UserConfigWrapperActions.getProAccessExpiry()) ?? 0;
@@ -158,14 +158,14 @@ async function mergeUserConfigsWithIncomingUpdates(
           const accessExpiryChanged = proAccessExpiryBefore !== proAccessExpiryAfter;
 
           if (accessExpiryChanged) {
-            // The `E`-changed proof nudge, called directly rather than left to the status fetch above
+            // The expiry-changed proof nudge, called directly rather than left to the status fetch above
             // as a side effect. Every completed fetch does end with a reconcile, but that fetch is
             // floored and a dropped one never reaches its callback, so the nudge has to hold whether or
             // not the fetch ran.
             //
             // It is the one edge from config to the proof loop, and it is load-bearing: if the
             // account had lapsed and the proof expired, `pro_renewal_target` returns nothing and the
-            // loop sits dormant with no wake. A synced `E` that advances means it would now say
+            // loop sits dormant with no wake. A synced expiry that advances means it would now say
             // "renew now", and nothing else re-evaluates that. A nudge the reconcile ignores (valid
             // proof, future target) is a harmless no-op, so any change is nudged, not just
             // past -> future.

--- a/ts/session/apis/file_server_api/FileServerApi.ts
+++ b/ts/session/apis/file_server_api/FileServerApi.ts
@@ -44,7 +44,13 @@ export const uploadFileToFsWithOnionV4 = async (
     return null;
   }
 
-  const target = process.env.POTATO_FS ? 'POTATO' : 'DEFAULT';
+  // TEST wins over POTATO: a run that configured a local file server meant it, and falling through to
+  // a remote one would put the upload somewhere the test cannot reach.
+  const target = FS.isTestFileServerConfigured()
+    ? 'TEST'
+    : process.env.POTATO_FS
+      ? 'POTATO'
+      : 'DEFAULT';
 
   const result = await OnionSending.sendBinaryViaOnionV4ToFileServer({
     abortSignal: new AbortController().signal,

--- a/ts/session/apis/file_server_api/FileServerTarget.ts
+++ b/ts/session/apis/file_server_api/FileServerTarget.ts
@@ -1,3 +1,5 @@
+import { crypto_sign_ed25519_pk_to_curve25519, from_hex, to_hex } from 'libsodium-wrappers-sumo';
+
 import { SERVER_HOSTS } from '..';
 import { assertUnreachable } from '../../../types/sqlSharedTypes';
 
@@ -10,7 +12,102 @@ type FileServerConfigType = {
 // not exported/included in the SERVER_HOSTS as this is for testing only
 const POTATO_FS_HOST = 'potatofiles.getsession.org';
 
-const FILE_SERVERS: Record<'DEFAULT' | 'POTATO', FileServerConfigType> = {
+// Host used when no test file server is configured, so an unconfigured TEST target still can't
+// resolve to anything real. Not in SERVER_HOSTS (testing only).
+const TEST_FS_UNCONFIGURED = 'test-file-server-not-configured.invalid';
+
+/**
+ * A local file server, supplied through the environment.
+ *
+ * Without this every upload goes to the production file server over an onion path, which no test can
+ * redirect — the same shape as the Pro backend before it gained TEST_PRO_BACKEND_*, and this mirrors
+ * that deliberately rather than inventing a second pattern.
+ *
+ *   TEST_FILE_SERVER_URL    e.g. http://192.168.139.2:8000
+ *   TEST_FILE_SERVER_ED_PK  the server's Ed25519 pubkey
+ *
+ * Only those two. The X25519 key the onion request encrypts to is **derived** from the Ed25519 one
+ * rather than configured: the server has one keypair and prints both representations of it, so asking
+ * for the second invites a mismatched pair that fails halfway through an exchange.
+ *
+ * Use an address the SNODES can reach rather than localhost: requests arrive over an onion path, so
+ * the host is resolved inside the snode containers.
+ *
+ * The env read happens once at module load; the key derivation is deferred (see `testTarget`).
+ */
+const testFromEnv = ((): { url: string; edPk: string } | null => {
+  const value = (name: string) => (process.env[name] ?? '').trim();
+  const url = value('TEST_FILE_SERVER_URL').replace(/\/$/, '');
+  const edPk = value('TEST_FILE_SERVER_ED_PK').toLowerCase();
+
+  if (!url && !edPk) {
+    return null;
+  }
+  // One without the other is always a mistake, and silently ignoring it would send the upload to
+  // production while the run looks configured.
+  if (!url || !edPk) {
+    throw new Error(
+      'TEST_FILE_SERVER_URL and TEST_FILE_SERVER_ED_PK must be set together ' +
+        `(got url="${url}", edPk="${edPk}")`
+    );
+  }
+  if (!/^https?:\/\/[^/\s]+$/.test(url)) {
+    throw new Error(`TEST_FILE_SERVER_URL must look like http://host:port (got "${url}")`);
+  }
+  if (!/^[0-9a-f]{64}$/.test(edPk)) {
+    throw new Error(
+      `TEST_FILE_SERVER_ED_PK must be a 64-character hex Ed25519 pubkey (got "${edPk}")`
+    );
+  }
+  return { url, edPk };
+})();
+
+/**
+ * The TEST target, with the X25519 key derived on first use.
+ *
+ * Deferred rather than computed alongside `testFromEnv` because the conversion needs libsodium, which
+ * is only usable after `sodium.ready` — module evaluation can happen before that. Everything that
+ * reads this does so at runtime, and `Object.keys` (which builds FILE_SERVER_TARGETS) does not invoke
+ * getters, so nothing forces it early.
+ */
+let testTargetCache: FileServerConfigType | null = null;
+
+/**
+ * 64 hex characters is not enough to be an Ed25519 key — an X25519 key looks identical — and the
+ * conversion is the only thing that can tell them apart. Left to libsodium it surfaces as a bare
+ * "invalid key" from a stack with no mention of the variable that caused it.
+ */
+function deriveXPkOrThrow(edPk: string) {
+  try {
+    return to_hex(crypto_sign_ed25519_pk_to_curve25519(from_hex(edPk)));
+  } catch (e) {
+    throw new Error(
+      `TEST_FILE_SERVER_ED_PK is not a valid Ed25519 pubkey: "${edPk}" cannot be converted to ` +
+        `X25519 ("${e.message}"). Note an X25519 key is also 64 hex characters, so check you took ` +
+        `the server's Ed25519 key and not its X25519 one.`
+    );
+  }
+}
+
+function testTarget(): FileServerConfigType {
+  if (!testTargetCache) {
+    testTargetCache = {
+      // Falls back to an unresolvable host with empty keys when unconfigured, so this target stays
+      // inert rather than silently pointing at the default file server.
+      url: testFromEnv?.url ?? `https://${TEST_FS_UNCONFIGURED}`,
+      edPk: testFromEnv?.edPk ?? '',
+      xPk: testFromEnv ? deriveXPkOrThrow(testFromEnv.edPk) : '',
+    };
+  }
+  return testTargetCache;
+}
+
+/** Whether a test file server is configured, i.e. whether the TEST target is usable. */
+function isTestFileServerConfigured() {
+  return testFromEnv !== null;
+}
+
+const FILE_SERVERS: Record<'DEFAULT' | 'POTATO' | 'TEST', FileServerConfigType> = {
   DEFAULT: {
     url: `http://${SERVER_HOSTS.DEFAULT_FILE_SERVER}`,
     xPk: '09324794aa9c11948189762d198c618148e9136ac9582068180661208927ef34',
@@ -20,6 +117,11 @@ const FILE_SERVERS: Record<'DEFAULT' | 'POTATO', FileServerConfigType> = {
     url: `http://${POTATO_FS_HOST}`,
     edPk: 'ff86dcd4b26d1bfec944c59859494248626d6428efc12168749d65a1b92f5e28',
     xPk: 'fc097b06821c98a2db75ce02e521cef5fd9d3446e42e81d843c4c8c4e9260f48',
+  },
+  // A getter, so the X25519 derivation in testTarget() happens on first read rather than at module
+  // load, where libsodium may not be ready yet.
+  get TEST() {
+    return testTarget();
   },
 };
 
@@ -38,6 +140,15 @@ function fileUrlToFileTarget(url: string): FILE_SERVER_TARGET_TYPE {
   for (let index = 0; index < FILE_SERVER_TARGETS.length; index++) {
     const target = FILE_SERVER_TARGETS[index];
     switch (target) {
+      case 'TEST':
+        // Matched against whatever TEST resolved to — the configured host, or the unresolvable
+        // placeholder when there is none. An exact host match rather than `includes`, because a
+        // configured test host is an arbitrary address (often a bare IP:port) and a substring test on
+        // one of those matches far too much.
+        if (parsedUrl.host === new URL(FILE_SERVERS.TEST.url).host) {
+          return 'TEST';
+        }
+        break;
       case 'POTATO':
         if (parsedUrl.host.includes(POTATO_FS_HOST)) {
           return 'POTATO';
@@ -57,6 +168,7 @@ function fileUrlToFileTarget(url: string): FILE_SERVER_TARGET_TYPE {
 
 export const FS = {
   isDefaultFileServer,
+  isTestFileServerConfigured,
   FILE_SERVERS,
   fileUrlToFileTarget,
 };

--- a/ts/session/revocation_list/pro_revocation_list.ts
+++ b/ts/session/revocation_list/pro_revocation_list.ts
@@ -111,6 +111,22 @@ function isB64HashEffectivelyRevoked(revocationTagBase64: string) {
   return !!found && NetworkTime.now() >= found.effectiveMs;
 }
 
+/**
+ * When a listed-but-not-yet-effective revocation starts to bite, or null if the hash is not listed or
+ * is already effective.
+ *
+ * Needed because a future-dated revocation changes the answer to "is this proof usable" with no event
+ * behind it: the list has already arrived, so nothing further will be fetched, and the instant simply
+ * passes. Anything holding a rendered copy of that answer has to arm a timer for it.
+ */
+function pendingRevocationMsForB64Hash(revocationTagBase64: string): number | null {
+  assertInitialFetchFromDBDone('pendingRevocationMsForB64Hash');
+
+  const found = cachedProRevocationListItems.find(m => m.revocationTagB64 === revocationTagBase64);
+
+  return found && found.effectiveMs > NetworkTime.now() ? found.effectiveMs : null;
+}
+
 export const ProRevocationCache = {
   getTicket,
   setTicket,
@@ -118,5 +134,6 @@ export const ProRevocationCache = {
   setListItems,
   clear,
   isB64HashEffectivelyRevoked,
+  pendingRevocationMsForB64Hash,
   loadFromDbIfNeeded,
 };

--- a/ts/session/utils/ProAccess.ts
+++ b/ts/session/utils/ProAccess.ts
@@ -1,0 +1,40 @@
+import { NetworkTime } from '../../util/NetworkTime';
+import { ProRevocationCache } from '../revocation_list/pro_revocation_list';
+import { getCachedUserConfig } from '../../webworker/workers/browser/libsession/libsession_worker_userconfig_interface';
+
+/**
+ * ACCESS: what this device may currently do — the single answer to "is our Pro usable right now".
+ *
+ * Derived from the proof in synced config, and validated on EVERY call against both the proof's own
+ * expiry and the cached revocation list (which honours each item's effective timestamp). Deliberately
+ * not memoized, cached or projected into redux: a value that is only correct when re-read is only
+ * correct if callers actually re-read it.
+ *
+ * This governs features AND what we attach when sending. It is NOT the value that decides what the Pro
+ * settings screen or the menu row show — that is DISPLAY ("what state is the plan in"), which comes
+ * from the backend status and may legitimately disagree. A plan that has lapsed while the proof still
+ * has time left displays as expired while the features keep working; that overhang is intended.
+ *
+ * Answers only for ourselves. Other people's proofs travel on their messages and are checked against
+ * the same revocation list in `ConversationModel.hasValidCurrentProProof`.
+ */
+export function currentUserProofIsValid(): boolean {
+  let proProof;
+  try {
+    proProof = getCachedUserConfig().proConfig?.proProof;
+  } catch {
+    // user config not initialised yet (e.g. pre-login): no proof, so nothing is unlocked.
+    return false;
+  }
+
+  if (!proProof) {
+    return false;
+  }
+
+  // Revocation before expiry: a revoked proof is unusable however much time is left on it.
+  if (ProRevocationCache.isB64HashEffectivelyRevoked(proProof.revocationTagB64)) {
+    return false;
+  }
+
+  return NetworkTime.nowTs().isBeforeMs({ ms: proProof.expiryMs });
+}

--- a/ts/session/utils/ProAccess.ts
+++ b/ts/session/utils/ProAccess.ts
@@ -1,4 +1,5 @@
 import { NetworkTime } from '../../util/NetworkTime';
+import { proAccessWithMock } from '../../state/ducks/types/proMocks';
 import { ProRevocationCache } from '../revocation_list/pro_revocation_list';
 import { getCachedUserConfig } from '../../webworker/workers/browser/libsession/libsession_worker_userconfig_interface';
 
@@ -17,8 +18,16 @@ import { getCachedUserConfig } from '../../webworker/workers/browser/libsession/
  *
  * Answers only for ourselves. Other people's proofs travel on their messages and are checked against
  * the same revocation list in `ConversationModel.hasValidCurrentProProof`.
+ *
+ * The status mock is applied HERE rather than at each caller, so rendering and enforcement can never
+ * disagree about what a mocked run is entitled to. See `proAccessWithMock` for why a mock has to reach
+ * ACCESS at all. Unmocked — which is every real client — this is the proof and nothing else.
  */
 export function currentUserProofIsValid(): boolean {
+  return proAccessWithMock(realProofIsValid());
+}
+
+function realProofIsValid(): boolean {
   let proProof;
   try {
     proProof = getCachedUserConfig().proConfig?.proProof;

--- a/ts/session/utils/User.ts
+++ b/ts/session/utils/User.ts
@@ -16,6 +16,7 @@ import {
   UserConfigWrapperActions,
 } from '../../webworker/workers/browser/libsession/libsession_worker_userconfig_interface';
 import { NetworkTime } from '../../util/NetworkTime';
+import { currentUserProofIsValid } from './ProAccess';
 
 export type HexKeyPair = {
   pubKey: string;
@@ -146,9 +147,14 @@ export async function getOutgoingProMessageDetails({
     UserConfigWrapperActions.getProProfileBitset(),
   ]);
 
-  // Note: if we do not have a proof we don't want to send a proMessage.
+  // Note: if we do not have a usable proof we don't want to send a proMessage.
   // Note: if we don't have a user pro feature enabled, we might still need to add one for the message itself, see below
-  if (!proConfig || isEmpty(proConfig?.proProof)) {
+  //
+  // ACCESS decides this, not proof presence: a proof that has expired or been revoked is still sitting
+  // in config until something clears it, and attaching one asserts an entitlement the recipient will
+  // reject anyway. `currentUserProofIsValid` is the same function the feature surfaces ask, so what we
+  // attach and what we let the user do cannot drift apart.
+  if (!currentUserProofIsValid() || !proConfig || isEmpty(proConfig?.proProof)) {
     return null;
   }
 

--- a/ts/session/utils/job_runners/jobs/UpdateProRevocationListJob.ts
+++ b/ts/session/utils/job_runners/jobs/UpdateProRevocationListJob.ts
@@ -12,7 +12,10 @@ import { DURATION } from '../../../constants';
 import { getFeatureFlag } from '../../../../state/ducks/types/releasedFeaturesReduxTypes';
 import { ProRevocationCache } from '../../../revocation_list/pro_revocation_list';
 import { stringify } from '../../../../types/sqlSharedTypes';
-import { proBackendDataActions } from '../../../../state/ducks/proBackendData';
+import {
+  persistProConfigWrite,
+  proBackendDataActions,
+} from '../../../../state/ducks/proBackendData';
 import { refreshProAccess } from '../../../../state/ducks/proAccess';
 import {
   getCachedUserConfig,
@@ -152,6 +155,7 @@ class UpdateProRevocationListJob extends PersistedJob<UpdateProRevocationListPer
           `UpdateProRevocationListJob: our current revocation tag is revoked. Clearing our pro proof.`
         );
         await UserConfigWrapperActions.removeProConfig();
+        await persistProConfigWrite();
         window.inboxStore?.dispatch(
           proBackendDataActions.refreshGetProStatusFromProBackend({}) as any
         );

--- a/ts/session/utils/job_runners/jobs/UpdateProRevocationListJob.ts
+++ b/ts/session/utils/job_runners/jobs/UpdateProRevocationListJob.ts
@@ -13,6 +13,7 @@ import { getFeatureFlag } from '../../../../state/ducks/types/releasedFeaturesRe
 import { ProRevocationCache } from '../../../revocation_list/pro_revocation_list';
 import { stringify } from '../../../../types/sqlSharedTypes';
 import { proBackendDataActions } from '../../../../state/ducks/proBackendData';
+import { refreshProAccess } from '../../../../state/ducks/proAccess';
 import {
   getCachedUserConfig,
   UserConfigWrapperActions,
@@ -125,6 +126,11 @@ class UpdateProRevocationListJob extends PersistedJob<UpdateProRevocationListPer
       // Note: we only want to update the lastRunAt once we have successfully fetched the new revocations
       await ProRevocationCache.setTicket(newTicket);
       await ProRevocationCache.setListItems(newItems);
+
+      // A revocation can invalidate our own proof without anything else moving, so the rendered ACCESS
+      // value has to be recomputed here. The enforcement paths read the list directly and are already
+      // correct at this point; this is only the mirror catching up.
+      refreshProAccess();
 
       window.log.info(
         `UpdateProRevocationListJob: new revocations from ticket #${ticketFromDb}: to #${newTicket}. itemsCount: ${response.items.length}`

--- a/ts/state/ducks/proAccess.ts
+++ b/ts/state/ducks/proAccess.ts
@@ -2,6 +2,7 @@ import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import { currentUserProofIsValid } from '../../session/utils/ProAccess';
 import { getCachedUserConfig } from '../../webworker/workers/browser/libsession/libsession_worker_userconfig_interface';
 import { NetworkTime } from '../../util/NetworkTime';
+import { ProRevocationCache } from '../../session/revocation_list/pro_revocation_list';
 
 export type ProAccessState = {
   /**
@@ -34,12 +35,43 @@ export default proAccessSlice.reducer;
 let expiryTimer: NodeJS.Timeout | null = null;
 
 /**
+ * The next instant at which our access could stop being valid with no event to announce it, or null if
+ * there is no such instant.
+ *
+ * Two of them, and both are silent — nothing arrives, a moment simply passes:
+ *   - the proof's own expiry;
+ *   - a revocation already in our list whose effective timestamp is still in the future. The list has
+ *     landed, so no further fetch is coming; the tag just starts biting.
+ * Whichever comes first is the one to wake for.
+ */
+function nextSilentAccessChangeMs(): number | null {
+  let proProof;
+  try {
+    proProof = getCachedUserConfig().proConfig?.proProof;
+  } catch {
+    return null;
+  }
+  if (!proProof) {
+    return null;
+  }
+
+  const pendingRevocationMs = ProRevocationCache.pendingRevocationMsForB64Hash(
+    proProof.revocationTagB64
+  );
+
+  if (!proProof.expiryMs) {
+    return pendingRevocationMs;
+  }
+  return pendingRevocationMs ? Math.min(proProof.expiryMs, pendingRevocationMs) : proProof.expiryMs;
+}
+
+/**
  * Recompute the rendered ACCESS value, and arm a timer for the next instant it could change on its own.
  *
  * Call this from every source that can change the answer: a config change carrying a new proof, a
- * revocation list update, and app startup. The proof's own expiry needs no external event, so it gets
- * the timer — without it a session left open would keep rendering Pro surfaces past the expiry, and the
- * enforcement paths (which call the function directly) would already be refusing.
+ * revocation list update, and app startup. The two silent instants get the timer instead — without it a
+ * session left open would keep rendering Pro surfaces after the entitlement had gone, while the
+ * enforcement paths (which call the function directly) were already refusing.
  */
 export function refreshProAccess() {
   const valid = currentUserProofIsValid();
@@ -56,19 +88,14 @@ export function refreshProAccess() {
     return;
   }
 
-  let expiryMs: number | undefined;
-  try {
-    expiryMs = getCachedUserConfig().proConfig?.proProof.expiryMs;
-  } catch {
-    return;
-  }
-  if (!expiryMs) {
+  const nextChangeMs = nextSilentAccessChangeMs();
+  if (!nextChangeMs) {
     return;
   }
 
   // `setTimeout` is clamped to a signed 32-bit delay, and a proof can legitimately sit further out than
   // that (~24.9 days), so re-arm at the ceiling instead of firing immediately on overflow.
-  const untilExpiryMs = Math.max(0, expiryMs - NetworkTime.now());
+  const untilChangeMs = Math.max(0, nextChangeMs - NetworkTime.now());
   const maxDelayMs = 2 ** 31 - 1;
-  expiryTimer = setTimeout(refreshProAccess, Math.min(untilExpiryMs, maxDelayMs));
+  expiryTimer = setTimeout(refreshProAccess, Math.min(untilChangeMs, maxDelayMs));
 }

--- a/ts/state/ducks/proAccess.ts
+++ b/ts/state/ducks/proAccess.ts
@@ -1,0 +1,74 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import { currentUserProofIsValid } from '../../session/utils/ProAccess';
+import { getCachedUserConfig } from '../../webworker/workers/browser/libsession/libsession_worker_userconfig_interface';
+import { NetworkTime } from '../../util/NetworkTime';
+
+export type ProAccessState = {
+  /**
+   * Whether our Pro proof is currently usable — the rendered mirror of `currentUserProofIsValid()`.
+   *
+   * Rendering subscribes to this; anything that GRANTS calls the function directly instead. The two
+   * must not drift, which is why nothing writes here except `refreshProAccess` below.
+   */
+  valid: boolean;
+};
+
+export const initialProAccessState: ProAccessState = {
+  valid: false,
+};
+
+export const proAccessSlice = createSlice({
+  name: 'proAccess',
+  initialState: initialProAccessState,
+  reducers: {
+    setProAccessValid(state, action: PayloadAction<boolean>) {
+      state.valid = action.payload;
+      return state;
+    },
+  },
+});
+
+export const proAccessActions = { ...proAccessSlice.actions };
+export default proAccessSlice.reducer;
+
+let expiryTimer: NodeJS.Timeout | null = null;
+
+/**
+ * Recompute the rendered ACCESS value, and arm a timer for the next instant it could change on its own.
+ *
+ * Call this from every source that can change the answer: a config change carrying a new proof, a
+ * revocation list update, and app startup. The proof's own expiry needs no external event, so it gets
+ * the timer — without it a session left open would keep rendering Pro surfaces past the expiry, and the
+ * enforcement paths (which call the function directly) would already be refusing.
+ */
+export function refreshProAccess() {
+  const valid = currentUserProofIsValid();
+  window.inboxStore?.dispatch(proAccessActions.setProAccessValid(valid));
+
+  if (expiryTimer) {
+    clearTimeout(expiryTimer);
+    expiryTimer = null;
+  }
+
+  if (!valid) {
+    // Nothing to wait for: an invalid proof only becomes valid again through one of the event sources
+    // above, which will call back in here.
+    return;
+  }
+
+  let expiryMs: number | undefined;
+  try {
+    expiryMs = getCachedUserConfig().proConfig?.proProof.expiryMs;
+  } catch {
+    return;
+  }
+  if (!expiryMs) {
+    return;
+  }
+
+  // `setTimeout` is clamped to a signed 32-bit delay, and a proof can legitimately sit further out than
+  // that (~24.9 days), so re-arm at the ceiling instead of firing immediately on overflow.
+  const untilExpiryMs = Math.max(0, expiryMs - NetworkTime.now());
+  const maxDelayMs = 2 ** 31 - 1;
+  expiryTimer = setTimeout(refreshProAccess, Math.min(untilExpiryMs, maxDelayMs));
+}

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -255,13 +255,14 @@ function haveValidProof(): boolean {
  * delay before that first job is not a gap to be worked around: it is there so a client that is still
  * receiving its own config does not publish a partial one over it.
  *
- * Call once per write group, not per setter. `E`, `A` and `G` are only jointly meaningful and are always
- * written together, and each dump costs a worker round trip plus an IPC round trip to the main process.
+ * Call once per write group, not per setter. The access expiry, the auto-renewing flag and the grace
+ * period are only jointly meaningful and are always written together, and each dump costs a worker round
+ * trip plus an IPC round trip to the main process.
  *
  * ⚠️ Never throws. A failed dump is a transient IPC/DB problem and the value is still correct in the
  * wrapper, so the next dump carries it; throwing here would abort the rest of the caller's write group
- * and leave `E` stored without the `A` and `G` that qualify it — the mismatch the callers go out of
- * their way to avoid.
+ * and leave the access expiry stored without the auto-renewing flag and grace period that qualify it —
+ * the mismatch the callers go out of their way to avoid.
  */
 export async function persistProConfigWrite(): Promise<void> {
   try {
@@ -293,9 +294,9 @@ async function applyProofOutcome(
       await UserConfigWrapperActions.setProConfig({ proProof, rotatingSeedHex });
     }
     // Refresh cached access-expiry from the advisory account_expiry (decoupled from the proof guard, so
-    // a mid-period horizon extension is still picked up). `A` and `G` ride along, and must: otherwise
-    // `E + G` pairs a fresh expiry with a grace from a different billing period, and an unwritten `A`
-    // reads as not-renewing.
+    // a mid-period horizon extension is still picked up). The auto-renewing flag and the grace period ride
+    // along, and must: otherwise coverage end pairs a fresh expiry with a grace from a different billing
+    // period, and an unwritten auto-renewing flag reads as not-renewing.
     //
     // All three writes belong inside the success branch. On a failure outcome core never fills
     // `accountAutoRenewing`/`accountGracePeriodMs`, so its struct defaults (`false`/`0`) come through,
@@ -316,10 +317,11 @@ async function applyProofOutcome(
     case 'subscription_expired':
       // Lapsed, so not entitled — the same conclusion as the two outcomes below, and cleared the same
       // way. A past expiry left in config has nothing left to compute: every window here is derived
-      // from `E`, and a lapse changes the grace and the renewing flag while typically leaving `E`
-      // itself alone, so refreshing only `E` would pair it with a grace the backend has stopped
-      // honouring. Clearing erases `A` and `G` alongside it instead, leaving absent keys rather than
-      // stored zeroes. Don't wipe a fresh proof a re-subscribe just landed.
+      // from the access expiry, and a lapse changes the grace period and the renewing flag while
+      // typically leaving the expiry itself alone, so refreshing only the expiry would pair it with a
+      // grace the backend has stopped honouring. Clearing erases the auto-renewing flag and grace period
+      // alongside it instead, leaving absent keys rather than stored zeroes. Don't wipe a fresh proof a
+      // re-subscribe just landed.
       if (!haveValidProof()) {
         await UserConfigWrapperActions.removeProConfig();
         await UserConfigWrapperActions.setProAccessExpiry(null);
@@ -375,9 +377,10 @@ async function handleClearProProof() {
 /**
  * Minimum gap between *routine* status fetches. Drop-on-fresh — see statusFetchIsFloored.
  *
- * A scheduled wake depends on this not being crossed: scheduleUserExpiryStatusWake arms two instants `G`
- * apart, both through the floored path, so when `G < STATUS_FLOOR_MS` the second fires and its fetch is
- * dropped with no log line to say so. `G` is at least an hour in production and ~10s on a compressed test
+ * A scheduled wake depends on this not being crossed: scheduleUserExpiryStatusWake arms two instants one
+ * grace period apart, both through the floored path, so when the grace period is shorter than
+ * STATUS_FLOOR_MS the second fires and its fetch is dropped with no log line to say so. Grace is at least
+ * an hour in production and ~10s on a compressed test
  * backend, whose scaled clock this constant does not participate in — override it by env var for those
  * runs rather than shortening it.
  */
@@ -386,7 +389,8 @@ const STATUS_FLOOR_MS = 60 * DURATION.SECONDS;
 const STATUS_STARTUP_MIN_INTERVAL_MS = 24 * DURATION.HOURS;
 /** #6: one wake past the account horizon, so grace surfaces without the Pro page being open. */
 const USER_EXPIRY_WAKE_DELAY_MS = 30 * DURATION.SECONDS;
-/** The Expiring-CTA window. The startup gate's "is E within the CTA window" test uses this too. */
+/** The Expiring-CTA window. The startup gate's "is the access expiry within the CTA window" test uses
+ * this too. */
 const PRO_EXPIRING_CTA_WINDOW_MS = 7 * DURATION.DAYS;
 /** The Expired-CTA window. */
 const PRO_EXPIRED_CTA_WINDOW_MS = 30 * DURATION.DAYS;
@@ -399,12 +403,13 @@ async function handleExpiryCTAs(
 ) {
   const now = NetworkTime.now();
 
-  // The Expiring window is anchored at `E`: "your payment is due soon" is a statement about the payment
-  // date, so coverage doesn't enter into it.
+  // The Expiring window is anchored at the access expiry: "your payment is due soon" is a statement about
+  // the payment date, so coverage doesn't enter into it.
   const sevenDaysBeforeExpiry = accessExpiryTsMs - PRO_EXPIRING_CTA_WINDOW_MS;
   // The Expired window is anchored at coverage end. The backend reports `Expired` only once coverage has
-  // ended, at `E + G`, so measuring the 30 days from `E` instead shortens the window by exactly `G` —
-  // and closes it entirely when `G >= 30d`, which a store grace period can reach.
+  // ended — at the access expiry plus the grace period — so measuring the 30 days from the expiry instead
+  // shortens the window by exactly the grace period, and closes it entirely once grace reaches 30d, which
+  // a store grace period can.
   const expiredCTADeadlineMs = accessExpiryTsMs + gracePeriodDurationMs + PRO_EXPIRED_CTA_WINDOW_MS;
 
   const proExpiringSoonCTA = !isUndefined(Storage.get(SettingsKey.proExpiringSoonCTA));
@@ -470,8 +475,8 @@ export async function applyMockedProStatusAtStartup(
   }
 
   let configExpiry: number | null = null;
-  // `G` only ever reaches config from a real response, so a mocked run usually has none and the
-  // Expired window falls back to being measured from `E` alone. Read from the same place as the
+  // The grace period only ever reaches config from a real response, so a mocked run usually has none and
+  // the Expired window falls back to being measured from the access expiry alone. Read from the same place as the
   // expiry rather than mocked separately: the two are written together, and a grace period that
   // disagreed with the expiry beside it is not a state the backend can produce.
   let configGraceMs = 0;
@@ -522,7 +527,7 @@ function lastStatusFetchAttemptAtMs(): number {
  * True when a routine status refresh should be *dropped* as too soon.
  *
  * Drop-on-fresh, not re-arm: rescheduling the skipped fetch would turn the routine triggers into a
- * self-sustaining once/60s poll, and during grace `E` sits static so it would carry nothing new. Safe
+ * self-sustaining once/60s poll, and during grace the access expiry sits static so it would carry nothing new. Safe
  * because status is display-only and backstopped by many triggers.
  *
  * The proof loop is deliberately the opposite — a throttled proof acquisition must still eventually
@@ -541,19 +546,20 @@ let userExpiryWakeIds: Array<ReturnType<typeof setTimeout>> = [];
  *
  * With the Pro page closed, nothing else re-checks between the expiry and the proof loop's own wake.
  *
- * Two instants, `E + 30s` and `(E + G) + 30s`, collapsing to one when `G` is zero. The second is not
- * redundant: the proof loop wakes near `E` by construction, but that chain fires only when `E` actually
- * changes, so it covers a renewal that succeeded and not one that failed.
+ * Two instants, 30s past the access expiry and 30s past coverage end, collapsing to one when there is no
+ * grace period. The second is not redundant: the proof loop wakes near the expiry by construction, but
+ * that chain fires only when the expiry actually changes, so it covers a renewal that succeeded and not
+ * one that failed.
  *
- * Re-derived on every call, so a renewal that advances `E` cannot leave a wake armed against the old
- * horizon.
+ * Re-derived on every call, so a renewal that advances the expiry cannot leave a wake armed against the
+ * old horizon.
  *
- * Both instants emit through the floored path and are `G` apart, so a short `G` drops the second one's
- * fetch — see STATUS_FLOOR_MS.
+ * Both instants emit through the floored path and are one grace period apart, so a short grace drops the
+ * second one's fetch — see STATUS_FLOOR_MS.
  */
 export async function scheduleUserExpiryStatusWake(): Promise<void> {
   // Always clear before re-deriving. This function is called on startup and after every successful
-  // fetch, so a renewal that advances `E` re-arms both instants against the NEW horizon; leaving a
+  // fetch, so a renewal that advances the expiry re-arms both instants against the NEW horizon; leaving a
   // stale wake armed would fire at an instant that no longer means anything.
   userExpiryWakeIds.forEach(clearTimeout);
   userExpiryWakeIds = [];
@@ -567,11 +573,11 @@ export async function scheduleUserExpiryStatusWake(): Promise<void> {
 
   // Two instants, because two distinct transitions matter and neither implies the other:
   //
-  //   expiry (E)              did the charge succeed, or has it silently failed?
-  //   coverage end (E + G)    did grace run out without a recovery?
+  //   accessExpiryMs   did the charge succeed, or has it silently failed?
+  //   coverageEndMs    did grace run out without a recovery?
   //
-  // Only one when `G` is zero, which is every non-auto-renewing account: the two collapse to the same
-  // moment and scheduling both would just double the fetch.
+  // Only one when there is no grace period, which is every non-auto-renewing account: the two collapse to
+  // the same moment and scheduling both would just double the fetch.
   const wakeAtMs = [accessExpiryMs];
   if (coverageEndMs !== accessExpiryMs) {
     wakeAtMs.push(coverageEndMs);
@@ -629,6 +635,8 @@ function logGateDecision(
  * refreshes on open — so decide from synced config whether a CTA could plausibly fire, rather than
  * fetching on every launch for every non-Pro and comfortably-active user.
  *
+ * Writing E for the access expiry and G for the grace period, so the rows line up:
+ *
  *   now >= E + G + 30d                            -> lapsed too long ago for any CTA, no fetch
  *   auto_renewing && now <  E                     -> comfortably active, no fetch
  *   auto_renewing && now >= E                     -> in grace or past it, unknowable from config,
@@ -636,8 +644,9 @@ function logGateDecision(
  *   !auto_renewing && E within the CTA window     -> expiring, fetch / CTA
  *   !auto_renewing && now >= E                    -> expired, confirm-fetch before the Expired CTA
  *
- * Only the upper bound uses `G`: grace and post-coverage both resolve to "fetch", so the lower bounds
- * need only "has the paid term ended", while "how long ago did this lapse" is measured from `E + G`.
+ * Only the upper bound uses the grace period: grace and post-coverage both resolve to "fetch", so the
+ * lower bounds need only "has the paid term ended", while "how long ago did this lapse" is measured from
+ * coverage end.
  *
  * Capped either way at one cold-start fetch per STATUS_STARTUP_MIN_INTERVAL_MS.
  */
@@ -658,7 +667,7 @@ async function coldStartShouldFetchProStatus(): Promise<boolean> {
   const accessExpiryMs = await UserConfigWrapperActions.getProAccessExpiry();
   if (!accessExpiryMs) {
     // No expiry in config: Pro was never held, or an outcome that ended entitlement cleared it. There is
-    // no window left to compute — every bound below is derived from `E` — so the only thing that can still
+    // no window left to compute — every bound below is derived from the access expiry — so the only thing that can still
     // want a fetch is an Expired CTA already latched by an earlier fetch. It gates on a status confirmed in
     // *this* process, so without a fetch here it can never be shown and the flag would sit set forever.
     const latchedExpiredCTA = Storage.get(SettingsKey.proExpiredCTA);
@@ -677,9 +686,10 @@ async function coldStartShouldFetchProStatus(): Promise<boolean> {
   // left to learn, so an account that lapsed long ago must stop fetching — otherwise it fetches once
   // per STATUS_STARTUP_MIN_INTERVAL_MS forever, for a CTA that can no longer fire.
   //
-  // Measured from coverage end, not from `E`: an account is not treated as lapsed until `E + G`, so
-  // measuring the elapsed time from `E` would shorten a renewing account's window by exactly its grace
-  // period. `G` is 0 when not auto-renewing, which makes this `E + 30d` for those accounts.
+  // Measured from coverage end, not from the access expiry: an account is not treated as lapsed until
+  // coverage ends, so measuring the elapsed time from the expiry would shorten a renewing account's window
+  // by exactly its grace period. Grace is 0 when not auto-renewing, which makes this expiry + 30d for
+  // those accounts.
   const gracePeriodMs = (await UserConfigWrapperActions.getProGracePeriod()) ?? 0;
   const inputs = { now, accessExpiryMs, autoRenewing, gracePeriodMs, lastStartupFetchMs };
   if (now >= accessExpiryMs + gracePeriodMs + PRO_EXPIRED_CTA_WINDOW_MS) {
@@ -687,11 +697,11 @@ async function coldStartShouldFetchProStatus(): Promise<boolean> {
   }
 
   if (autoRenewing) {
-    // `E` is the account's true expiry — what has been paid for. Past it the renewal has either landed
-    // (and `E` should have moved) or it hasn't, and config alone cannot tell which, so fetch and find
-    // out. The lower bound is `E` and not coverage end: both sides of `E + G` want a fetch — inside
+    // The access expiry is what has actually been paid for. Past it the renewal has either landed (and the
+    // expiry should have moved) or it hasn't, and config alone cannot tell which, so fetch and find out.
+    // The lower bound is the expiry and not coverage end: both sides of coverage end want a fetch — inside
     // grace to surface "renewal unsuccessful", past it to surface Expired — so the only instant that
-    // changes the answer is `E` itself.
+    // changes the answer is the expiry itself.
     return logGateDecision(
       now >= accessExpiryMs,
       'auto-renewing, so nothing to learn until the paid term has ended',
@@ -699,7 +709,7 @@ async function coldStartShouldFetchProStatus(): Promise<boolean> {
     );
   }
 
-  // Not auto-renewing. Expiring inside the CTA window, or already past `E` (where the fetch is the
+  // Not auto-renewing. Expiring inside the CTA window, or already past the access expiry (where the fetch is the
   // confirm-before-Expired-CTA step — config can say expired while a renewal that landed on another
   // device hasn't synced yet).
   return logGateDecision(
@@ -710,25 +720,27 @@ async function coldStartShouldFetchProStatus(): Promise<boolean> {
 }
 
 /**
- * Read `auto_renewing` (config key `A`) from synced config.
+ * Read the auto-renewing flag from synced config.
  *
- * `A` is presence-only in core: `set_pro_auto_renewing` uses `set_nonzero_int`, so writing false erases
+ * It is presence-only in core: `set_pro_auto_renewing` uses `set_nonzero_int`, so writing false erases
  * the key and the getter returns false for both "not auto-renewing" and "never written".
  *
- * That ambiguity is harmless because an `A` without an `E` beside it is not reachable here: the only two
- * paths that write `E` — the status fetch and a successful proof — write `A` from the same response, and
- * every outcome that ends entitlement *clears* `E`, which erases `A` and `G` with it. A new writer of `E`
- * has to carry the renewing flag, or that stops being true.
+ * That ambiguity is harmless because a renewing flag with no access expiry beside it is not reachable
+ * here: the only two paths that write the expiry — the status fetch and a successful proof — write the
+ * flag from the same response, and every outcome that ends entitlement *clears* the expiry, which erases
+ * the flag and the grace period with it. A new writer of the expiry has to carry the renewing flag, or
+ * that stops being true.
  */
 async function getProAutoRenewingFromConfig(): Promise<boolean> {
   return UserConfigWrapperActions.getProAutoRenewing();
 }
 
 /**
- * Persist `auto_renewing` into synced config, mirroring how each fetch persists `E`.
+ * Persist the auto-renewing flag into synced config, mirroring how each fetch persists the access expiry.
  *
  * Unconditional: libSession de-dupes a no-change write one layer down. A *presence*-based guard would be
- * actively wrong — `A` is presence-only, so a `false` erases the key and presence flips on every change.
+ * actively wrong — the flag is presence-only, so a `false` erases the key and presence flips on every
+ * change.
  */
 async function writeProAutoRenewingToConfig(autoRenewing: boolean): Promise<void> {
   await UserConfigWrapperActions.setProAutoRenewing(autoRenewing);
@@ -850,13 +862,14 @@ const fetchGetProStatusFromProBackend = createAsyncThunk(
           switch (state.data.userStatus) {
             case ProStatus.Active:
               window.log.debug(`[handleBackendProStatusChange] ProStatus.Active`);
-              // Keep the cached access-expiry (E) fresh from the account horizon (catches a
+              // Keep the cached access expiry fresh from the account horizon (catches a
               // horizon-only change the renewal path wouldn't). The proof itself is (re)obtained by
               // the reconcile loop, triggered below.
               //
               // All three are written from the SAME response, which is the only way they are jointly
-              // meaningful: `E + G` is coverage end, so a fresh `E` beside a `G` left over from an
-              // earlier subscription state describes an instant that was never true. `G` is the
+              // meaningful: the expiry plus the grace period is coverage end, so a fresh expiry beside a
+              // grace left over from an earlier subscription state describes an instant that was never
+              // true. The grace period written here is the
               // ACCOUNT-level `gracePeriodDurationMs` at the response root — not `latestPayment`'s
               // field of the same name, which is one store's raw declaration and is not gated on
               // auto-renewal.
@@ -908,7 +921,7 @@ const fetchGetProStatusFromProBackend = createAsyncThunk(
 
         if (state.data) {
           await putProStatusInStorage(state.data);
-          // `E` may have moved, so re-aim #6 at the new horizon.
+          // The access expiry may have moved, so re-aim #6 at the new horizon.
           void scheduleUserExpiryStatusWake();
         }
         // trigger a UI refresh so our state and Pro rights are up to date without a restart (animated image should stop animating)

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -1,6 +1,6 @@
 import type { WithMasterPrivKeyHex } from 'libsession_util_nodejs';
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { isNumber, isUndefined } from 'lodash';
+import { isUndefined } from 'lodash';
 import type { StateType } from '../reducer';
 import ProBackendAPI from '../../session/apis/pro_backend_api/ProBackendAPI';
 import { getFeatureFlag } from './types/releasedFeaturesReduxTypes';
@@ -410,123 +410,6 @@ async function handleExpiryCTAs(
       await Storage.put(SettingsKey.proExpiringSoonCTA, true);
     }
   }
-}
-
-/**
- * Shortest gap between two cold-launch status fetches. Desktop is relaunched many times a day, and
- * without a floor every launch spends an onion round trip re-confirming a status that cannot have
- * moved.
- *
- * 24h to match iOS (`SessionPro.StatusRefresh.startupMinIntervalSeconds`) and Android
- * (`ProRefreshWindows.STARTUP_MIN_INTERVAL`) — the consistency is the point of the gate.
- */
-const STARTUP_FETCH_MIN_INTERVAL_MS = 24 * DURATION.HOURS;
-
-/**
- * Whether the cold-launch get_pro_status fetch is worth making, matching the gate iOS
- * (`startupStatusFetchIsNeeded`) and Android (`startupGate`) already apply. The question both ask is
- * "could a CTA fire", so a comfortably-active account skips the fetch entirely.
- *
- * ⚠️ **Not all of the inputs are synced.** Only the expiry (`E`) and the proof arrive by config sync.
- * `autoRenewing` (`A`) and `gracePeriodDurationMs` (`G`) exist only on a fetched `GetProStatusResponse`,
- * so they can be read only from the last one persisted. A device that has never fetched knows `E` but
- * neither `A` nor `G`.
- *
- * Every unknown therefore resolves toward fetching, because the two errors are not symmetric: a
- * suppressed fetch can leave an account stranded on stale state, while a redundant one costs a request.
- * The gate stays quiet only when it positively knows the account is comfortably active.
- */
-/**
- * Evaluate the cold-launch gate and, if it says so, make the fetch and spend the interval.
- *
- * Run on returning to the foreground as well as at launch. The expiring-soon CTA arms seven days before
- * the access expiry, and nothing that survives backgrounding fires before that window opens — the proof
- * wakes land at the expiry and at the end of coverage. A subscriber who crosses into the window while
- * the app sits in the background would otherwise not be warned until it was next started cold.
- *
- * Evaluating more often is safe because the predicate is unchanged: a call inside the 24h interval
- * declines on the interval alone, before reading anything else, so this cannot become a fetch per
- * foreground.
- */
-export async function evaluateStartupProStatusFetch(): Promise<void> {
-  if (getFeatureFlag('mockProBackendSuccess')) {
-    // The mocked startup path already decided the CTAs without a round trip; a real response landing
-    // afterwards would overwrite that decision.
-    return;
-  }
-  if (!(await startupProStatusFetchIsNeeded())) {
-    return;
-  }
-  await Storage.put(SettingsKey.proStatusLastStartupFetchMs, Date.now());
-  window.inboxStore?.dispatch(proBackendDataActions.refreshGetProStatusFromProBackend({}) as any);
-}
-
-export async function startupProStatusFetchIsNeeded(): Promise<boolean> {
-  // Logged either way: a gate that declines silently is indistinguishable from a gate
-  // that never ran, and telling those apart is most of the work when a fetch shows up unexpectedly.
-  const decision = (needed: boolean, why: string) => {
-    window?.log?.debug(
-      `[startupProStatusFetch] ${needed ? 'fetching' : 'skipping the startup fetch'}: ${why}`
-    );
-    return needed;
-  };
-
-  const lastFetchMs = Storage.get(SettingsKey.proStatusLastStartupFetchMs);
-  const now = NetworkTime.now();
-  if (
-    isNumber(lastFetchMs) &&
-    lastFetchMs > 0 &&
-    now - lastFetchMs < STARTUP_FETCH_MIN_INTERVAL_MS
-  ) {
-    return decision(false, 'within the minimum interval since the last startup fetch');
-  }
-
-  let proAccessExpiry: number | null = null;
-  let haveProof = false;
-  try {
-    const cached = getCachedUserConfig();
-    proAccessExpiry = cached.proAccessExpiry ?? null;
-    haveProof = !!cached.proConfig?.proProof;
-  } catch {
-    // config not initialised yet (pre-login): nothing to reason about, and nothing to fetch for.
-    return decision(false, 'user config not initialised yet');
-  }
-
-  const lastResponse = getProStatusFromStorage();
-  const expiryMs = proAccessExpiry || lastResponse?.expiryMs || 0;
-
-  // Never had Pro and hold no proof: there is nothing local a CTA could be about.
-  // NOTE: an entitlement granted server-side that this device has never seen — a voucher, say — stays
-  // undiscovered until something else prompts a fetch. That is the cost of gating on local state.
-  if (!expiryMs && !haveProof) {
-    return decision(false, 'no access expiry and no proof');
-  }
-  if (!expiryMs) {
-    // A proof but no expiry: we cannot place ourselves on the timeline, so confirm.
-    return decision(true, 'a proof but no access expiry');
-  }
-
-  if (!lastResponse) {
-    // E is known but A and G are not, so no row of the table can be evaluated. Confirm.
-    return decision(true, 'an access expiry but no cached response for autoRenew/grace');
-  }
-
-  const { autoRenewing, gracePeriodDurationMs } = lastResponse;
-  const coverageEndMs = expiryMs + (gracePeriodDurationMs || 0);
-
-  if (now >= coverageEndMs) {
-    // Lapsed: confirm, so a renewal that landed on another device can't surface a false expiry here.
-    return decision(true, 'past the end of coverage');
-  }
-  if (autoRenewing) {
-    // Renewal is due at E and served through grace; only worth asking once we are past E.
-    return decision(now >= expiryMs, 'auto-renewing, renewal due at the access expiry');
-  }
-  // Not auto-renewing: the expiring-soon CTA arms seven days out, so ask once inside that window.
-  return decision(
-    now >= expiryMs - 7 * DURATION.DAYS,
-    'not auto-renewing, expiring-soon window opens seven days before the access expiry'
-  );
 }
 
 /**

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -4,6 +4,7 @@ import { isUndefined } from 'lodash';
 import type { StateType } from '../reducer';
 import ProBackendAPI from '../../session/apis/pro_backend_api/ProBackendAPI';
 import { getFeatureFlag } from './types/releasedFeaturesReduxTypes';
+import { mockedProExpiryMs, proAutoRenewWithMock, proStatusWithMock } from './types/proMocks';
 import { UserUtils } from '../../session/utils';
 import { getProMasterKeyHex } from '../../session/utils/User';
 import { updateLocalizedPopupDialog } from './modalDialog';
@@ -202,6 +203,31 @@ async function putProStatusInStorage(details: ProStatusResultType) {
   await Storage.put(SettingsKey.proStatus, details);
 }
 
+export function getProStatusFromStorage(): ProStatusResultType | null {
+  const response = Storage.get(SettingsKey.proStatus);
+  if (!response) {
+    return null;
+  }
+  // We persist, verbatim, the JS object the libsession-util-nodejs glue produced from the backend
+  // response (see putProStatusInStorage) — not a raw libsession struct — and cast it back to the
+  // CURRENT ProStatusResultType (an alias of the glue's GetProStatusResponse). session-desktop and
+  // libsession-util-nodejs ship in lockstep, so within a single build the producer, the type and this
+  // consumer can't drift — but a cache written by an OLDER build can.
+  //
+  // ⚠️ TRANSITION REQUIRED IF YOU ADD A REQUIRED FIELD to this shape: an upgraded client would read a
+  // stale-shape cache here and cast it to the new type with that field undefined (the Array.isArray
+  // check below validates only the top level, not individual fields). Handle it as part of that change —
+  // e.g. drop this cache behind a stored shape/version marker, or keep the new field optional at this
+  // boundary. It's a transient, re-fetched cache, so drop-and-refetch is the simplest transition. This
+  // is left as a reminder rather than pre-built, since pre-building would just be guessing at the shape.
+  if (typeof response === 'object' && response !== null && 'userStatus' in response) {
+    return response as ProStatusResultType;
+  }
+  void Storage.remove(SettingsKey.proStatus);
+  window?.log?.error('pro status in storage were malformed; removing.');
+  return null;
+}
+
 /** A currently-usable proof is held (unexpired). Revocation is a separate clear path. */
 function haveValidProof(): boolean {
   const proof = getCachedUserConfig().proConfig?.proProof;
@@ -381,6 +407,50 @@ async function handleExpiryCTAs(
       await Storage.put(SettingsKey.proExpiringSoonCTA, true);
     }
   }
+}
+
+/**
+ * Arm the expiry CTAs from the mocks alone, with no backend round trip.
+ *
+ * The CTA decision on Desktop is *persisted*, not derived: `handleExpiryCTAs` writes
+ * `SettingsKey.proExpiringSoonCTA` from a fetched response, and `handleTriggeredCTAs` later reads the
+ * mark. A mock applied where status is *selected* therefore lands downstream of the decision, which is
+ * why the existing mocks can render a Pro screen but cannot arm this CTA. iOS reaches the same place
+ * with `LoadingState.simulate(.success)`.
+ *
+ * This deliberately runs the real `handleExpiryCTAs` rather than seeding the stored flag: the seven-day
+ * and thirty-day boundaries, and the clearing when an account goes active again, are the behaviour a
+ * spec exists to exercise.
+ *
+ * Returns whether it handled startup, so the caller can skip the real fetch — letting both run would
+ * have a genuine response overwrite the mocked decision moments later.
+ */
+export async function applyMockedProStatusAtStartup(
+  dispatch: Parameters<typeof handleTriggeredCTAs>[0]
+): Promise<boolean> {
+  if (!getFeatureFlag('mockProBackendSuccess')) {
+    return false;
+  }
+
+  let configExpiry: number | null = null;
+  try {
+    configExpiry = getCachedUserConfig().proAccessExpiry ?? null;
+  } catch {
+    // config not initialised yet: the mocked expiry is the only source, which is the normal case here.
+  }
+  const expiryMs = mockedProExpiryMs() ?? configExpiry ?? 0;
+  if (!expiryMs) {
+    // Every branch of handleExpiryCTAs is relative to the expiry, so without one it is a no-op and a
+    // spec would see nothing with no indication why.
+    window?.log?.warn(
+      'mockProBackendSuccess is set but no expiry is known: set SESSION_PRO_ACCESS_EXPIRY'
+    );
+  }
+
+  await handleExpiryCTAs(expiryMs, proAutoRenewWithMock(true), proStatusWithMock(ProStatus.Active));
+  void handleTriggeredCTAs(dispatch, false);
+  firstFetchProStatusHappened = true;
+  return true;
 }
 
 let firstFetchProStatusHappened = false;
@@ -722,11 +792,14 @@ const fetchGetProStatusFromProBackend = createAsyncThunk(
               );
               break;
           }
+          // The mocks have to be applied here too, not only in the settings selector: this reads the
+          // raw fetched response, so without them a mocked expiry or status never reaches the code
+          // that arms the CTAs and neither expiry CTA is reachable from a test.
           await handleExpiryCTAs(
-            state.data.expiryMs,
+            mockedProExpiryMs() ?? state.data.expiryMs,
             state.data.gracePeriodDurationMs,
-            state.data.autoRenewing,
-            state.data.userStatus
+            proAutoRenewWithMock(state.data.autoRenewing),
+            proStatusWithMock(state.data.userStatus)
           );
           // on the first fetch of our pro status after a restart, we want to show the CTAs if needed
           if (window.inboxStore?.dispatch && !firstFetchProStatusHappened) {

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -565,6 +565,30 @@ export async function scheduleUserExpiryStatusWake(): Promise<void> {
 // ===== The startup gate =====
 
 /**
+ * Record the startup gate's verdict, the row that produced it, and the values that row read.
+ *
+ * A gate that declines silently is indistinguishable from one that never ran, so a log line that only
+ * said "no fetch" would not be worth its cost — the reason and the inputs are the whole point. Every
+ * row logs, including the ones that allow the fetch, because "which row let this through" is the same
+ * question asked from the other side.
+ *
+ * Pass-through: it returns what it is given, so it cannot move the gate's answer.
+ */
+function logGateDecision(
+  shouldFetch: boolean,
+  reason: string,
+  inputs: Record<string, unknown>
+): boolean {
+  const values = Object.entries(inputs)
+    .map(([key, value]) => `${key}=${value}`)
+    .join(' ');
+  window?.log?.debug(
+    `[proStartupGate] ${shouldFetch ? 'FETCH' : 'no fetch'}: ${reason} — ${values}`
+  );
+  return shouldFetch;
+}
+
+/**
  * Whether a *cold start* is allowed to fetch `get_pro_status`.
  *
  * Startup's only consumer is the home CTAs — entitlement comes from the proof and the settings screen
@@ -588,8 +612,13 @@ async function coldStartShouldFetchProStatus(): Promise<boolean> {
   // is keyed on a stored flag rather than on a horizon and would otherwise fetch on every single launch.
   const lastStartupFetchMs =
     (Storage.get(SettingsKey.proStatusLastStartupFetchMs) as number | undefined) ?? 0;
-  if (NetworkTime.now() < lastStartupFetchMs + STATUS_STARTUP_MIN_INTERVAL_MS) {
-    return false;
+  const nowAtEntry = NetworkTime.now();
+  if (nowAtEntry < lastStartupFetchMs + STATUS_STARTUP_MIN_INTERVAL_MS) {
+    return logGateDecision(false, 'inside the minimum interval since the last cold-start fetch', {
+      now: nowAtEntry,
+      lastStartupFetchMs,
+      minIntervalMs: STATUS_STARTUP_MIN_INTERVAL_MS,
+    });
   }
 
   const accessExpiryMs = await UserConfigWrapperActions.getProAccessExpiry();
@@ -598,7 +627,12 @@ async function coldStartShouldFetchProStatus(): Promise<boolean> {
     // no window left to compute — every bound below is derived from `E` — so the only thing that can still
     // want a fetch is an Expired CTA already latched by an earlier fetch. It gates on a status confirmed in
     // *this* process, so without a fetch here it can never be shown and the flag would sit set forever.
-    return !isUndefined(Storage.get(SettingsKey.proExpiredCTA));
+    const latchedExpiredCTA = Storage.get(SettingsKey.proExpiredCTA);
+    return logGateDecision(
+      !isUndefined(latchedExpiredCTA),
+      'no access expiry in config, so only a latched Expired CTA can still want a fetch',
+      { now: nowAtEntry, accessExpiryMs, latchedExpiredCTA, lastStartupFetchMs }
+    );
   }
 
   const now = NetworkTime.now();
@@ -613,8 +647,9 @@ async function coldStartShouldFetchProStatus(): Promise<boolean> {
   // measuring the elapsed time from `E` would shorten a renewing account's window by exactly its grace
   // period. `G` is 0 when not auto-renewing, which makes this `E + 30d` for those accounts.
   const gracePeriodMs = (await UserConfigWrapperActions.getProGracePeriod()) ?? 0;
+  const inputs = { now, accessExpiryMs, autoRenewing, gracePeriodMs, lastStartupFetchMs };
   if (now >= accessExpiryMs + gracePeriodMs + PRO_EXPIRED_CTA_WINDOW_MS) {
-    return false;
+    return logGateDecision(false, 'lapsed longer ago than any CTA window reaches back', inputs);
   }
 
   if (autoRenewing) {
@@ -623,13 +658,21 @@ async function coldStartShouldFetchProStatus(): Promise<boolean> {
     // out. The lower bound is `E` and not coverage end: both sides of `E + G` want a fetch — inside
     // grace to surface "renewal unsuccessful", past it to surface Expired — so the only instant that
     // changes the answer is `E` itself.
-    return now >= accessExpiryMs;
+    return logGateDecision(
+      now >= accessExpiryMs,
+      'auto-renewing, so nothing to learn until the paid term has ended',
+      inputs
+    );
   }
 
   // Not auto-renewing. Expiring inside the CTA window, or already past `E` (where the fetch is the
   // confirm-before-Expired-CTA step — config can say expired while a renewal that landed on another
   // device hasn't synced yet).
-  return now >= accessExpiryMs - PRO_EXPIRING_CTA_WINDOW_MS;
+  return logGateDecision(
+    now >= accessExpiryMs - PRO_EXPIRING_CTA_WINDOW_MS,
+    'not auto-renewing, so the expiring-soon window is the lower bound',
+    inputs
+  );
 }
 
 /**

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -1,6 +1,6 @@
 import type { WithMasterPrivKeyHex } from 'libsession_util_nodejs';
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { isUndefined } from 'lodash';
+import { isNumber, isUndefined } from 'lodash';
 import type { StateType } from '../reducer';
 import ProBackendAPI from '../../session/apis/pro_backend_api/ProBackendAPI';
 import { getFeatureFlag } from './types/releasedFeaturesReduxTypes';
@@ -553,8 +553,15 @@ export async function applyMockedProStatusAtStartup(
   }
 
   let configExpiry: number | null = null;
+  // `G` only ever reaches config from a real response, so a mocked run usually has none and the
+  // Expired window falls back to being measured from `E` alone. Read from the same place as the
+  // expiry rather than mocked separately: the two are written together, and a grace period that
+  // disagreed with the expiry beside it is not a state the backend can produce.
+  let configGraceMs = 0;
   try {
-    configExpiry = getCachedUserConfig().proAccessExpiry ?? null;
+    const cached = getCachedUserConfig();
+    configExpiry = cached.proAccessExpiry ?? null;
+    configGraceMs = cached.proGracePeriod ?? 0;
   } catch {
     // config not initialised yet: the mocked expiry is the only source, which is the normal case here.
   }
@@ -567,7 +574,12 @@ export async function applyMockedProStatusAtStartup(
     );
   }
 
-  await handleExpiryCTAs(expiryMs, proAutoRenewWithMock(true), proStatusWithMock(ProStatus.Active));
+  await handleExpiryCTAs(
+    expiryMs,
+    configGraceMs,
+    proAutoRenewWithMock(true),
+    proStatusWithMock(ProStatus.Active)
+  );
   // A simulated success confirms a status as far as the CTAs are concerned: the whole point is to reach
   // them without a round trip, and the guard they sit behind asks whether a status is known, not whether
   // the network produced it.

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -413,6 +413,123 @@ async function handleExpiryCTAs(
 }
 
 /**
+ * Shortest gap between two cold-launch status fetches. Desktop is relaunched many times a day, and
+ * without a floor every launch spends an onion round trip re-confirming a status that cannot have
+ * moved.
+ *
+ * 24h to match iOS (`SessionPro.StatusRefresh.startupMinIntervalSeconds`) and Android
+ * (`ProRefreshWindows.STARTUP_MIN_INTERVAL`) — the consistency is the point of the gate.
+ */
+const STARTUP_FETCH_MIN_INTERVAL_MS = 24 * DURATION.HOURS;
+
+/**
+ * Whether the cold-launch get_pro_status fetch is worth making, matching the gate iOS
+ * (`startupStatusFetchIsNeeded`) and Android (`startupGate`) already apply. The question both ask is
+ * "could a CTA fire", so a comfortably-active account skips the fetch entirely.
+ *
+ * ⚠️ **Not all of the inputs are synced.** Only the expiry (`E`) and the proof arrive by config sync.
+ * `autoRenewing` (`A`) and `gracePeriodDurationMs` (`G`) exist only on a fetched `GetProStatusResponse`,
+ * so they can be read only from the last one persisted. A device that has never fetched knows `E` but
+ * neither `A` nor `G`.
+ *
+ * Every unknown therefore resolves toward fetching, because the two errors are not symmetric: a
+ * suppressed fetch can leave an account stranded on stale state, while a redundant one costs a request.
+ * The gate stays quiet only when it positively knows the account is comfortably active.
+ */
+/**
+ * Evaluate the cold-launch gate and, if it says so, make the fetch and spend the interval.
+ *
+ * Run on returning to the foreground as well as at launch. The expiring-soon CTA arms seven days before
+ * the access expiry, and nothing that survives backgrounding fires before that window opens — the proof
+ * wakes land at the expiry and at the end of coverage. A subscriber who crosses into the window while
+ * the app sits in the background would otherwise not be warned until it was next started cold.
+ *
+ * Evaluating more often is safe because the predicate is unchanged: a call inside the 24h interval
+ * declines on the interval alone, before reading anything else, so this cannot become a fetch per
+ * foreground.
+ */
+export async function evaluateStartupProStatusFetch(): Promise<void> {
+  if (getFeatureFlag('mockProBackendSuccess')) {
+    // The mocked startup path already decided the CTAs without a round trip; a real response landing
+    // afterwards would overwrite that decision.
+    return;
+  }
+  if (!(await startupProStatusFetchIsNeeded())) {
+    return;
+  }
+  await Storage.put(SettingsKey.proStatusLastStartupFetchMs, Date.now());
+  window.inboxStore?.dispatch(proBackendDataActions.refreshGetProStatusFromProBackend({}) as any);
+}
+
+export async function startupProStatusFetchIsNeeded(): Promise<boolean> {
+  // Logged either way: a gate that declines silently is indistinguishable from a gate
+  // that never ran, and telling those apart is most of the work when a fetch shows up unexpectedly.
+  const decision = (needed: boolean, why: string) => {
+    window?.log?.debug(
+      `[startupProStatusFetch] ${needed ? 'fetching' : 'skipping the startup fetch'}: ${why}`
+    );
+    return needed;
+  };
+
+  const lastFetchMs = Storage.get(SettingsKey.proStatusLastStartupFetchMs);
+  const now = NetworkTime.now();
+  if (
+    isNumber(lastFetchMs) &&
+    lastFetchMs > 0 &&
+    now - lastFetchMs < STARTUP_FETCH_MIN_INTERVAL_MS
+  ) {
+    return decision(false, 'within the minimum interval since the last startup fetch');
+  }
+
+  let proAccessExpiry: number | null = null;
+  let haveProof = false;
+  try {
+    const cached = getCachedUserConfig();
+    proAccessExpiry = cached.proAccessExpiry ?? null;
+    haveProof = !!cached.proConfig?.proProof;
+  } catch {
+    // config not initialised yet (pre-login): nothing to reason about, and nothing to fetch for.
+    return decision(false, 'user config not initialised yet');
+  }
+
+  const lastResponse = getProStatusFromStorage();
+  const expiryMs = proAccessExpiry || lastResponse?.expiryMs || 0;
+
+  // Never had Pro and hold no proof: there is nothing local a CTA could be about.
+  // NOTE: an entitlement granted server-side that this device has never seen — a voucher, say — stays
+  // undiscovered until something else prompts a fetch. That is the cost of gating on local state.
+  if (!expiryMs && !haveProof) {
+    return decision(false, 'no access expiry and no proof');
+  }
+  if (!expiryMs) {
+    // A proof but no expiry: we cannot place ourselves on the timeline, so confirm.
+    return decision(true, 'a proof but no access expiry');
+  }
+
+  if (!lastResponse) {
+    // E is known but A and G are not, so no row of the table can be evaluated. Confirm.
+    return decision(true, 'an access expiry but no cached response for autoRenew/grace');
+  }
+
+  const { autoRenewing, gracePeriodDurationMs } = lastResponse;
+  const coverageEndMs = expiryMs + (gracePeriodDurationMs || 0);
+
+  if (now >= coverageEndMs) {
+    // Lapsed: confirm, so a renewal that landed on another device can't surface a false expiry here.
+    return decision(true, 'past the end of coverage');
+  }
+  if (autoRenewing) {
+    // Renewal is due at E and served through grace; only worth asking once we are past E.
+    return decision(now >= expiryMs, 'auto-renewing, renewal due at the access expiry');
+  }
+  // Not auto-renewing: the expiring-soon CTA arms seven days out, so ask once inside that window.
+  return decision(
+    now >= expiryMs - 7 * DURATION.DAYS,
+    'not auto-renewing, expiring-soon window opens seven days before the access expiry'
+  );
+}
+
+/**
  * Arm the expiry CTAs from the mocks alone, with no backend round trip.
  *
  * The CTA decision on Desktop is *persisted*, not derived: `handleExpiryCTAs` writes

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -21,7 +21,10 @@ import {
   UserConfigWrapperActions,
 } from '../../webworker/workers/browser/libsession/libsession_worker_userconfig_interface';
 import { ConvoHub } from '../../session/conversations';
-import { handleTriggeredCTAs } from '../../components/dialog/SessionCTA';
+import {
+  handleTriggeredCTAs,
+  markProStatusConfirmedThisRun,
+} from '../../components/dialog/SessionCTA';
 
 type RequestState<D = unknown> = {
   isFetching: boolean;
@@ -448,6 +451,10 @@ export async function applyMockedProStatusAtStartup(
   }
 
   await handleExpiryCTAs(expiryMs, proAutoRenewWithMock(true), proStatusWithMock(ProStatus.Active));
+  // A simulated success confirms a status as far as the CTAs are concerned: the whole point is to reach
+  // them without a round trip, and the guard they sit behind asks whether a status is known, not whether
+  // the network produced it.
+  markProStatusConfirmedThisRun();
   void handleTriggeredCTAs(dispatch, false);
   firstFetchProStatusHappened = true;
   return true;
@@ -801,6 +808,7 @@ const fetchGetProStatusFromProBackend = createAsyncThunk(
             proAutoRenewWithMock(state.data.autoRenewing),
             proStatusWithMock(state.data.userStatus)
           );
+          markProStatusConfirmedThisRun();
           // on the first fetch of our pro status after a restart, we want to show the CTAs if needed
           if (window.inboxStore?.dispatch && !firstFetchProStatusHappened) {
             void handleTriggeredCTAs(window.inboxStore?.dispatch, false);

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -250,10 +250,9 @@ function haveValidProof(): boolean {
  * whose periodic tick does not exist until the 20s timeout in `doAppStartUp` has scheduled the first
  * one. A process that ends before then loses the write outright.
  *
- * Local durability only — deliberately not a push. The wrapper records that a change still needs
- * pushing and that state rides the dump, so the ordinary sync job sends this whenever it next runs. The
- * delay before that first job is not a gap to be worked around: it is there so a client that is still
- * receiving its own config does not publish a partial one over it.
+ * The first sync job is delayed so a client still receiving its own config does not publish a partial one
+ * over it, so this dumps without pushing; the wrapper records that a push is still needed and that state
+ * rides the dump, so the ordinary job sends it whenever it next runs.
  *
  * Call once per write group, not per setter. The access expiry, the auto-renewing flag and the grace
  * period are only jointly meaningful and are always written together, and each dump costs a worker round

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -21,6 +21,7 @@ import {
   UserConfigWrapperActions,
 } from '../../webworker/workers/browser/libsession/libsession_worker_userconfig_interface';
 import { ConvoHub } from '../../session/conversations';
+import { LibSessionUtil } from '../../session/utils/libsession/libsession_utils';
 import {
   handleTriggeredCTAs,
   markProStatusConfirmedThisRun,
@@ -242,6 +243,34 @@ function haveValidProof(): boolean {
  * agent-comms/pro-proof-renewal-loop-design.md §4). A stale response must never reduce coverage:
  * upgrades are gated on a strictly-newer expiry, clears on there being no valid proof to protect.
  */
+/**
+ * Put a Pro config write on disk, now rather than whenever something else happens to.
+ *
+ * A setter leaves its value in the in-memory wrapper, and the only writer of the dump is `UserSyncJob`,
+ * whose periodic tick does not exist until the 20s timeout in `doAppStartUp` has scheduled the first
+ * one. A process that ends before then loses the write outright.
+ *
+ * Local durability only — deliberately not a push. The wrapper records that a change still needs
+ * pushing and that state rides the dump, so the ordinary sync job sends this whenever it next runs. The
+ * delay before that first job is not a gap to be worked around: it is there so a client that is still
+ * receiving its own config does not publish a partial one over it.
+ *
+ * Call once per write group, not per setter. `E`, `A` and `G` are only jointly meaningful and are always
+ * written together, and each dump costs a worker round trip plus an IPC round trip to the main process.
+ *
+ * ⚠️ Never throws. A failed dump is a transient IPC/DB problem and the value is still correct in the
+ * wrapper, so the next dump carries it; throwing here would abort the rest of the caller's write group
+ * and leave `E` stored without the `A` and `G` that qualify it — the mismatch the callers go out of
+ * their way to avoid.
+ */
+export async function persistProConfigWrite(): Promise<void> {
+  try {
+    await LibSessionUtil.saveDumpsToDb(UserUtils.getOurPubKeyStrFromCache());
+  } catch (e) {
+    window?.log?.warn(`persistProConfigWrite: saving the config dump failed: ${e.message}`);
+  }
+}
+
 async function applyProofOutcome(
   response: Awaited<ReturnType<typeof ProBackendAPI.generateProProof>>,
   rotatingSeedHex: string
@@ -279,6 +308,7 @@ async function applyProofOutcome(
     }
     await writeProAutoRenewingToConfig(response.accountAutoRenewing);
     await UserConfigWrapperActions.setProGracePeriod(response.accountGracePeriodMs);
+    await persistProConfigWrite();
     return;
   }
   // Non-ok: the machine slug (error_code) decides.
@@ -293,6 +323,7 @@ async function applyProofOutcome(
       if (!haveValidProof()) {
         await UserConfigWrapperActions.removeProConfig();
         await UserConfigWrapperActions.setProAccessExpiry(null);
+        await persistProConfigWrite();
         // Entitlement ended, and nothing observes that: the config watch that would refresh our status
         // runs on incoming merges, so a local write reaches no one. The Expired CTA needs a status fetch
         // to be raised at all — it is written by one — and the clear above leaves the cold-start gate
@@ -311,6 +342,7 @@ async function applyProofOutcome(
       if (!haveValidProof()) {
         await UserConfigWrapperActions.removeProConfig();
         await UserConfigWrapperActions.setProAccessExpiry(null);
+        await persistProConfigWrite();
       }
       break;
     case 'revoked':
@@ -318,6 +350,7 @@ async function applyProofOutcome(
       // proof gone we must also clear E, or the renewal target (future E, no proof) would spin.
       await UserConfigWrapperActions.removeProConfig();
       await UserConfigWrapperActions.setProAccessExpiry(null);
+      await persistProConfigWrite();
       break;
     default:
       // Unrecognized error_code: fail closed, non-destructively — treat as transient (no write/clear).
@@ -331,6 +364,7 @@ async function applyProofOutcome(
 async function handleClearProProof() {
   await UserConfigWrapperActions.removeProConfig();
   await UserConfigWrapperActions.setProAccessExpiry(null);
+  await persistProConfigWrite();
 }
 
 // ===== get_pro_status refresh discipline =====
@@ -829,6 +863,7 @@ const fetchGetProStatusFromProBackend = createAsyncThunk(
               await UserConfigWrapperActions.setProAccessExpiry(state.data.expiryMs);
               await writeProAutoRenewingToConfig(state.data.autoRenewing);
               await UserConfigWrapperActions.setProGracePeriod(state.data.gracePeriodDurationMs);
+              await persistProConfigWrite();
               break;
 
             case ProStatus.Never:

--- a/ts/state/ducks/types/defaultFeatureFlags.ts
+++ b/ts/state/ducks/types/defaultFeatureFlags.ts
@@ -1,8 +1,10 @@
 import { isEmpty } from 'lodash';
 import { isTestIntegration, isTestNet } from '../../../shared/env_vars';
-import type {
-  SessionBooleanFeatureFlags,
-  SessionDataFeatureFlags,
+import { ProStatus } from '../../../session/apis/pro_backend_api/types';
+import {
+  MockProAccessExpiryOptions,
+  type SessionBooleanFeatureFlags,
+  type SessionDataFeatureFlags,
 } from './releasedFeaturesReduxTypes';
 
 export const defaultProBooleanFeatureFlags = {
@@ -70,20 +72,95 @@ function getMockNetworkPageNodeCount() {
   }
 }
 
+/**
+ * An unrecognised value for a mock env var must not degrade to "no override". A typo would then
+ * surface as a failed assertion about the app, several steps from its cause, rather than as a
+ * setup error — so these throw.
+ */
+function invalidMockEnvVar(name: string, value: string, allowed: Array<string>): never {
+  const message = `${name}: "${value}" is not one of ${allowed.join(' | ')}`;
+  // eslint-disable-next-line no-console
+  console.error(message);
+  window?.log?.error(message);
+  throw new Error(message);
+}
+
+/**
+ * The Pro status the app should project, from the environment.
+ *
+ * The slugs are libsession's own (`ProStatus`) plus `useactual`, which is the shared vocabulary the
+ * iOS and Android harnesses also take, so one value in a cross-platform test config drives all
+ * three clients. `useactual` is spelled out rather than left to an unset variable so a config can
+ * say "no override" explicitly.
+ *
+ * Note for whoever maps the shared `active` token onto Desktop: on all three clients `active` means
+ * active *and not auto-renewing*, so the harness must pass SESSION_USER_HAS_PRO_CANCELLED alongside
+ * this. Deliberately not coupled here — this flag projects the status and nothing else, and having
+ * it silently move autoRenew would surprise every non-test reader of `mockProCurrentStatus`.
+ */
+function getMockProCurrentStatus(): ProStatus | null {
+  const envVar = process.env.SESSION_PRO_CURRENT_STATUS?.trim();
+  if (!envVar) {
+    return null;
+  }
+  const known = [ProStatus.Never, ProStatus.Active, ProStatus.Expired] as Array<ProStatus>;
+  if (known.includes(envVar)) {
+    return envVar;
+  }
+  if (envVar === 'useactual') {
+    return null;
+  }
+  return invalidMockEnvVar('SESSION_PRO_CURRENT_STATUS', envVar, [...known, 'useactual']);
+}
+
+/**
+ * Named rather than numeric, because the enum's numbering is an implementation detail that
+ * reorders whenever a case is inserted — an environment pinned to `2` would silently start
+ * meaning a different duration.
+ */
+function getMockProAccessExpiry(): MockProAccessExpiryOptions | null {
+  const envVar = process.env.SESSION_PRO_ACCESS_EXPIRY?.trim();
+  if (!envVar) {
+    return null;
+  }
+  const option = MockProAccessExpiryOptions[envVar as keyof typeof MockProAccessExpiryOptions];
+  if (typeof option === 'number') {
+    return option;
+  }
+  return invalidMockEnvVar(
+    'SESSION_PRO_ACCESS_EXPIRY',
+    envVar,
+    Object.keys(MockProAccessExpiryOptions).filter(k => Number.isNaN(Number(k)))
+  );
+}
+
+/**
+ * Path to an image for the test-integration avatar picker to return.
+ *
+ * Only emptiness is checked here — whether the file exists and is a usable image is settled in
+ * `pickFileForTestIntegration`, which owns the accepted-extension list. Duplicating that list here
+ * would give two sources of truth for one rule, and the picker's error is raised the moment a test
+ * uploads, which is loud enough.
+ */
+function getFakeAvatarPickerFile(): string | null {
+  return process.env.SESSION_FAKE_AVATAR_PICKER_FILE?.trim() || null;
+}
+
 export const defaultAvatarPickerColor = '#0000ff'; // defaults to blue
 
 export const defaultProDataFeatureFlags = {
   mockMessageProFeatures: null,
-  mockProCurrentStatus: null,
+  mockProCurrentStatus: getMockProCurrentStatus(),
   mockProPaymentProvider: null,
   mockProAccessVariant: null,
-  mockProAccessExpiry: null,
+  mockProAccessExpiry: getMockProAccessExpiry(),
   mockProLongerMessagesSent: null,
   mockProPinnedConversations: null,
   mockProBadgesSent: null,
   mockProGroupsUpgraded: null,
   mockNetworkPageNodeCount: getMockNetworkPageNodeCount(),
   fakeAvatarPickerColor: defaultAvatarPickerColor,
+  fakeAvatarPickerFile: getFakeAvatarPickerFile(),
 } as const;
 
 export const defaultDataFeatureFlags = {

--- a/ts/state/ducks/types/defaultFeatureFlags.ts
+++ b/ts/state/ducks/types/defaultFeatureFlags.ts
@@ -19,6 +19,9 @@ export const defaultProBooleanFeatureFlags = {
   mockProRecoverButtonAlwaysFail: !isEmpty(process.env.SESSION_PRO_RECOVER_ALWAYS_FAIL),
   mockProBackendLoading: !isEmpty(process.env.SESSION_PRO_BACKEND_LOADING),
   mockProBackendError: !isEmpty(process.env.SESSION_PRO_BACKEND_ERROR),
+  // Completes the triple: the other two mock the negative outcomes of a get_pro_status fetch, this
+  // one mocks a confirmed success, which is the state the expiry CTAs are armed from.
+  mockProBackendSuccess: !isEmpty(process.env.SESSION_PRO_BACKEND_SUCCESS),
 } as const;
 
 export const defaultBooleanFeatureFlags = {

--- a/ts/state/ducks/types/defaultFeatureFlags.ts
+++ b/ts/state/ducks/types/defaultFeatureFlags.ts
@@ -3,6 +3,7 @@ import { isTestIntegration, isTestNet } from '../../../shared/env_vars';
 import { ProStatus } from '../../../session/apis/pro_backend_api/types';
 import {
   MockProAccessExpiryOptions,
+  MockProProofOptions,
   type SessionBooleanFeatureFlags,
   type SessionDataFeatureFlags,
 } from './releasedFeaturesReduxTypes';
@@ -117,6 +118,33 @@ function getMockProCurrentStatus(): ProStatus | null {
 }
 
 /**
+ * Whether a mocked run holds a usable Pro proof — ACCESS, as opposed to the plan status this
+ * deliberately does NOT touch.
+ *
+ * Split from `SESSION_PRO_CURRENT_STATUS` because one lever driving both made the interesting state
+ * unreachable: a plan that reads active while no usable proof exists is exactly where a message is
+ * accepted at the Pro length and then silently truncated for every recipient, and a test could not ask
+ * for it. Specs now set both, so what a client shows and what it may do are stated separately.
+ *
+ * `useactual` is spelled out rather than left to an unset variable, matching the other Pro mocks, so a
+ * config can say "no override" explicitly.
+ */
+function getMockProProof(): MockProProofOptions | null {
+  const envVar = process.env.SESSION_PRO_MOCK_PROOF?.trim();
+  if (!envVar) {
+    return null;
+  }
+  const known = Object.values(MockProProofOptions) as Array<string>;
+  if (known.includes(envVar)) {
+    return envVar as MockProProofOptions;
+  }
+  if (envVar === 'useactual') {
+    return null;
+  }
+  return invalidMockEnvVar('SESSION_PRO_MOCK_PROOF', envVar, [...known, 'useactual']);
+}
+
+/**
  * Named rather than numeric, because the enum's numbering is an implementation detail that
  * reorders whenever a case is inserted — an environment pinned to `2` would silently start
  * meaning a different duration.
@@ -154,6 +182,7 @@ export const defaultAvatarPickerColor = '#0000ff'; // defaults to blue
 export const defaultProDataFeatureFlags = {
   mockMessageProFeatures: null,
   mockProCurrentStatus: getMockProCurrentStatus(),
+  mockProProof: getMockProProof(),
   mockProPaymentProvider: null,
   mockProAccessVariant: null,
   mockProAccessExpiry: getMockProAccessExpiry(),

--- a/ts/state/ducks/types/proMocks.ts
+++ b/ts/state/ducks/types/proMocks.ts
@@ -72,6 +72,25 @@ export function proStatusWithMock(actual: ProStatus): ProStatus {
   return getDataFeatureFlag('mockProCurrentStatus') ?? actual;
 }
 
+/**
+ * Whether our Pro ACCESS should be treated as granted, given what the proof actually says.
+ *
+ * A mocked run holds no real proof — the mock names a status, and no signed credential exists to go
+ * with it. So the status mock has to reach ACCESS as well, or every surface that reads ACCESS goes dark
+ * under exactly the mocks the tests drive Pro state with, and the mock would only be able to express
+ * "not Pro".
+ *
+ * This is the one place the two values are deliberately tied together, and only when mocked. Leave the
+ * real path alone: unmocked, ACCESS is the proof and nothing else.
+ */
+export function proAccessWithMock(actual: boolean): boolean {
+  const mocked = getDataFeatureFlag('mockProCurrentStatus');
+  if (mocked === null) {
+    return actual;
+  }
+  return mocked === ProStatus.Active;
+}
+
 /** Whether the plan should be treated as auto-renewing, given what the backend actually reported. */
 export function proAutoRenewWithMock(actual: boolean): boolean {
   return getFeatureFlag('mockCurrentUserHasProCancelled') ? false : actual;

--- a/ts/state/ducks/types/proMocks.ts
+++ b/ts/state/ducks/types/proMocks.ts
@@ -1,0 +1,78 @@
+import { ProStatus } from '../../../session/apis/pro_backend_api/types';
+import { NetworkTime } from '../../../util/NetworkTime';
+import {
+  getDataFeatureFlag,
+  getFeatureFlag,
+  MockProAccessExpiryOptions,
+} from './releasedFeaturesReduxTypes';
+
+/**
+ * One definition of what the Pro mocks mean, shared by everything that has to honour them.
+ *
+ * There are three consumers and they are reached by different paths — the settings selector, the
+ * `useHasPro` gate, and the CTA arming inside the get_pro_status thunk, which reads the raw fetched
+ * response rather than the selector's output. Each applying its own overrides is how the CTAs ended up
+ * unreachable from a mock while the settings screen honoured it.
+ */
+
+function mockedProAccessExpiryDuration(variant: MockProAccessExpiryOptions): number | null {
+  switch (variant) {
+    case MockProAccessExpiryOptions.P7D:
+      return 7 * 24 * 60 * 60 * 1000;
+    case MockProAccessExpiryOptions.P29D:
+      return 29 * 24 * 60 * 60 * 1000;
+    case MockProAccessExpiryOptions.P30D:
+      return 30 * 24 * 60 * 60 * 1000;
+    case MockProAccessExpiryOptions.P30DT1S:
+      return 30 * 24 * 60 * 61 * 1000;
+    case MockProAccessExpiryOptions.P90D:
+      return 90 * 24 * 60 * 60 * 1000;
+    case MockProAccessExpiryOptions.P300D:
+      return 300 * 24 * 60 * 60 * 1000;
+    case MockProAccessExpiryOptions.P365D:
+      return 365 * 24 * 60 * 60 * 1000;
+    case MockProAccessExpiryOptions.P24DT1M:
+      return 24 * 24 * 60 * 60 * 1000 + 60 * 60 * 1000;
+    case MockProAccessExpiryOptions.PT24H1M:
+      return 24 * 60 * 60 * 1000 + 60 * 60 * 1000;
+    case MockProAccessExpiryOptions.PT23H59M:
+      return 23 * 60 * 60 * 1000 + 59 * 60 * 1000;
+    case MockProAccessExpiryOptions.PT33M:
+      return 33 * 60 * 1000;
+    case MockProAccessExpiryOptions.PT1M:
+      return 1 * 60 * 1000;
+    case MockProAccessExpiryOptions.PT10S:
+      return 10 * 1000;
+    default:
+      return null;
+  }
+}
+
+/**
+ * The mocked access expiry as an absolute timestamp, or null when unmocked.
+ *
+ * Measured from `NetworkTime.now()`, not `Date.now()`: every consumer compares this against network
+ * time, so a device clock offset would otherwise move a mocked "expires in N" by that offset relative
+ * to the window judging it. Harmless at N = 30 days, decisive at the sub-minute options.
+ *
+ * The extra -250ms keeps the rendered duration rounding up to the mocked value rather than losing a
+ * unit to render lag.
+ */
+export function mockedProExpiryMs(): number | null {
+  const variant = getDataFeatureFlag('mockProAccessExpiry');
+  if (variant === null) {
+    return null;
+  }
+  const duration = mockedProAccessExpiryDuration(variant);
+  return duration === null ? null : NetworkTime.now() - 250 + duration;
+}
+
+/** The Pro status to project, given the one the backend actually reported. */
+export function proStatusWithMock(actual: ProStatus): ProStatus {
+  return getDataFeatureFlag('mockProCurrentStatus') ?? actual;
+}
+
+/** Whether the plan should be treated as auto-renewing, given what the backend actually reported. */
+export function proAutoRenewWithMock(actual: boolean): boolean {
+  return getFeatureFlag('mockCurrentUserHasProCancelled') ? false : actual;
+}

--- a/ts/state/ducks/types/proMocks.ts
+++ b/ts/state/ducks/types/proMocks.ts
@@ -4,6 +4,7 @@ import {
   getDataFeatureFlag,
   getFeatureFlag,
   MockProAccessExpiryOptions,
+  MockProProofOptions,
 } from './releasedFeaturesReduxTypes';
 
 /**
@@ -75,20 +76,22 @@ export function proStatusWithMock(actual: ProStatus): ProStatus {
 /**
  * Whether our Pro ACCESS should be treated as granted, given what the proof actually says.
  *
- * A mocked run holds no real proof — the mock names a status, and no signed credential exists to go
- * with it. So the status mock has to reach ACCESS as well, or every surface that reads ACCESS goes dark
- * under exactly the mocks the tests drive Pro state with, and the mock would only be able to express
- * "not Pro".
+ * Driven by its OWN mock, not by the status mock. A mocked run holds no signed credential, so without a
+ * lever of its own every ACCESS surface would be dark in every mocked run — but tying it to the status
+ * mock instead would make the one interesting state unexpressible: a plan reading active while no usable
+ * proof exists, which is where a message is accepted at the Pro length and silently truncated for every
+ * recipient. Two levers, set independently, so a test can ask for either or for the disagreement.
  *
- * This is the one place the two values are deliberately tied together, and only when mocked. Leave the
- * real path alone: unmocked, ACCESS is the proof and nothing else.
+ * Applied at the single ACCESS function rather than at each caller, so rendering and enforcement can
+ * never differ about what a mocked run is entitled to. Unmocked — every real client — ACCESS is the
+ * proof and nothing else.
  */
 export function proAccessWithMock(actual: boolean): boolean {
-  const mocked = getDataFeatureFlag('mockProCurrentStatus');
+  const mocked = getDataFeatureFlag('mockProProof');
   if (mocked === null) {
     return actual;
   }
-  return mocked === ProStatus.Active;
+  return mocked === MockProProofOptions.Valid;
 }
 
 /** Whether the plan should be treated as auto-renewing, given what the backend actually reported. */

--- a/ts/state/ducks/types/releasedFeaturesReduxTypes.ts
+++ b/ts/state/ducks/types/releasedFeaturesReduxTypes.ts
@@ -82,6 +82,9 @@ export type SessionDataFeatureFlags = {
   mockProGroupsUpgraded: number | null;
   mockNetworkPageNodeCount: number | null;
   fakeAvatarPickerColor: string | null; // defaults to defaultAvatarPickerColor
+  // Absolute path to an image the test-integration avatar picker returns instead of the generated
+  // solid colour. The only way a test can supply an animated avatar, or any specific content.
+  fakeAvatarPickerFile: string | null;
 };
 
 export type SessionBooleanFeatureFlagKeys = keyof SessionBooleanFeatureFlags;

--- a/ts/state/ducks/types/releasedFeaturesReduxTypes.ts
+++ b/ts/state/ducks/types/releasedFeaturesReduxTypes.ts
@@ -70,10 +70,27 @@ export enum MockProAccessExpiryOptions {
   PT10S = 12,
 }
 
+/**
+ * What a mocked run should hold for a Pro PROOF, independent of what the plan's status says.
+ *
+ * Separate from `mockProCurrentStatus` because the two answer different questions and are allowed to
+ * disagree: the status is DISPLAY ("what state is the plan in"), the proof is ACCESS ("what may this
+ * device do"). One lever driving both made the state where they differ — a plan reading active with no
+ * usable proof, which is where messages get silently truncated — impossible to reach from a test.
+ *
+ * `null` means no override: use whatever proof the client actually holds.
+ */
+export const MockProProofOptions = {
+  Valid: 'valid',
+  None: 'none',
+} as const;
+export type MockProProofOptions = (typeof MockProProofOptions)[keyof typeof MockProProofOptions];
+
 export type SessionDataFeatureFlags = {
   useLocalDevNet: string | null;
   mockMessageProFeatures: Array<ProMessageFeature> | null;
   mockProCurrentStatus: ProStatus | null;
+  mockProProof: MockProProofOptions | null;
   mockProPaymentProvider: ProPaymentProvider | null;
   mockProAccessVariant: ProAccessVariant | null;
   mockProAccessExpiry: MockProAccessExpiryOptions | null;

--- a/ts/state/ducks/types/releasedFeaturesReduxTypes.ts
+++ b/ts/state/ducks/types/releasedFeaturesReduxTypes.ts
@@ -27,6 +27,7 @@ type SessionBaseBooleanFeatureFlags = {
   mockProRecoverButtonAlwaysFail: boolean;
   mockProBackendLoading: boolean;
   mockProBackendError: boolean;
+  mockProBackendSuccess: boolean;
   fsTTL30s: boolean;
   debugForceSeedNodeFailure: boolean;
 };

--- a/ts/state/reducer.ts
+++ b/ts/state/reducer.ts
@@ -25,6 +25,7 @@ import { debugReducer, type DebugState } from './ducks/debug';
 import networkModalReducer, { type NetworkModalState } from './ducks/networkModal';
 import networkDataReducer, { type NetworkDataState } from './ducks/networkData';
 import proBackendDataReducer, { ProBackendDataState } from './ducks/proBackendData';
+import proAccessReducer, { type ProAccessState } from './ducks/proAccess';
 import announcementsReducer, { AnnouncementsState } from './ducks/announcements';
 
 export type StateType = {
@@ -48,6 +49,7 @@ export type StateType = {
   networkModal: NetworkModalState;
   networkData: NetworkDataState;
   proBackendData: ProBackendDataState;
+  proAccess: ProAccessState;
   announcements: AnnouncementsState;
 };
 
@@ -72,6 +74,7 @@ const reducers = {
   networkModal: networkModalReducer,
   networkData: networkDataReducer,
   proBackendData: proBackendDataReducer,
+  proAccess: proAccessReducer,
   announcements: announcementsReducer,
 };
 

--- a/ts/state/selectors/proBackendData.ts
+++ b/ts/state/selectors/proBackendData.ts
@@ -1,21 +1,19 @@
 import { useSelector } from 'react-redux';
 import type { StateType } from '../reducer';
 import {
+  getProStatusFromStorage,
   proBackendDataActions,
   RequestActionArgs,
   WithCallerContext,
   WithImmediate,
   type ProBackendDataState,
 } from '../ducks/proBackendData';
-import { SettingsKey } from '../../data/settings-key';
-import { Storage } from '../../util/storage';
-import type { ProStatusResultType } from '../../session/apis/pro_backend_api/schemas';
 import {
   getDataFeatureFlag,
   getFeatureFlag,
   getFeatureFlagMemo,
-  MockProAccessExpiryOptions,
 } from '../ducks/types/releasedFeaturesReduxTypes';
+import { mockedProExpiryMs, proAutoRenewWithMock } from '../ducks/types/proMocks';
 import { NetworkTime } from '../../util/NetworkTime';
 import {
   formatDateWithLocale,
@@ -35,31 +33,6 @@ import { sleepFor } from '../../session/utils/Promise';
 const getProBackendData = (state: StateType): ProBackendDataState => {
   return state.proBackendData;
 };
-
-function getProStatusFromStorage(): ProStatusResultType | null {
-  const response = Storage.get(SettingsKey.proStatus);
-  if (!response) {
-    return null;
-  }
-  // We persist, verbatim, the JS object the libsession-util-nodejs glue produced from the backend
-  // response (see putProStatusInStorage) — not a raw libsession struct — and cast it back to the
-  // CURRENT ProStatusResultType (an alias of the glue's GetProStatusResponse). session-desktop and
-  // libsession-util-nodejs ship in lockstep, so within a single build the producer, the type and this
-  // consumer can't drift — but a cache written by an OLDER build can.
-  //
-  // ⚠️ TRANSITION REQUIRED IF YOU ADD A REQUIRED FIELD to this shape: an upgraded client would read a
-  // stale-shape cache here and cast it to the new type with that field undefined (the Array.isArray
-  // check below validates only the top level, not individual fields). Handle it as part of that change —
-  // e.g. drop this cache behind a stored shape/version marker, or keep the new field optional at this
-  // boundary. It's a transient, re-fetched cache, so drop-and-refetch is the simplest transition. This
-  // is left as a reminder rather than pre-built, since pre-building would just be guessing at the shape.
-  if (typeof response === 'object' && response !== null && 'userStatus' in response) {
-    return response as ProStatusResultType;
-  }
-  void Storage.remove(SettingsKey.proStatus);
-  window?.log?.error('pro status in storage were malformed; removing.');
-  return null;
-}
 
 export function proAccessVariantToString(variant: ProAccessVariant): string {
   switch (variant) {
@@ -144,39 +117,6 @@ export function getProProviderConstantsWithFallbacks(
   };
 }
 
-function getMockedProAccessExpiry(variant: MockProAccessExpiryOptions): number | null {
-  switch (variant) {
-    case MockProAccessExpiryOptions.P7D:
-      return 7 * 24 * 60 * 60 * 1000;
-    case MockProAccessExpiryOptions.P29D:
-      return 29 * 24 * 60 * 60 * 1000;
-    case MockProAccessExpiryOptions.P30D:
-      return 30 * 24 * 60 * 60 * 1000;
-    case MockProAccessExpiryOptions.P30DT1S:
-      return 30 * 24 * 60 * 61 * 1000;
-    case MockProAccessExpiryOptions.P90D:
-      return 90 * 24 * 60 * 60 * 1000;
-    case MockProAccessExpiryOptions.P300D:
-      return 300 * 24 * 60 * 60 * 1000;
-    case MockProAccessExpiryOptions.P365D:
-      return 365 * 24 * 60 * 60 * 1000;
-    case MockProAccessExpiryOptions.P24DT1M:
-      return 24 * 24 * 60 * 60 * 1000 + 60 * 60 * 1000;
-    case MockProAccessExpiryOptions.PT24H1M:
-      return 24 * 60 * 60 * 1000 + 60 * 60 * 1000;
-    case MockProAccessExpiryOptions.PT23H59M:
-      return 23 * 60 * 60 * 1000 + 59 * 60 * 1000;
-    case MockProAccessExpiryOptions.PT33M:
-      return 33 * 60 * 1000;
-    case MockProAccessExpiryOptions.PT1M:
-      return 1 * 60 * 1000;
-    case MockProAccessExpiryOptions.PT10S:
-      return 10 * 1000;
-    default:
-      return null;
-  }
-}
-
 type ProAccessDetailsSourceData = {
   currentStatus: ProStatus;
   autoRenew: boolean;
@@ -240,21 +180,11 @@ function processProBackendData({
 
   const mockVariant = getDataFeatureFlag('mockProAccessVariant');
   const mockPlatform = getDataFeatureFlag('mockProPaymentProvider');
-  const mockCancelled = getFeatureFlag('mockCurrentUserHasProCancelled');
   const mockInGracePeriod = getFeatureFlag('mockCurrentUserHasProInGracePeriod');
   const mockIsPlatformRefundAvailable = !getFeatureFlag(
     'mockCurrentUserHasProPlatformRefundExpired'
   );
-  const expiryVariant = getDataFeatureFlag('mockProAccessExpiry');
-  const mockedExpiryDuration =
-    expiryVariant !== null ? getMockedProAccessExpiry(expiryVariant) : null;
-  let mockExpiry = null;
-  if (mockedExpiryDuration !== null) {
-    // NOTE: the mock expiry time should be pinned to x - 250ms after "now", the -250ms ensures the string
-    // representation rounds up to the expected mock value and prevents render lag from changing the timestamp
-    const now = Date.now() - 250;
-    mockExpiry = now + mockedExpiryDuration;
-  }
+  const mockExpiry = mockedProExpiryMs();
 
   const isLoading = mockIsLoading || _isLoading;
   const isFetching = mockIsLoading || _isFetching;
@@ -278,9 +208,9 @@ function processProBackendData({
     (latestAccess?.platformRefundExpiryTsMs && now < latestAccess.platformRefundExpiryTsMs) ||
     defaultProAccessDetailsSourceData.isPlatformRefundAvailable;
 
-  const autoRenew = mockCancelled
-    ? !mockCancelled
-    : (data?.autoRenewing ?? defaultProAccessDetailsSourceData.autoRenew);
+  const autoRenew = proAutoRenewWithMock(
+    data?.autoRenewing ?? defaultProAccessDetailsSourceData.autoRenew
+  );
 
   // `expiry_ts` is the account's true expiry — what the user has paid through — so it is the date to
   // show, with no arithmetic. Coverage runs past it: the backend serves until `expiry_ts +

--- a/ts/state/selectors/proBackendData.ts
+++ b/ts/state/selectors/proBackendData.ts
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 import type { StateType } from '../reducer';
 import {
+  getProStatusFromStorage,
   proBackendDataActions,
   RequestActionArgs,
   WithCallerContext,
@@ -164,7 +165,7 @@ export type ProcessedProStatus = {
   isError: boolean;
   // When the last successful fetch completed (ms, network time), 0 if none happened this run.
   // Note: the displayed status can be non-default with a 0 here, as it is seeded from local state
-  // until a response arrives — see `displaySeedFromLocalState`.
+  // until a response arrives — see `displayStatusSeedFromLocalState`.
   lastFetchedMs: number;
   data: ProAccessDetails;
 };
@@ -173,16 +174,23 @@ export type ProcessedProStatus = {
  * DISPLAY, before any status response has arrived this run: what the plan state looks like from what
  * we hold locally.
  *
+ * A STATUS ONLY — deliberately never a date. Only a response carries `latest_payment` and the values
+ * that have to agree with it, so a date shown before one lands would be a guess dressed as a fact. On
+ * the QA backend the compressed clock shortens the PROOF's lifetime without shortening the account's
+ * entitlement, so seeding a date from the proof would show an account paid for a month as expiring in
+ * minutes. The Pro settings screen — the only place a date is wanted — fetches on arrival, so
+ * withholding it costs a moment.
+ *
  * Seeded from synced config rather than from the last response persisted to disk, because a stored
- * response is never re-evaluated — it keeps asserting whatever the backend last said, for as long as
- * the client stays offline. The access expiry and the proof both carry their own timeline, so they go
+ * response is never re-evaluated: it keeps asserting whatever the backend last said, for as long as
+ * the client stays offline. The access expiry and the proof each carry their own timeline, so they go
  * stale honestly.
  *
  * This is DISPLAY only. It may say active while ACCESS says no (an entitlement we know about but hold
  * no usable proof for), and it may say expired while ACCESS still says yes (the overhang on a proof
  * that outlives the plan). Both are intended.
  */
-function displaySeedFromLocalState(): { currentStatus: ProStatus; expiryTimeMs: number } {
+function displayStatusSeedFromLocalState(): ProStatus {
   let proAccessExpiry: number | null = null;
   let haveProof = false;
   try {
@@ -191,26 +199,21 @@ function displaySeedFromLocalState(): { currentStatus: ProStatus; expiryTimeMs: 
     haveProof = !!cached.proConfig?.proProof;
   } catch {
     // user config not initialised yet (e.g. pre-login): nothing to place on a timeline.
-    return { currentStatus: ProStatus.Never, expiryTimeMs: 0 };
+    return ProStatus.Never;
   }
 
-  // The access expiry (E) is the account's own paid-through instant, so it answers "what state is the
-  // plan in" more directly than the proof, whose expiry is clamped to a shorter credential lifetime.
+  // E is the PAYMENT-DUE instant, not the end of coverage — that runs to E + G, and G only ever
+  // arrives on a response. Being past E therefore means "renewal due", not "lapsed", which is why this
+  // seeds a status and leaves the dates to the fetch that follows.
   if (proAccessExpiry) {
-    return {
-      currentStatus: NetworkTime.now() < proAccessExpiry ? ProStatus.Active : ProStatus.Expired,
-      expiryTimeMs: proAccessExpiry,
-    };
+    return NetworkTime.now() < proAccessExpiry ? ProStatus.Active : ProStatus.Expired;
   }
 
   if (haveProof) {
-    return {
-      currentStatus: currentUserProofIsValid() ? ProStatus.Active : ProStatus.Expired,
-      expiryTimeMs: getCachedUserConfig().proConfig?.proProof.expiryMs ?? 0,
-    };
+    return currentUserProofIsValid() ? ProStatus.Active : ProStatus.Expired;
   }
 
-  return { currentStatus: ProStatus.Never, expiryTimeMs: 0 };
+  return ProStatus.Never;
 }
 
 function processProBackendData({
@@ -237,23 +240,36 @@ function processProBackendData({
 
   const now = NetworkTime.now();
 
-  // No response this run: fall back to what config implies rather than to a stored response.
-  const seed = data ? null : displaySeedFromLocalState();
+  // No response this run: seed the STATUS from config, and nothing else. See
+  // `displayStatusSeedFromLocalState` for why the date is deliberately left unset.
+  const seededStatus = data ? null : displayStatusSeedFromLocalState();
 
   const expiryTimeMs =
-    mockExpiry ??
-    data?.expiryMs ??
-    seed?.expiryTimeMs ??
-    defaultProAccessDetailsSourceData.expiryTimeMs;
+    mockExpiry ?? data?.expiryMs ?? defaultProAccessDetailsSourceData.expiryTimeMs;
 
   const latestAccess = data?.latestPayment ?? undefined;
+
+  // The persisted response is read for the PLAN and the PROVIDER and for NOTHING ELSE. Those two alone
+  // come from `latest_payment` and have no config or proof equivalent, so without this exception they
+  // would read "N/A" on every cold launch until a fetch returned. Everything else here — the status,
+  // the dates, the refund window — either has a local source that can be re-evaluated or must wait for
+  // a response: a stored response is a snapshot of what the backend said once, not evidence about now.
+  // Note in particular that `platformRefundExpiryTsMs` below reads `latestAccess`, never this.
+  const storedPlanAndProvider = data ? undefined : getProStatusFromStorage()?.latestPayment;
+
   const provider =
-    mockPlatform ?? latestAccess?.paymentProvider ?? defaultProAccessDetailsSourceData.provider;
+    mockPlatform ??
+    latestAccess?.paymentProvider ??
+    storedPlanAndProvider?.paymentProvider ??
+    defaultProAccessDetailsSourceData.provider;
   const variant = mockVariant ?? defaultProAccessDetailsSourceData.variant;
   // Real data carries a parsed {planCount, planUnit}; the mock still uses a legacy variant slug.
   const variantString = mockVariant
     ? proAccessVariantToString(mockVariant)
-    : planPeriodToString(latestAccess?.planCount, latestAccess?.planUnit);
+    : planPeriodToString(
+        latestAccess?.planCount ?? storedPlanAndProvider?.planCount,
+        latestAccess?.planUnit ?? storedPlanAndProvider?.planUnit
+      );
   const isPlatformRefundAvailable =
     mockIsPlatformRefundAvailable ||
     (latestAccess?.platformRefundExpiryTsMs && now < latestAccess.platformRefundExpiryTsMs) ||
@@ -305,7 +321,7 @@ function processProBackendData({
   return {
     data: {
       currentStatus:
-        data?.userStatus ?? seed?.currentStatus ?? defaultProAccessDetailsSourceData.currentStatus,
+        data?.userStatus ?? seededStatus ?? defaultProAccessDetailsSourceData.currentStatus,
       autoRenew,
       inGracePeriod,
       isProcessingRefund,
@@ -313,11 +329,17 @@ function processProBackendData({
       variantString,
       expiryTimeMs,
       coverageEndMs,
-      expiryTimeDateString: formatDateWithLocale({
-        date: new Date(expiryTimeMs),
-        formatStr: 'MMM d, yyyy',
-      }),
-      expiryTimeRelativeString: formatRoundedUpTimeUntilTimestamp(expiryTimeMs),
+      // An unset expiry renders as ABSENT, never as the epoch. Formatting a 0 gave "Jan 1, 1970" on
+      // every screen that shows a date before a response has landed, which is now the specified
+      // pre-response state rather than a rare one. The screens carry their own loading and error
+      // states, so showing nothing is the honest option.
+      expiryTimeDateString: expiryTimeMs
+        ? formatDateWithLocale({
+            date: new Date(expiryTimeMs),
+            formatStr: 'MMM d, yyyy',
+          })
+        : '',
+      expiryTimeRelativeString: expiryTimeMs ? formatRoundedUpTimeUntilTimestamp(expiryTimeMs) : '',
       isPlatformRefundAvailable,
       provider,
       providerConstants: getProProviderConstantsWithFallbacks(provider),

--- a/ts/state/selectors/proBackendData.ts
+++ b/ts/state/selectors/proBackendData.ts
@@ -295,16 +295,17 @@ function processProBackendData({
   // cancels mid-retry keeps a nonzero value there, and reading it would place coverage weeks late.
   //
   // The root value is 0 whenever the subscription isn't auto-renewing, so no provider branching is needed
-  // or wanted: a store that folds grace into its own expiry just sends a later `E`.
+  // or wanted: a store that folds grace into its own expiry just sends a later access expiry.
   //
-  // Both values are milliseconds here; core stores `G` in seconds and the wrapper converts, so grace read
-  // from *config* is on the other side of that boundary.
+  // Both values are milliseconds here; core stores the grace period in seconds and the wrapper converts,
+  // so grace read from *config* is on the other side of that boundary.
   const coverageEndMs = expiryTimeMs ? expiryTimeMs + (data?.gracePeriodDurationMs ?? 0) : 0;
 
   let inGracePeriod = mockInGracePeriod;
   if (expiryTimeMs && !mockInGracePeriod) {
-    // Past the expiry but still covered. The upper bound is coverage end, not the expiry: `now >= E`
-    // and `now < E` cannot both hold, so bounding this by `E` would make the indicator unreachable.
+    // Past the expiry but still covered. The upper bound is coverage end, not the expiry: "now is past
+    // the expiry" and "now is before it" cannot both hold, so bounding this by the expiry would make the
+    // indicator unreachable.
     // When grace is 0 the window is empty by construction, which is correct — an account with no grace
     // has no overdue-but-covered state to show.
     //

--- a/ts/state/selectors/proBackendData.ts
+++ b/ts/state/selectors/proBackendData.ts
@@ -8,7 +8,6 @@ import {
   WithImmediate,
   type ProBackendDataState,
 } from '../ducks/proBackendData';
-import { currentUserProofIsValid } from '../../session/utils/ProAccess';
 import {
   getDataFeatureFlag,
   getFeatureFlag,
@@ -192,25 +191,33 @@ export type ProcessedProStatus = {
  */
 function displayStatusSeedFromLocalState(): ProStatus {
   let proAccessExpiry: number | null = null;
-  let haveProof = false;
+  let proofExpiryMs: number | null = null;
   try {
     const cached = getCachedUserConfig();
     proAccessExpiry = cached.proAccessExpiry ?? null;
-    haveProof = !!cached.proConfig?.proProof;
+    proofExpiryMs = cached.proConfig?.proProof.expiryMs ?? null;
   } catch {
     // user config not initialised yet (e.g. pre-login): nothing to place on a timeline.
     return ProStatus.Never;
   }
 
+  // One instant for both rungs. Reading the clock twice can straddle them, describing an account as it
+  // never was at any single moment.
+  const now = NetworkTime.now();
+
   // E is the PAYMENT-DUE instant, not the end of coverage — that runs to E + G, and G only ever
   // arrives on a response. Being past E therefore means "renewal due", not "lapsed", which is why this
   // seeds a status and leaves the dates to the fetch that follows.
   if (proAccessExpiry) {
-    return NetworkTime.now() < proAccessExpiry ? ProStatus.Active : ProStatus.Expired;
+    return now < proAccessExpiry ? ProStatus.Active : ProStatus.Expired;
   }
 
-  if (haveProof) {
-    return currentUserProofIsValid() ? ProStatus.Active : ProStatus.Expired;
+  // The proof's EXPIRY alone, deliberately — not whether it is usable. Revocation withdraws what this
+  // device may do, and says nothing about whether the account is still paid: a credential can be
+  // revoked and reissued while the plan runs on untouched. Reading usability here would also let an
+  // ACCESS input decide a DISPLAY value, which is the separation this pair of values exists to keep.
+  if (proofExpiryMs) {
+    return now < proofExpiryMs ? ProStatus.Active : ProStatus.Expired;
   }
 
   return ProStatus.Never;

--- a/ts/state/selectors/proBackendData.ts
+++ b/ts/state/selectors/proBackendData.ts
@@ -1,13 +1,13 @@
 import { useSelector } from 'react-redux';
 import type { StateType } from '../reducer';
 import {
-  getProStatusFromStorage,
   proBackendDataActions,
   RequestActionArgs,
   WithCallerContext,
   WithImmediate,
   type ProBackendDataState,
 } from '../ducks/proBackendData';
+import { currentUserProofIsValid } from '../../session/utils/ProAccess';
 import {
   getDataFeatureFlag,
   getFeatureFlag,
@@ -163,10 +163,55 @@ export type ProcessedProStatus = {
   isFetching: boolean;
   isError: boolean;
   // When the last successful fetch completed (ms, network time), 0 if none happened this run.
-  // Note: `data` can be non-null with a 0 here, as it falls back to the copy persisted on disk.
+  // Note: the displayed status can be non-default with a 0 here, as it is seeded from local state
+  // until a response arrives — see `displaySeedFromLocalState`.
   lastFetchedMs: number;
   data: ProAccessDetails;
 };
+
+/**
+ * DISPLAY, before any status response has arrived this run: what the plan state looks like from what
+ * we hold locally.
+ *
+ * Seeded from synced config rather than from the last response persisted to disk, because a stored
+ * response is never re-evaluated — it keeps asserting whatever the backend last said, for as long as
+ * the client stays offline. The access expiry and the proof both carry their own timeline, so they go
+ * stale honestly.
+ *
+ * This is DISPLAY only. It may say active while ACCESS says no (an entitlement we know about but hold
+ * no usable proof for), and it may say expired while ACCESS still says yes (the overhang on a proof
+ * that outlives the plan). Both are intended.
+ */
+function displaySeedFromLocalState(): { currentStatus: ProStatus; expiryTimeMs: number } {
+  let proAccessExpiry: number | null = null;
+  let haveProof = false;
+  try {
+    const cached = getCachedUserConfig();
+    proAccessExpiry = cached.proAccessExpiry ?? null;
+    haveProof = !!cached.proConfig?.proProof;
+  } catch {
+    // user config not initialised yet (e.g. pre-login): nothing to place on a timeline.
+    return { currentStatus: ProStatus.Never, expiryTimeMs: 0 };
+  }
+
+  // The access expiry (E) is the account's own paid-through instant, so it answers "what state is the
+  // plan in" more directly than the proof, whose expiry is clamped to a shorter credential lifetime.
+  if (proAccessExpiry) {
+    return {
+      currentStatus: NetworkTime.now() < proAccessExpiry ? ProStatus.Active : ProStatus.Expired,
+      expiryTimeMs: proAccessExpiry,
+    };
+  }
+
+  if (haveProof) {
+    return {
+      currentStatus: currentUserProofIsValid() ? ProStatus.Active : ProStatus.Expired,
+      expiryTimeMs: getCachedUserConfig().proConfig?.proProof.expiryMs ?? 0,
+    };
+  }
+
+  return { currentStatus: ProStatus.Never, expiryTimeMs: 0 };
+}
 
 function processProBackendData({
   isLoading: _isLoading,
@@ -192,8 +237,14 @@ function processProBackendData({
 
   const now = NetworkTime.now();
 
+  // No response this run: fall back to what config implies rather than to a stored response.
+  const seed = data ? null : displaySeedFromLocalState();
+
   const expiryTimeMs =
-    mockExpiry ?? data?.expiryMs ?? defaultProAccessDetailsSourceData.expiryTimeMs;
+    mockExpiry ??
+    data?.expiryMs ??
+    seed?.expiryTimeMs ??
+    defaultProAccessDetailsSourceData.expiryTimeMs;
 
   const latestAccess = data?.latestPayment ?? undefined;
   const provider =
@@ -253,7 +304,8 @@ function processProBackendData({
 
   return {
     data: {
-      currentStatus: data?.userStatus ?? defaultProAccessDetailsSourceData.currentStatus,
+      currentStatus:
+        data?.userStatus ?? seed?.currentStatus ?? defaultProAccessDetailsSourceData.currentStatus,
       autoRenew,
       inGracePeriod,
       isProcessingRefund,
@@ -278,10 +330,7 @@ function processProBackendData({
 }
 
 export const getProBackendProStatus = (state: StateType): ProcessedProStatus => {
-  const details = getProBackendData(state).details;
-  const mergedDetails = details.data ? details : { ...details, data: getProStatusFromStorage() };
-
-  return processProBackendData(mergedDetails);
+  return processProBackendData(getProBackendData(state).details);
 };
 
 export const getProBackendCurrentUserStatus = (state: StateType) => {

--- a/ts/state/startup.ts
+++ b/ts/state/startup.ts
@@ -28,9 +28,11 @@ import { initialNetworkModalState } from './ducks/networkModal';
 import { initialNetworkDataState, networkDataActions } from './ducks/networkData';
 import {
   applyMockedProStatusAtStartup,
+  claimProStatusFetchSlot,
   initialProBackendDataState,
   refreshProStatusOnStartupIfNeeded,
 } from './ducks/proBackendData';
+import { setProAccessValuesChangedHandler } from '../webworker/workers/browser/libsession/libsession_worker_userconfig_interface';
 import { MessageQueue } from '../session/sending';
 import { AvatarMigrate } from '../session/utils/job_runners/jobs/AvatarMigrateJob';
 import { handleTriggeredCTAs } from '../components/dialog/SessionCTA';
@@ -42,7 +44,7 @@ import { DURATION } from '../session/constants';
 import { getSwarmPollingInstance } from '../session/apis/snode_api';
 import { getOpenGroupManager } from '../session/apis/open_group_api/opengroupV2/OpenGroupManagerV2';
 import { loadDefaultRooms } from '../session/apis/open_group_api/opengroupV2/ApiUtil';
-import { getDataFeatureFlag } from './ducks/types/releasedFeaturesReduxTypes';
+import { getDataFeatureFlag, getFeatureFlag } from './ducks/types/releasedFeaturesReduxTypes';
 import { isTestIntegration } from '../shared/env_vars';
 import { sleepFor } from '../session/utils/Promise';
 import { UpdateProRevocationList } from '../session/utils/job_runners/jobs/UpdateProRevocationListJob';
@@ -168,6 +170,18 @@ export const doAppStartUp = async () => {
       hasGiphyIntegrationEnabled: Storage.getBoolOr(SettingsKey.hasGiphyIntegrationEnabled, false),
     })
   );
+
+  // Trigger the Pro status refresh the unified trigger set asks for when synced config delivers a new
+  // access expiry or prepaid marker. Registered here rather than dispatched from the libsession layer,
+  // which reports the change but should not decide what it means.
+  setProAccessValuesChangedHandler(() => {
+    // Dispatched unconditionally: the thunk applies the persisted status floor itself, which is the
+    // right bound — a second one here would be per-run, so a relaunch would defeat it.
+    window.inboxStore?.dispatch(proBackendDataActions.refreshGetProStatusFromProBackend({}) as any);
+    // Explicit rather than left to the thunk's own trailing reconcile: this handler exists for the
+    // config-init path, and a floored fetch never reaches that callback.
+    void reconcileProProof();
+  });
 
   // Deliberately NOT inside the swarm-ready block below: the whole point of the mock is to reach the
   // expiry CTAs without a backend round trip, and waiting on the swarm would put a network dependency

--- a/ts/state/startup.ts
+++ b/ts/state/startup.ts
@@ -185,7 +185,9 @@ export const doAppStartUp = async () => {
     if (accessValuesChanged) {
       // Dispatched unconditionally: the thunk applies the persisted status floor itself, which is the
       // right bound — a second one here would be per-run, so a relaunch would defeat it.
-      window.inboxStore?.dispatch(proBackendDataActions.refreshGetProStatusFromProBackend({}) as any);
+      window.inboxStore?.dispatch(
+        proBackendDataActions.refreshGetProStatusFromProBackend({}) as any
+      );
       // Not floored: entitlement comes from the proof, and libsession decides on its own whether one is
       // actually due.
       void reconcileProProof();

--- a/ts/state/startup.ts
+++ b/ts/state/startup.ts
@@ -219,6 +219,11 @@ export const doAppStartUp = async () => {
     if (!proStatusMocked) {
       await refreshProStatusOnStartupIfNeeded();
     }
+    // Deliberately outside the gate, mirroring iOS (`SessionProManager.swift`), where the gated status
+    // fetch and the proof reconcile are two separate statements. Entitlement comes from the proof, so a
+    // relaunch has to be able to notice a renewal is due even on a launch that skips the status fetch —
+    // the loop is otherwise only ever kicked by that fetch.
+    void reconcileProProof();
     if (window.inboxStore) {
       const delayedTimeout = getDataFeatureFlag('useLocalDevNet') && isTestIntegration() ? 2000 : 0;
       /**

--- a/ts/state/startup.ts
+++ b/ts/state/startup.ts
@@ -28,11 +28,10 @@ import { initialNetworkModalState } from './ducks/networkModal';
 import { initialNetworkDataState, networkDataActions } from './ducks/networkData';
 import {
   applyMockedProStatusAtStartup,
-  claimProStatusFetchSlot,
-  evaluateStartupProStatusFetch,
   initialProBackendDataState,
   proBackendDataActions,
   reconcileProProof,
+  refreshProStatusOnStartupIfNeeded,
 } from './ducks/proBackendData';
 import { setProUserConfigChangedHandler } from '../webworker/workers/browser/libsession/libsession_worker_userconfig_interface';
 import { initialProAccessState, refreshProAccess } from './ducks/proAccess';
@@ -184,11 +183,9 @@ export const doAppStartUp = async () => {
       refreshProAccess();
     }
     if (accessValuesChanged) {
-      if (claimProStatusFetchSlot()) {
-        window.inboxStore?.dispatch(
-          proBackendDataActions.refreshGetProStatusFromProBackend({}) as any
-        );
-      }
+      // Dispatched unconditionally: the thunk applies the persisted status floor itself, which is the
+      // right bound — a second one here would be per-run, so a relaunch would defeat it.
+      window.inboxStore?.dispatch(proBackendDataActions.refreshGetProStatusFromProBackend({}) as any);
       // Not floored: entitlement comes from the proof, and libsession decides on its own whether one is
       // actually due.
       void reconcileProProof();
@@ -212,8 +209,13 @@ export const doAppStartUp = async () => {
     window.log.debug('appStartup: got our fresh swarm, starting polling');
     // trigger any other actions that need to be done after the swarm is ready
     window.inboxStore?.dispatch(networkDataActions.fetchInfoFromSeshServer() as any);
+    // Trigger #1, gated: a cold start only fetches get_pro_status when a home CTA could plausibly
+    // fire, and at most once/24h. Also arms the #6 wake at the account horizon for this session.
+    //
+    // Suppressed when the mocks have already answered for this run: letting both go lets a real
+    // response land on top of a mocked CTA decision moments later.
     if (!proStatusMocked) {
-      await evaluateStartupProStatusFetch();
+      await refreshProStatusOnStartupIfNeeded();
     }
     if (window.inboxStore) {
       const delayedTimeout = getDataFeatureFlag('useLocalDevNet') && isTestIntegration() ? 2000 : 0;

--- a/ts/state/startup.ts
+++ b/ts/state/startup.ts
@@ -29,8 +29,10 @@ import { initialNetworkDataState, networkDataActions } from './ducks/networkData
 import {
   applyMockedProStatusAtStartup,
   claimProStatusFetchSlot,
+  evaluateStartupProStatusFetch,
   initialProBackendDataState,
-  refreshProStatusOnStartupIfNeeded,
+  proBackendDataActions,
+  reconcileProProof,
 } from './ducks/proBackendData';
 import { setProUserConfigChangedHandler } from '../webworker/workers/browser/libsession/libsession_worker_userconfig_interface';
 import { initialProAccessState, refreshProAccess } from './ducks/proAccess';
@@ -210,13 +212,8 @@ export const doAppStartUp = async () => {
     window.log.debug('appStartup: got our fresh swarm, starting polling');
     // trigger any other actions that need to be done after the swarm is ready
     window.inboxStore?.dispatch(networkDataActions.fetchInfoFromSeshServer() as any);
-    // Trigger #1, gated: a cold start only fetches get_pro_status when a home CTA could plausibly
-    // fire, and at most once/24h. Also arms the #6 wake at the account horizon for this session.
-    //
-    // Suppressed when the mocks have already answered for this run: letting both go lets a real
-    // response land on top of a mocked CTA decision moments later.
     if (!proStatusMocked) {
-      void refreshProStatusOnStartupIfNeeded();
+      await evaluateStartupProStatusFetch();
     }
     if (window.inboxStore) {
       const delayedTimeout = getDataFeatureFlag('useLocalDevNet') && isTestIntegration() ? 2000 : 0;

--- a/ts/state/startup.ts
+++ b/ts/state/startup.ts
@@ -32,7 +32,8 @@ import {
   initialProBackendDataState,
   refreshProStatusOnStartupIfNeeded,
 } from './ducks/proBackendData';
-import { setProAccessValuesChangedHandler } from '../webworker/workers/browser/libsession/libsession_worker_userconfig_interface';
+import { setProUserConfigChangedHandler } from '../webworker/workers/browser/libsession/libsession_worker_userconfig_interface';
+import { initialProAccessState, refreshProAccess } from './ducks/proAccess';
 import { MessageQueue } from '../session/sending';
 import { AvatarMigrate } from '../session/utils/job_runners/jobs/AvatarMigrateJob';
 import { handleTriggeredCTAs } from '../components/dialog/SessionCTA';
@@ -99,6 +100,7 @@ async function createSessionInboxStore() {
     networkModal: initialNetworkModalState,
     networkData: initialNetworkDataState,
     proBackendData: initialProBackendDataState,
+    proAccess: initialProAccessState,
     announcements: initialAnnouncementState,
   };
 
@@ -171,17 +173,30 @@ export const doAppStartUp = async () => {
     })
   );
 
-  // Trigger the Pro status refresh the unified trigger set asks for when synced config delivers a new
-  // access expiry or prepaid marker. Registered here rather than dispatched from the libsession layer,
-  // which reports the change but should not decide what it means.
-  setProAccessValuesChangedHandler(() => {
-    // Dispatched unconditionally: the thunk applies the persisted status floor itself, which is the
-    // right bound — a second one here would be per-run, so a relaunch would defeat it.
-    window.inboxStore?.dispatch(proBackendDataActions.refreshGetProStatusFromProBackend({}) as any);
-    // Explicit rather than left to the thunk's own trailing reconcile: this handler exists for the
-    // config-init path, and a floored fetch never reaches that callback.
-    void reconcileProProof();
+  // React to synced config delivering new Pro values. Registered here rather than dispatched from the
+  // libsession layer, which reports the change but should not decide what it means.
+  setProUserConfigChangedHandler(({ accessValuesChanged, proofChanged }) => {
+    if (proofChanged) {
+      // The proof is ACCESS, so the rendered mirror has to follow it immediately. No fetch: a new proof
+      // is not news about the plan, and treating it as such would hit the backend on every renewal.
+      refreshProAccess();
+    }
+    if (accessValuesChanged) {
+      if (claimProStatusFetchSlot()) {
+        window.inboxStore?.dispatch(
+          proBackendDataActions.refreshGetProStatusFromProBackend({}) as any
+        );
+      }
+      // Not floored: entitlement comes from the proof, and libsession decides on its own whether one is
+      // actually due.
+      void reconcileProProof();
+    }
   });
+
+  // Seed the rendered ACCESS value from the config we already hold. Deliberately outside the
+  // swarm-ready block below: what a held proof entitles us to is answerable with no network at all, and
+  // the first projection of an existing account is swallowed by design, so nothing else would set it.
+  refreshProAccess();
 
   // Deliberately NOT inside the swarm-ready block below: the whole point of the mock is to reach the
   // expiry CTAs without a backend round trip, and waiting on the swarm would put a network dependency

--- a/ts/state/startup.ts
+++ b/ts/state/startup.ts
@@ -27,6 +27,7 @@ import { initialThemeState } from './theme/ducks/theme';
 import { initialNetworkModalState } from './ducks/networkModal';
 import { initialNetworkDataState, networkDataActions } from './ducks/networkData';
 import {
+  applyMockedProStatusAtStartup,
   initialProBackendDataState,
   refreshProStatusOnStartupIfNeeded,
 } from './ducks/proBackendData';
@@ -168,6 +169,13 @@ export const doAppStartUp = async () => {
     })
   );
 
+  // Deliberately NOT inside the swarm-ready block below: the whole point of the mock is to reach the
+  // expiry CTAs without a backend round trip, and waiting on the swarm would put a network dependency
+  // back in front of it.
+  const proStatusMocked = window.inboxStore?.dispatch
+    ? await applyMockedProStatusAtStartup(window.inboxStore.dispatch)
+    : false;
+
   // eslint-disable-next-line more/no-then
   void SnodePool.getFreshSwarmFor(UserUtils.getOurPubKeyStrFromCache()).then(async () => {
     window.log.debug('appStartup: got our fresh swarm, starting polling');
@@ -175,7 +183,12 @@ export const doAppStartUp = async () => {
     window.inboxStore?.dispatch(networkDataActions.fetchInfoFromSeshServer() as any);
     // Trigger #1, gated: a cold start only fetches get_pro_status when a home CTA could plausibly
     // fire, and at most once/24h. Also arms the #6 wake at the account horizon for this session.
-    void refreshProStatusOnStartupIfNeeded();
+    //
+    // Suppressed when the mocks have already answered for this run: letting both go lets a real
+    // response land on top of a mocked CTA decision moments later.
+    if (!proStatusMocked) {
+      void refreshProStatusOnStartupIfNeeded();
+    }
     if (window.inboxStore) {
       const delayedTimeout = getDataFeatureFlag('useLocalDevNet') && isTestIntegration() ? 2000 : 0;
       /**

--- a/ts/state/startup.ts
+++ b/ts/state/startup.ts
@@ -47,7 +47,7 @@ import { DURATION } from '../session/constants';
 import { getSwarmPollingInstance } from '../session/apis/snode_api';
 import { getOpenGroupManager } from '../session/apis/open_group_api/opengroupV2/OpenGroupManagerV2';
 import { loadDefaultRooms } from '../session/apis/open_group_api/opengroupV2/ApiUtil';
-import { getDataFeatureFlag, getFeatureFlag } from './ducks/types/releasedFeaturesReduxTypes';
+import { getDataFeatureFlag } from './ducks/types/releasedFeaturesReduxTypes';
 import { isTestIntegration } from '../shared/env_vars';
 import { sleepFor } from '../session/utils/Promise';
 import { UpdateProRevocationList } from '../session/utils/job_runners/jobs/UpdateProRevocationListJob';

--- a/ts/types/attachments/VisualAttachment.ts
+++ b/ts/types/attachments/VisualAttachment.ts
@@ -2,6 +2,7 @@
 /* global document, URL, Blob */
 
 import { dataURLToBlob } from 'blob-util';
+import { existsSync, readFileSync } from 'fs';
 import { toLogFormat } from './Errors';
 
 import { DecryptedAttachmentsManager } from '../../session/crypto/DecryptedAttachmentsManager';
@@ -187,8 +188,28 @@ export const revokeObjectUrl = (objectUrl: string) => {
   URL.revokeObjectURL(objectUrl);
 };
 
+const AVATAR_MIME_BY_EXTENSION = {
+  '.png': 'image/png',
+  '.gif': 'image/gif',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.webp': 'image/webp',
+} as const;
+
+type AvatarExtension = keyof typeof AVATAR_MIME_BY_EXTENSION;
+
+/**
+ * The formats the avatar picker accepts, including `.webp` — the animated one, and so the Pro feature.
+ *
+ * Unconditional because Pro is permanently available; the gate that used to wrap `.webp` went with the
+ * flag it read. The map is what lets a path be turned back into a MIME type rather than guessed at.
+ */
+function acceptedAvatarExtensions(): Array<AvatarExtension> {
+  return ['.png', '.gif', '.jpeg', '.jpg', '.webp'];
+}
+
 async function pickFileForReal() {
-  const acceptedImages = ['.png', '.gif', '.jpeg', '.jpg', '.webp'];
+  const acceptedImages = acceptedAvatarExtensions();
 
   const [fileHandle] = await (window as any).showOpenFilePicker({
     types: [
@@ -225,7 +246,36 @@ function hexToRgb(hex: string) {
   };
 }
 
+/**
+ * The generated avatar is a solid colour and therefore never animated, so a test could not reach
+ * anything gated on `isAnimated` — nor assert anything about avatar content, since every avatar in
+ * every test was the same square. `fakeAvatarPickerFile` substitutes a real image from disk.
+ */
+function pickFileFromDisk(path: string) {
+  const accepted = acceptedAvatarExtensions();
+  const extension = accepted.find(ext => path.toLowerCase().endsWith(ext));
+
+  // Throwing rather than falling back to the generated avatar: a silent fallback would surface as a
+  // test asserting the wrong image, several steps from the typo that caused it.
+  if (!extension) {
+    throw new Error(`fakeAvatarPickerFile: "${path}" must end in one of ${accepted.join(', ')}`);
+  }
+  if (!existsSync(path)) {
+    throw new Error(`fakeAvatarPickerFile: no file at "${path}"`);
+  }
+
+  const buffer = readFileSync(path);
+  return new File([buffer], `fakeAvatarPickerFile${extension}`, {
+    type: AVATAR_MIME_BY_EXTENSION[extension],
+  });
+}
+
 async function pickFileForTestIntegration() {
+  const fakeAvatarPickerFile = getDataFeatureFlag('fakeAvatarPickerFile');
+  if (fakeAvatarPickerFile) {
+    return pickFileFromDisk(fakeAvatarPickerFile);
+  }
+
   const fakeAvatarPickerColor = getDataFeatureFlag('fakeAvatarPickerColor');
   const blueAvatarDetails = await ImageProcessor.testIntegrationFakeAvatar(
     maxAvatarDetails.maxSidePlanReupload,

--- a/ts/webworker/workers/browser/libsession/libsession_worker_userconfig_interface.ts
+++ b/ts/webworker/workers/browser/libsession/libsession_worker_userconfig_interface.ts
@@ -80,6 +80,7 @@ async function fullRefreshCachedUserConfig() {
   }
   const proAccessExpiryBefore = cached.proAccessExpiry;
   const proPrepaidBefore = cached.proPrepaid;
+  const proConfigBefore = cached.proConfig;
 
   applyUserConfigIfChanged('priority', priority);
   applyUserConfigIfChanged('name', name);
@@ -95,25 +96,37 @@ async function fullRefreshCachedUserConfig() {
   applyUserConfigIfChanged('proAutoRenewing', proAutoRenewing);
   applyUserConfigIfChanged('proGracePeriod', proGracePeriod);
 
-  if (
+  const accessValuesChanged =
     !isEqual(proAccessExpiryBefore, cached.proAccessExpiry) ||
-    !isEqual(proPrepaidBefore, cached.proPrepaid)
-  ) {
+    !isEqual(proPrepaidBefore, cached.proPrepaid);
+  // The proof is reported separately because it answers a different question: it decides what this
+  // device may DO, where the expiry and prepaid marker describe what the plan is doing. One consumer
+  // wants each, and conflating them would fetch a status every time a proof renewed.
+  const proofChanged = !isEqual(proConfigBefore, cached.proConfig);
+
+  if (accessValuesChanged || proofChanged) {
     // Contained deliberately: `user_base_actions` awaits this function as `modifiedCb` after both
     // `init` and `merge`, so an unguarded throw here would fail config initialisation or a config
     // merge. Whatever the handler wants to do about Pro is not worth that blast radius.
     try {
-      proAccessValuesChangedHandler?.();
+      proUserConfigChangedHandler?.({ accessValuesChanged, proofChanged });
     } catch (e) {
       window.log.error(
-        `fullRefreshCachedUserConfig: proAccessValuesChangedHandler failed: ${e.message}`
+        `fullRefreshCachedUserConfig: proUserConfigChangedHandler failed: ${e.message}`
       );
     }
   }
 }
 
+export type ProUserConfigChange = {
+  /** The synced access expiry or prepaid marker moved — the plan's state may have changed. */
+  accessValuesChanged: boolean;
+  /** The proof itself moved — what this device may do may have changed. */
+  proofChanged: boolean;
+};
+
 /**
- * Notified when the synced access expiry or prepaid marker changes.
+ * Notified when the synced Pro values change: the access expiry or prepaid marker, the proof, or both.
  *
  * A callback rather than a direct dispatch because deciding what a config change means is not this
  * layer's job, and because the Pro duck already imports `getCachedUserConfig` from here — reaching
@@ -122,7 +135,7 @@ async function fullRefreshCachedUserConfig() {
  * Deliberately not called for the first population of the cache — that is the state the app started
  * with, not something arriving. See `isFirstProjection` above.
  */
-let proAccessValuesChangedHandler: (() => void) | null = null;
+let proUserConfigChangedHandler: ((changed: ProUserConfigChange) => void) | null = null;
 
 /**
  * Single-consumer by design: one slot, registered from `doAppStartUp`.
@@ -134,13 +147,13 @@ let proAccessValuesChangedHandler: (() => void) | null = null;
  * The warning is for the case that is actually a mistake: a SECOND consumer registering and silently
  * unhooking the first. If that is ever genuinely wanted, make this a list rather than dropping the log.
  */
-export function setProAccessValuesChangedHandler(handler: () => void) {
-  if (proAccessValuesChangedHandler) {
+export function setProUserConfigChangedHandler(handler: (changed: ProUserConfigChange) => void) {
+  if (proUserConfigChangedHandler) {
     window.log.warn(
-      'setProAccessValuesChangedHandler: replacing an existing handler — expected when app startup re-runs, a mistake if a second consumer is being added'
+      'setProUserConfigChangedHandler: replacing an existing handler — expected when app startup re-runs, a mistake if a second consumer is being added'
     );
   }
-  proAccessValuesChangedHandler = handler;
+  proUserConfigChangedHandler = handler;
 }
 
 function applyUserConfigIfChanged<T extends keyof CachedUserConfig>(

--- a/ts/webworker/workers/browser/libsession/libsession_worker_userconfig_interface.ts
+++ b/ts/webworker/workers/browser/libsession/libsession_worker_userconfig_interface.ts
@@ -45,7 +45,19 @@ async function fullRefreshCachedUserConfig() {
   const proAutoRenewing = await UserConfigWrapperActions.getProAutoRenewing();
   const proGracePeriod = await UserConfigWrapperActions.getProGracePeriod();
 
-  if (!cachedUserConfig) {
+  // A relaunching subscriber loads its access expiry from a dump on every launch. Treating that first
+  // projection as a change would fetch on every cold launch and defeat the startup gate.
+  //
+  // The guard is scoped to the account session, not the process. On desktop those coincide: an account
+  // is only ever loaded into a fresh renderer, because deleting an account ends in `window.restart()`
+  // (`accountManager.ts:298`) and the registration view is unreachable once registration is done. If an
+  // in-process account switch is ever added, this must be re-armed by clearing `cachedUserConfig`.
+  // Aliased into a const so the checks below narrow; it is the same object `applyUserConfigIfChanged`
+  // mutates in place, so it reads back the updated values too.
+  const cached = cachedUserConfig;
+  const isFirstProjection = !cached;
+
+  if (isFirstProjection) {
     cachedUserConfig = {
       enableBlindedMsgRequest,
       noteToSelfExpirySeconds,
@@ -63,8 +75,8 @@ async function fullRefreshCachedUserConfig() {
     };
     return;
   }
-  const proAccessExpiryBefore = cachedUserConfig.proAccessExpiry;
-  const proPrepaidBefore = cachedUserConfig.proPrepaid;
+  const proAccessExpiryBefore = cached.proAccessExpiry;
+  const proPrepaidBefore = cached.proPrepaid;
 
   applyUserConfigIfChanged('priority', priority);
   applyUserConfigIfChanged('name', name);
@@ -81,8 +93,8 @@ async function fullRefreshCachedUserConfig() {
   applyUserConfigIfChanged('proGracePeriod', proGracePeriod);
 
   if (
-    !isEqual(proAccessExpiryBefore, cachedUserConfig.proAccessExpiry) ||
-    !isEqual(proPrepaidBefore, cachedUserConfig.proPrepaid)
+    !isEqual(proAccessExpiryBefore, cached.proAccessExpiry) ||
+    !isEqual(proPrepaidBefore, cached.proPrepaid)
   ) {
     // Contained deliberately: `user_base_actions` awaits this function as `modifiedCb` after both
     // `init` and `merge`, so an unguarded throw here would fail config initialisation or a config
@@ -104,10 +116,8 @@ async function fullRefreshCachedUserConfig() {
  * layer's job, and because the Pro duck already imports `getCachedUserConfig` from here — reaching
  * back the other way would make that a cycle.
  *
- * Deliberately not called for the FIRST population of the cache: that is the state the app started
- * with, not something arriving. A relaunching subscriber loads an expiry from its dump every time,
- * and treating that as a change would fetch on every launch — which is what the startup gate exists
- * to stop.
+ * Deliberately not called for the first population of the cache — that is the state the app started
+ * with, not something arriving. See `isFirstProjection` above.
  */
 let proAccessValuesChangedHandler: (() => void) | null = null;
 

--- a/ts/webworker/workers/browser/libsession/libsession_worker_userconfig_interface.ts
+++ b/ts/webworker/workers/browser/libsession/libsession_worker_userconfig_interface.ts
@@ -63,6 +63,9 @@ async function fullRefreshCachedUserConfig() {
     };
     return;
   }
+  const proAccessExpiryBefore = cachedUserConfig.proAccessExpiry;
+  const proPrepaidBefore = cachedUserConfig.proPrepaid;
+
   applyUserConfigIfChanged('priority', priority);
   applyUserConfigIfChanged('name', name);
   applyUserConfigIfChanged('profilePic', profilePic);
@@ -76,6 +79,55 @@ async function fullRefreshCachedUserConfig() {
   applyUserConfigIfChanged('proPrepaid', proPrepaid);
   applyUserConfigIfChanged('proAutoRenewing', proAutoRenewing);
   applyUserConfigIfChanged('proGracePeriod', proGracePeriod);
+
+  if (
+    !isEqual(proAccessExpiryBefore, cachedUserConfig.proAccessExpiry) ||
+    !isEqual(proPrepaidBefore, cachedUserConfig.proPrepaid)
+  ) {
+    // Contained deliberately: `user_base_actions` awaits this function as `modifiedCb` after both
+    // `init` and `merge`, so an unguarded throw here would fail config initialisation or a config
+    // merge. Whatever the handler wants to do about Pro is not worth that blast radius.
+    try {
+      proAccessValuesChangedHandler?.();
+    } catch (e) {
+      window.log.error(
+        `fullRefreshCachedUserConfig: proAccessValuesChangedHandler failed: ${e.message}`
+      );
+    }
+  }
+}
+
+/**
+ * Notified when the synced access expiry or prepaid marker changes.
+ *
+ * A callback rather than a direct dispatch because deciding what a config change means is not this
+ * layer's job, and because the Pro duck already imports `getCachedUserConfig` from here — reaching
+ * back the other way would make that a cycle.
+ *
+ * Deliberately not called for the FIRST population of the cache: that is the state the app started
+ * with, not something arriving. A relaunching subscriber loads an expiry from its dump every time,
+ * and treating that as a change would fetch on every launch — which is what the startup gate exists
+ * to stop.
+ */
+let proAccessValuesChangedHandler: (() => void) | null = null;
+
+/**
+ * Single-consumer by design: one slot, registered from `doAppStartUp`.
+ *
+ * Replacing rather than throwing on a second call, because `doAppStartUp` legitimately runs more than
+ * once per renderer — opening the inbox from a notification, and the `openInbox` event registration
+ * fires after — so a hard failure here would break a real path to stop a hypothetical one.
+ *
+ * The warning is for the case that is actually a mistake: a SECOND consumer registering and silently
+ * unhooking the first. If that is ever genuinely wanted, make this a list rather than dropping the log.
+ */
+export function setProAccessValuesChangedHandler(handler: () => void) {
+  if (proAccessValuesChangedHandler) {
+    window.log.warn(
+      'setProAccessValuesChangedHandler: replacing an existing handler — expected when app startup re-runs, a mistake if a second consumer is being added'
+    );
+  }
+  proAccessValuesChangedHandler = handler;
 }
 
 function applyUserConfigIfChanged<T extends keyof CachedUserConfig>(

--- a/ts/webworker/workers/browser/libsession/libsession_worker_userconfig_interface.ts
+++ b/ts/webworker/workers/browser/libsession/libsession_worker_userconfig_interface.ts
@@ -48,10 +48,13 @@ async function fullRefreshCachedUserConfig() {
   // A relaunching subscriber loads its access expiry from a dump on every launch. Treating that first
   // projection as a change would fetch on every cold launch and defeat the startup gate.
   //
-  // The guard is scoped to the account session, not the process. On desktop those coincide: an account
-  // is only ever loaded into a fresh renderer, because deleting an account ends in `window.restart()`
-  // (`accountManager.ts:298`) and the registration view is unreachable once registration is done. If an
-  // in-process account switch is ever added, this must be re-armed by clearing `cachedUserConfig`.
+  // Note this asks about POSITION ("is this the first projection?") as a proxy for what we actually
+  // want to know, which is SEMANTICS ("is this config news?"). The two agree here because the cases
+  // separate cleanly: a relaunch projects a dump that already holds the expiry, and a restore projects
+  // empty wrappers first and only learns the expiry from the merge that follows. Do not assume that
+  // holds if the load order changes — a first projection that arrives already populated on a device
+  // that has never fetched a status would be news, and this would swallow it.
+  //
   // Aliased into a const so the checks below narrow; it is the same object `applyUserConfigIfChanged`
   // mutates in place, so it reads back the updated values too.
   const cached = cachedUserConfig;


### PR DESCRIPTION
Draft — parked for review, not ready to merge.

Splits Pro into two values: **ACCESS** (the proof in config, validated on every read against expiry and the revocation list) and **DISPLAY** (the backend status, seeded from the proof at launch with no date). They are meant to disagree — a lapsed plan whose proof still has time left displays as expired while the features keep working.

Also here: upsell affordances read DISPLAY rather than inverted ACCESS, so a user whose plan reads active is not invited to buy Pro they already have; and a test mock for the proof, separate from the status mock, which is what makes an active-plan-with-no-proof client reachable at all.

**Deliberately not done** — held items and accepted trades are recorded in the code comments, including a refusal that is currently silent because no copy exists for "your plan is active but we cannot verify it yet".

Client-side counterpart to session-appium#128.
