### PR TITLE
test(pro): tag each message-info feature row

### DIFF
--- a/ts/components/conversation/right-panel/overlay/message-info/components/MessageInfo.tsx
+++ b/ts/components/conversation/right-panel/overlay/message-info/components/MessageInfo.tsx
@@ -1,3 +1,4 @@
+import type { SessionDataTestId } from 'react';
 import styled from 'styled-components';
 import { MessageFrom } from '.';
 import {
@@ -177,6 +178,26 @@ function proFeatureToTrKey(proFeature: ProMessageFeature) {
   }
 }
 
+/**
+ * The test id of a feature row.
+ *
+ * A cross-platform contract, not a local convention: Android and iOS tag the same rows with these
+ * exact strings, so one Appium locator serves all three clients.
+ */
+function proFeatureToTestId(proFeature: ProMessageFeature): SessionDataTestId {
+  switch (proFeature) {
+    case ProMessageFeature.PRO_BADGE:
+      return 'pro-message-feature-badges';
+    case ProMessageFeature.PRO_INCREASED_MESSAGE_LENGTH:
+      return 'pro-message-feature-longer-messages';
+    case ProMessageFeature.PRO_ANIMATED_DISPLAY_PICTURE:
+      return 'pro-message-feature-animated-display-picture';
+    default:
+      assertUnreachable(proFeature, 'proFeatureToTestId: unknown case');
+      throw new Error('unreachable');
+  }
+}
+
 function ProMessageFeaturesDetails({ messageId }: { messageId: string }) {
   const currentUserHasPro = useCurrentUserHasPro();
 
@@ -211,7 +232,7 @@ function ProMessageFeaturesDetails({ messageId }: { messageId: string }) {
       </StyledProDescription>
       <StyledProFeaturesContainer>
         {messageSentWithProFeat.map(feature => (
-          <StyledProFeatureRow key={feature}>
+          <StyledProFeatureRow key={feature} data-testid={proFeatureToTestId(feature)}>
             <LucideIcon
               unicode={LUCIDE_ICONS_UNICODE.CIRCLE_CHECK}
               iconSize="medium"

--- a/ts/react.d.ts
+++ b/ts/react.d.ts
@@ -141,6 +141,21 @@ declare module 'react' {
     | 'badges'
     | 'loads-more';
 
+  /**
+   * The subset of `ProFeatureItems` a single message can carry, as listed on its message-info panel.
+   *
+   * Derived rather than restated so the two surfaces cannot drift into naming the same feature
+   * differently, and so a feature that stops being per-message fails to compile here.
+   *
+   * These exact strings are a cross-platform contract: Android defines them in its
+   * `content-descriptions` module and iOS in `SessionProUI.AccessibilityIdentifier`, so one Appium
+   * locator serves all three clients.
+   */
+  type ProMessageFeatureItems = Extract<
+    ProFeatureItems,
+    'longer-messages' | 'badges' | 'animated-display-picture'
+  >;
+
   type MenuItems = 'block' | 'delete' | 'accept';
 
   type Inputs =
@@ -454,6 +469,7 @@ declare module 'react' {
     | `${NotificationRadioButtons}`
     | `avatar-${Avatars}`
     | `pro-badge-${ProBadges}`
+    | `pro-message-feature-${ProMessageFeatureItems}`
     // empty msg view ids
     | 'empty-msg-view-account-created'
     | 'empty-msg-view-welcome'


### PR DESCRIPTION
The message info panel lists the Session Pro features a message was sent with, but the rows carried no test id — so an automated test can only match them by their localized text. That breaks on any wording or translation change, and it cannot distinguish *which* feature a row is without hard-coding three strings.

This tags each row with a per-feature id, named from the vocabulary the Pro settings screen already uses:

```ts
type ProMessageFeatureItems = Extract<
  ProFeatureItems,
  'longer-messages' | 'badges' | 'animated-display-picture'
>;
```

`Extract`ed rather than restated, so the two surfaces cannot drift into naming the same feature differently, and a feature that stops being per-message fails to compile here.

| Feature | Test id |
|---|---|
| `PRO_BADGE` | `pro-message-feature-badges` |
| `PRO_INCREASED_MESSAGE_LENGTH` | `pro-message-feature-longer-messages` |
| `PRO_ANIMATED_DISPLAY_PICTURE` | `pro-message-feature-animated-display-picture` |

These strings are a **cross-platform contract**: the matching PRs give Android the same values in its `content-descriptions` module and iOS the same in `SessionProUI.AccessibilityIdentifier`, so one Appium locator serves all three clients.

Distinct from #1983, which tags the Pro **settings** surface (`${ProFeatureItems}-pro-settings-menu-item`, the section headers, the status banner) and does not touch the message-info panel. The two only overlap in `ts/react.d.ts`, in hunks far enough apart to merge cleanly.

No behaviour change. Verified with `tsc --noEmit`, prettier and eslint.