### PR TITLE
fix: keep Home and End within message input

### DIFF
--- a/ts/components/conversation/SessionMessagesList.tsx
+++ b/ts/components/conversation/SessionMessagesList.tsx
@@ -30,6 +30,7 @@ import { ReduxConversationType } from '../../state/ducks/conversations';
 import { SessionScrollButton } from '../SessionScrollButton';
 import { ConvoHub } from '../../session/conversations';
 import { SessionMessageInteractables } from './SessionMessageInteractables';
+import { isEditableTarget } from '../../util/isEditableTarget';
 
 export const MESSAGE_LIST_MESSAGE_PADDING_PX = 'var(--margins-lg)' as const;
 
@@ -67,7 +68,7 @@ const StyledTypingBubbleContainer = styled.div`
 `;
 
 function isNotTextboxEvent(e: KeyboardEvent) {
-  return (e?.target as any)?.type === undefined;
+  return (e?.target as any)?.type === undefined && !isEditableTarget(e.target);
 }
 
 let previousRenderedConvo: string | undefined;

--- a/ts/components/conversation/composition/CompositionTextArea.tsx
+++ b/ts/components/conversation/composition/CompositionTextArea.tsx
@@ -50,6 +50,7 @@ import { Mention } from '../AddMentions';
 import { useDebugInputCommands } from '../../dialog/debug/hooks/useDebugInputCommands';
 import { useKeyboardShortcut } from '../../../hooks/useKeyboardShortcut';
 import { isEnterKey, isEscapeKey, KbdShortcut } from '../../../util/keyboardShortcuts';
+import { isEditableTarget } from '../../../util/isEditableTarget';
 import { PopoverTriggerPosition } from '../../SessionTooltip';
 import { getAppDispatch } from '../../../state/dispatch';
 import { setIsCompositionTextAreaFocused } from '../../../state/ducks/conversations';
@@ -65,16 +66,6 @@ type Props = {
 };
 
 type SearchableSuggestion = SessionSuggestionDataItem & { searchable?: Array<string> };
-
-function isEditableTarget(target: EventTarget | null) {
-  if (!(target instanceof HTMLElement)) {
-    return false;
-  }
-
-  const editableSelector =
-    'input, textarea, select, [contenteditable="true"], [contenteditable="plaintext-only"]';
-  return !!target.closest(editableSelector);
-}
 
 function isPrintableTypingEvent(event: globalThis.KeyboardEvent) {
   return (

--- a/ts/test/util/isEditableTarget_test.ts
+++ b/ts/test/util/isEditableTarget_test.ts
@@ -1,0 +1,63 @@
+import { expect } from 'chai';
+
+import { isEditableTarget } from '../../util/isEditableTarget';
+
+describe('isEditableTarget', () => {
+  it('rejects missing targets', () => {
+    expect(isEditableTarget(null)).to.equal(false);
+  });
+
+  it('rejects regular elements', () => {
+    expect(isEditableTarget(document.createElement('div'))).to.equal(false);
+  });
+
+  it('recognizes editable form controls', () => {
+    expect(isEditableTarget(document.createElement('input'))).to.equal(true);
+    expect(isEditableTarget(document.createElement('textarea'))).to.equal(true);
+    expect(isEditableTarget(document.createElement('select'))).to.equal(true);
+  });
+
+  it('rejects buttons', () => {
+    expect(isEditableTarget(document.createElement('button'))).to.equal(false);
+  });
+
+  it('recognizes contenteditable elements', () => {
+    const editor = document.createElement('div');
+    editor.setAttribute('contenteditable', 'plaintext-only');
+
+    expect(isEditableTarget(editor)).to.equal(true);
+  });
+
+  it('recognizes children of contenteditable elements', () => {
+    const editor = document.createElement('div');
+    const child = document.createElement('span');
+    editor.setAttribute('contenteditable', 'true');
+    editor.appendChild(child);
+
+    expect(isEditableTarget(child)).to.equal(true);
+  });
+
+  it('recognizes non-editable children inside contenteditable elements', () => {
+    const editor = document.createElement('div');
+    const child = document.createElement('span');
+    editor.setAttribute('contenteditable', 'plaintext-only');
+    child.setAttribute('contenteditable', 'false');
+    editor.appendChild(child);
+
+    expect(isEditableTarget(child)).to.equal(true);
+  });
+
+  it('rejects disabled contenteditable elements', () => {
+    const editor = document.createElement('div');
+    editor.setAttribute('contenteditable', 'false');
+
+    expect(isEditableTarget(editor)).to.equal(false);
+  });
+
+  it('rejects invalid contenteditable values', () => {
+    const editor = document.createElement('div');
+    editor.setAttribute('contenteditable', 'inherit');
+
+    expect(isEditableTarget(editor)).to.equal(false);
+  });
+});

--- a/ts/util/isEditableTarget.ts
+++ b/ts/util/isEditableTarget.ts
@@ -1,0 +1,9 @@
+export function isEditableTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+
+  const editableSelector =
+    'input, textarea, select, [contenteditable="true"], [contenteditable="plaintext-only"]';
+  return !!target.closest(editableSelector);
+}


### PR DESCRIPTION
### Contributor checklist:

- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`dev`](https://github.com/session-foundation/session-desktop/tree/dev) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/session-foundation/session-desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Fixes #1543

The conversation-level Home and End handlers only treated targets with a `type` property as text inputs. The message composer is contenteditable, so these keys could still reach the history navigation handler

This reuses the existing editable-target detection for the message list while preserving the previous behavior for typed controls

Tests:

- added regression coverage for editable controls, contenteditable roots and descendants, disabled editors, and non-editable targets
- `pnpm ready`
