### PR TITLE
fix(pro): make the platform refund window defer to the payment, not to a missing mock

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "framer-motion": "^12.5.0",
     "fs-extra": "11.3.0",
     "image-type": "^4.1.0",
-    "libsession_util_nodejs": "https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.0/libsession_util_nodejs-v0.7.0.tar.gz",
+    "libsession_util_nodejs": "https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.1/libsession_util_nodejs-v0.7.1.tar.gz",
     "libsodium-wrappers-sumo": "0.7.15",
     "linkify-it": "^5.0.0",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "framer-motion": "^12.5.0",
     "fs-extra": "11.3.0",
     "image-type": "^4.1.0",
-    "libsession_util_nodejs": "https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.1/libsession_util_nodejs-v0.7.1.tar.gz",
+    "libsession_util_nodejs": "https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.2/libsession_util_nodejs-v0.7.2.tar.gz",
     "libsodium-wrappers-sumo": "0.7.15",
     "linkify-it": "^5.0.0",
     "lodash": "^4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       libsession_util_nodejs:
-        specifier: https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.0/libsession_util_nodejs-v0.7.0.tar.gz
-        version: https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.0/libsession_util_nodejs-v0.7.0.tar.gz
+        specifier: https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.1/libsession_util_nodejs-v0.7.1.tar.gz
+        version: https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.1/libsession_util_nodejs-v0.7.1.tar.gz
       libsodium-wrappers-sumo:
         specifier: 0.7.15
         version: 0.7.15
@@ -4184,9 +4184,9 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  libsession_util_nodejs@https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.0/libsession_util_nodejs-v0.7.0.tar.gz:
-    resolution: {integrity: sha512-RJ9n4tf/JCPqVCNkSz9x6AllUyNg/uWqXRAjxAXfvoUNTtEYO3HNqyF2EytBkfPoPvkogVuonHgWo1F5jdjEtQ==, tarball: https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.0/libsession_util_nodejs-v0.7.0.tar.gz}
-    version: 0.7.0
+  libsession_util_nodejs@https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.1/libsession_util_nodejs-v0.7.1.tar.gz:
+    resolution: {integrity: sha512-r1Amg3SKhIhNx/kS4ycbPzDoEwtpKrvPFCWpD7XcyVqUZr9GEIizsB2X7+IZTW4Wec2Nh1/j4MeQglrDqRN/Ig==, tarball: https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.1/libsession_util_nodejs-v0.7.1.tar.gz}
+    version: 0.7.1
 
   libsodium-sumo@0.7.16:
     resolution: {integrity: sha512-x6atrz2AdXCJg6G709x9W9TTJRI6/0NcL5dD0l5GGVqNE48UJmDsjO4RUWYTeyXXUpg+NXZ2SHECaZnFRYzwGA==}
@@ -10378,7 +10378,7 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  libsession_util_nodejs@https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.0/libsession_util_nodejs-v0.7.0.tar.gz:
+  libsession_util_nodejs@https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.1/libsession_util_nodejs-v0.7.1.tar.gz:
     dependencies:
       cmake-js: 7.3.1
       node-addon-api: 8.9.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,8 +100,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       libsession_util_nodejs:
-        specifier: https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.1/libsession_util_nodejs-v0.7.1.tar.gz
-        version: https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.1/libsession_util_nodejs-v0.7.1.tar.gz
+        specifier: https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.2/libsession_util_nodejs-v0.7.2.tar.gz
+        version: https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.2/libsession_util_nodejs-v0.7.2.tar.gz
       libsodium-wrappers-sumo:
         specifier: 0.7.15
         version: 0.7.15
@@ -4184,9 +4184,9 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  libsession_util_nodejs@https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.1/libsession_util_nodejs-v0.7.1.tar.gz:
-    resolution: {integrity: sha512-r1Amg3SKhIhNx/kS4ycbPzDoEwtpKrvPFCWpD7XcyVqUZr9GEIizsB2X7+IZTW4Wec2Nh1/j4MeQglrDqRN/Ig==, tarball: https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.1/libsession_util_nodejs-v0.7.1.tar.gz}
-    version: 0.7.1
+  libsession_util_nodejs@https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.2/libsession_util_nodejs-v0.7.2.tar.gz:
+    resolution: {integrity: sha512-bScGqpy6jFvSIcgZ+otHyWnyvREFDsh6BM47QBYarK0mPkS6iwwbB+ANNiYbPW4hWkTUHgB9KN4ep+FENeC/8w==, tarball: https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.2/libsession_util_nodejs-v0.7.2.tar.gz}
+    version: 0.7.2
 
   libsodium-sumo@0.7.16:
     resolution: {integrity: sha512-x6atrz2AdXCJg6G709x9W9TTJRI6/0NcL5dD0l5GGVqNE48UJmDsjO4RUWYTeyXXUpg+NXZ2SHECaZnFRYzwGA==}
@@ -10378,7 +10378,7 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  libsession_util_nodejs@https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.1/libsession_util_nodejs-v0.7.1.tar.gz:
+  libsession_util_nodejs@https://github.com/session-foundation/libsession-util-nodejs/releases/download/v0.7.2/libsession_util_nodejs-v0.7.2.tar.gz:
     dependencies:
       cmake-js: 7.3.1
       node-addon-api: 8.9.2

--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -369,7 +369,11 @@ message GroupUpdateDeleteMemberContentMessage {
 }
 
 message ProProof {
-  optional uint32 version           = 1;
+  // Numbering starts at 2: field 1 was `version`, dropped because a proof's format is its type
+  // rather than a value it carries -- the format is bound into the signature by the domain prefix
+  // it picks, and a future format arrives as its own message/field.
+  reserved 1;
+  reserved "version";
   optional bytes  revocationTag      = 2;
   optional bytes  rotatingPublicKey = 3;
   optional uint64 expiryUnixTs      = 4; // Epoch timestamp in whole seconds (what the Session Pro backend signs over)

--- a/ts/components/buttons/panel/PanelButton.tsx
+++ b/ts/components/buttons/panel/PanelButton.tsx
@@ -107,15 +107,17 @@ type PanelButtonGroupProps = {
   style?: CSSProperties;
   isSidePanel?: boolean;
   withBorder?: boolean;
+  dataTestId?: SessionDataTestId;
 };
 
 export const PanelButtonGroup = (
   props: PanelButtonGroupProps & { containerStyle?: CSSProperties }
 ) => {
-  const { children, style, containerStyle, isSidePanel, withBorder } = props;
+  const { children, style, containerStyle, isSidePanel, withBorder, dataTestId } = props;
   const isDarkTheme = useIsDarkTheme();
   return (
     <StyledRoundedPanelButtonGroup
+      data-testid={dataTestId}
       style={style}
       $isSidePanel={isSidePanel}
       $withBorder={withBorder}

--- a/ts/components/dialog/debug/FeatureFlags.tsx
+++ b/ts/components/dialog/debug/FeatureFlags.tsx
@@ -8,6 +8,7 @@ import {
   getDataFeatureFlag,
   getFeatureFlag,
   MockProAccessExpiryOptions,
+  MockProPlatformRefundWindowOptions,
   MockProProofOptions,
   SessionDataFeatureFlags,
   getDataFeatureFlagMemo,
@@ -427,14 +428,6 @@ function formatDefaultFlagName(key: string) {
 }
 
 const proBooleanFlags: BooleanFlags = [
-  {
-    label: 'Platform Refund Expired',
-    flag: 'mockCurrentUserHasProPlatformRefundExpired',
-    visibleWithEnumFlag: {
-      flag: 'mockProCurrentStatus',
-      isVisible: v => v === ProStatus.Active,
-    },
-  },
   {
     label: 'Cancelled',
     flag: 'mockCurrentUserHasProCancelled',
@@ -965,6 +958,26 @@ export const ProDebugSection = ({
         ]}
         forceUpdate={forceUpdate}
         unsetOption={{ label: 'Use the actual proof', value: null }}
+      />
+      <FlagEnumDropdownInput
+        label="Quick-refund window"
+        flag="mockProPlatformRefundWindow"
+        options={[
+          {
+            label: "The store's window is still open",
+            value: MockProPlatformRefundWindowOptions.Open,
+          },
+          {
+            label: "The store's window has closed",
+            value: MockProPlatformRefundWindowOptions.Closed,
+          },
+        ]}
+        forceUpdate={forceUpdate}
+        unsetOption={{ label: "Use the payment's own refund expiry", value: null }}
+        visibleWithEnumFlag={{
+          flag: 'mockProCurrentStatus',
+          isVisible: v => v === ProStatus.Active,
+        }}
       />
       <i>
         Status above is what the plan DISPLAYS; proof here is what the app may DO. They are separate

--- a/ts/components/dialog/debug/FeatureFlags.tsx
+++ b/ts/components/dialog/debug/FeatureFlags.tsx
@@ -730,17 +730,12 @@ function ProConfigForm({
   const [genHashInput, setGenHashInput] = useState<string>(
     proConfig?.proProof.revocationTagB64 ?? ''
   );
-  const [versionInput, setVersionInput] = useState<string>(
-    proConfig?.proProof.version.toString() ?? ''
-  );
-
   const removeConfig = useCallback(async () => {
     await UserConfigWrapperActions.removeProConfig();
     setRotatingPrivKeyInput('');
     setExpiryInput('');
     setSigInput('');
     setGenHashInput('');
-    setVersionInput('');
     await forceUpdate();
   }, [forceUpdate]);
 
@@ -762,7 +757,6 @@ function ProConfigForm({
       <DebugInput label="Expiry Timestamp (ms)" value={expiryInput} setValue={setExpiryInput} />
       <DebugInput label="Signature" value={sigInput} setValue={setSigInput} />
       <DebugInput label="Gen Hash" value={genHashInput} setValue={setGenHashInput} />
-      <DebugInput label="Version" value={versionInput} setValue={setVersionInput} />
     </div>
   );
 }

--- a/ts/components/dialog/user-settings/pages/user-pro/ProNonOriginatingPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProNonOriginatingPage.tsx
@@ -63,6 +63,15 @@ const useCurrentNeverHadProLocal = useCurrentNeverHadPro;
  * For some texts, we want `Apple website` for apple but `Google Play Store website` for google...
  * Those two are not stored in the same field, so this hook can be used to fetch the right one
  */
+/**
+ * The two Session-owned refund links. Duplicated here rather than read from libsession: the
+ * quick-refund one has no `url_pro_*` entry, and adding one would gate a copy change on a libsession
+ * bump across three clients. session-android's `ProUrls` and iOS's url string provider carry the same
+ * pair.
+ */
+const PRO_QUICK_REFUND_URL = 'https://getsession.org/android-refund';
+const PRO_SUPPORT_URL = LIBSESSION_CONSTANTS.LIBSESSION_PRO_URLS.support_url;
+
 function useStoreOrPlatformFromProvider(data: ProcessedProStatus['data']) {
   return data.provider === ProPaymentProvider.AppStore
     ? data.providerConstants.platform // we want `Apple website` for apple
@@ -687,9 +696,14 @@ function ProPageButtonRefund() {
       {...proButtonProps}
       buttonColor={SessionButtonColor.Danger}
       onClick={() => {
-        void openProviderUrl(
-          data.provider,
-          u => (data.isPlatformRefundAvailable ? u.refundPlatformUrl : u.refundSupportUrl),
+        // Two Session-owned links, chosen on the window alone — not the provider's own
+        // refund_platform_url/refund_support_url. Being ours, the destinations can be repointed without
+        // a client release, and all three clients agree on them.
+        //
+        // The window is what decides who can act: while it is open the store takes the request, and
+        // once it closes only Session can, which is what the copy beside this button promises.
+        showLinkVisitWarningDialog(
+          data.isPlatformRefundAvailable ? PRO_QUICK_REFUND_URL : PRO_SUPPORT_URL,
           dispatch
         );
       }}

--- a/ts/components/dialog/user-settings/pages/user-pro/ProNonOriginatingPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProNonOriginatingPage.tsx
@@ -63,13 +63,7 @@ const useCurrentNeverHadProLocal = useCurrentNeverHadPro;
  * For some texts, we want `Apple website` for apple but `Google Play Store website` for google...
  * Those two are not stored in the same field, so this hook can be used to fetch the right one
  */
-/**
- * The two Session-owned refund links. Duplicated here rather than read from libsession: the
- * quick-refund one has no `url_pro_*` entry, and adding one would gate a copy change on a libsession
- * bump across three clients. session-android's `ProUrls` and iOS's url string provider carry the same
- * pair.
- */
-const PRO_QUICK_REFUND_URL = 'https://getsession.org/android-refund';
+/** The route once the store's window has closed — libsession's `url_pro_support`. */
 const PRO_SUPPORT_URL = LIBSESSION_CONSTANTS.LIBSESSION_PRO_URLS.support_url;
 
 function useStoreOrPlatformFromProvider(data: ProcessedProStatus['data']) {
@@ -702,10 +696,20 @@ function ProPageButtonRefund() {
         //
         // The window is what decides who can act: while it is open the store takes the request, and
         // once it closes only Session can, which is what the copy beside this button promises.
-        showLinkVisitWarningDialog(
-          data.isPlatformRefundAvailable ? PRO_QUICK_REFUND_URL : PRO_SUPPORT_URL,
-          dispatch
-        );
+        // The quick-refund link is Google Play's: it redirects into the Play store, so it is only a
+        // usable route for a plan bought there. An App Store plan reports its window as open for the
+        // whole subscription, so gating on the window alone would send an Apple subscriber to the
+        // wrong store's refund flow.
+        const canUseStoreRoute =
+          data.isPlatformRefundAvailable && data.provider === ProPaymentProvider.GooglePlay;
+        if (canUseStoreRoute) {
+          // libsession's own per-provider value. Note the slot: for Google Play its
+          // `refund_support_url` IS the Session short link that redirects into the Play store, so the
+          // url wanted for the window-OPEN route sits under libsession's "support" name.
+          void openProviderUrl(data.provider, u => u.refundSupportUrl, dispatch);
+          return;
+        }
+        showLinkVisitWarningDialog(PRO_SUPPORT_URL, dispatch);
       }}
       dataTestId="pro-open-platform-website-button"
     >

--- a/ts/components/dialog/user-settings/pages/user-pro/ProNonOriginatingPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProNonOriginatingPage.tsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { type ReactNode, useEffect, useState } from 'react';
+import { type ReactNode, type SessionDataTestId, useEffect, useState } from 'react';
 import type { ProviderUrls } from 'libsession_util_nodejs';
 import { getAppDispatch } from '../../../../../state/dispatch';
 import { isSimpleTokenNoArgs, tr } from '../../../../../localization/localeTools';
@@ -290,12 +290,14 @@ function ProInfoBlockWebsite({
 }
 
 function ProInfoBlockLayout({
+  dataTestId,
   titleElement,
   descriptionElement,
   descriptionOnClick,
   subtitleElement,
   blockItems,
 }: {
+  dataTestId?: SessionDataTestId;
   titleElement: ReactNode;
   descriptionElement: ReactNode;
   descriptionOnClick?: () => void;
@@ -304,6 +306,7 @@ function ProInfoBlockLayout({
 }) {
   return (
     <PanelButtonGroup
+      dataTestId={dataTestId}
       containerStyle={{
         paddingBlock: 'var(--margins-lg)',
         paddingInline: 'var(--margins-lg)',
@@ -498,7 +501,10 @@ const containerStyle = {
 
 function ProInfoBlockRefundSessionSupport() {
   return (
-    <PanelButtonGroup containerStyle={containerStyle}>
+    <PanelButtonGroup
+      containerStyle={containerStyle}
+      dataTestId="pro-screen-refund-session-support"
+    >
       <ProInfoBlockRefundTitle>
         <Localizer token="proRefunding" />
       </ProInfoBlockRefundTitle>
@@ -514,7 +520,7 @@ function ProInfoBlockRefundSessionSupport() {
 function ProInfoBlockRefundGooglePlay() {
   const { data } = useProBackendProStatusLocal();
   return (
-    <PanelButtonGroup containerStyle={containerStyle}>
+    <PanelButtonGroup containerStyle={containerStyle} dataTestId="pro-screen-refund-store-policies">
       <ProInfoBlockRefundTitle>
         <Localizer token="proRefunding" />
       </ProInfoBlockRefundTitle>
@@ -531,6 +537,7 @@ function ProInfoBlockRefundIOS() {
   const { data } = useProBackendProStatusLocal();
   return (
     <ProInfoBlockLayout
+      dataTestId="pro-screen-refund-platform-account"
       titleElement={tr('proRefunding')}
       descriptionElement={
         <Localizer

--- a/ts/components/dialog/user-settings/pages/user-pro/ProNonOriginatingPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProNonOriginatingPage.tsx
@@ -420,7 +420,7 @@ function ProInfoBlockRenew() {
         />
       }
       descriptionOnClick={() =>
-        showLinkVisitWarningDialog('https://getsession.org/pro-roadmap', dispatch)
+        showLinkVisitWarningDialog(LIBSESSION_CONSTANTS.LIBSESSION_PRO_URLS.roadmap, dispatch)
       }
       subtitleElement={
         <ProInfoBlockSectionSubtitle>
@@ -700,12 +700,16 @@ function ProPageButtonRefund() {
         // usable route for a plan bought there. An App Store plan reports its window as open for the
         // whole subscription, so gating on the window alone would send an Apple subscriber to the
         // wrong store's refund flow.
-        const canUseStoreRoute =
-          data.isPlatformRefundAvailable && data.provider === ProPaymentProvider.GooglePlay;
-        if (canUseStoreRoute) {
+        if (data.isPlatformRefundAvailable) {
           // libsession's own per-provider value. Note the slot: for Google Play its
           // `refund_support_url` IS the Session short link that redirects into the Play store, so the
           // url wanted for the window-OPEN route sits under libsession's "support" name.
+          //
+          // No provider check on top of the window: `providerUrls` is looked up by the ORIGINATING
+          // provider, so an App Store plan yields Apple's own refund page here rather than the
+          // Play-store link. Checking the provider as well would replace that correct page with
+          // Session's form — and Apple's two refund urls are the same value, so the window is the only
+          // thing that can distinguish anything for it.
           void openProviderUrl(data.provider, u => u.refundSupportUrl, dispatch);
           return;
         }

--- a/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
@@ -238,6 +238,18 @@ const useCurrentNeverHadProInternal = useCurrentNeverHadPro;
 const useIsDarkThemeInternal = useIsDarkTheme;
 const usePinnedConversationsCountInternal = usePinnedConversationsCount;
 
+/**
+ * Mirror of libsession's `url_pro_faq` (`session_protocol.cpp`). libsession owns the Pro URL
+ * registry as the single source of truth, but the Node binding does not expose this entry yet:
+ * `constants.cpp` builds `LIBSESSION_PRO_URLS` out of `url_pro_roadmap`, `url_privacy_policy`,
+ * `url_terms_of_service`, `url_pro_access_not_found` and `url_pro_support` only, so
+ * `ProBackendUrlsType` has no `faq` field (nor `pro_page` / `upgrade`, the other two omissions).
+ *
+ * This literal is therefore a copy under protest, not a choice — delete it and read the constant
+ * the moment libsession_util_nodejs surfaces `url_pro_faq`.
+ */
+const PRO_FAQ_URL = 'https://getsession.org/pro#faq';
+
 // Trigger #4's cadence (a cross-client contract, see the constants in ducks/proBackendData.ts).
 /** How long past the `user_expiry` crossing to wait before the first refetch. */
 const GRACE_POLL_CROSSING_SLACK_MS = 5 * DURATION.SECONDS;
@@ -1026,7 +1038,13 @@ function ProHelp() {
           text={{ token: 'proFaq' }}
           subText={{ token: 'proFaqDescription' }}
           onClick={async () =>
-            showLinkVisitWarningDialog('https://getsession.org/faq#pro', dispatch)
+            // A copy under protest, not a choice: this mirrors libsession's `url_pro_faq`
+            // (session_protocol.cpp), which the Node binding does NOT surface —
+            // `constants.cpp` builds `LIBSESSION_PRO_URLS` from only `url_pro_roadmap`,
+            // `url_privacy_policy`, `url_terms_of_service`, `url_pro_access_not_found` and
+            // `url_pro_support`, so there is no `faq` field on `ProBackendUrlsType` to read.
+            // Replace this literal with the constant as soon as the binding exports it.
+            showLinkVisitWarningDialog(PRO_FAQ_URL, dispatch)
           }
         />
         <SettingsExternalLinkBasic

--- a/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
@@ -238,7 +238,6 @@ const useCurrentNeverHadProInternal = useCurrentNeverHadPro;
 const useIsDarkThemeInternal = useIsDarkTheme;
 const usePinnedConversationsCountInternal = usePinnedConversationsCount;
 
-
 // Trigger #4's cadence (a cross-client contract, see the constants in ducks/proBackendData.ts).
 /** How long past the `user_expiry` crossing to wait before the first refetch. */
 const GRACE_POLL_CROSSING_SLACK_MS = 5 * DURATION.SECONDS;

--- a/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
@@ -238,17 +238,6 @@ const useCurrentNeverHadProInternal = useCurrentNeverHadPro;
 const useIsDarkThemeInternal = useIsDarkTheme;
 const usePinnedConversationsCountInternal = usePinnedConversationsCount;
 
-/**
- * Mirror of libsession's `url_pro_faq` (`session_protocol.cpp`). libsession owns the Pro URL
- * registry as the single source of truth, but the Node binding does not expose this entry yet:
- * `constants.cpp` builds `LIBSESSION_PRO_URLS` out of `url_pro_roadmap`, `url_privacy_policy`,
- * `url_terms_of_service`, `url_pro_access_not_found` and `url_pro_support` only, so
- * `ProBackendUrlsType` has no `faq` field (nor `pro_page` / `upgrade`, the other two omissions).
- *
- * This literal is therefore a copy under protest, not a choice — delete it and read the constant
- * the moment libsession_util_nodejs surfaces `url_pro_faq`.
- */
-const PRO_FAQ_URL = 'https://getsession.org/pro#faq';
 
 // Trigger #4's cadence (a cross-client contract, see the constants in ducks/proBackendData.ts).
 /** How long past the `user_expiry` crossing to wait before the first refetch. */
@@ -1038,13 +1027,7 @@ function ProHelp() {
           text={{ token: 'proFaq' }}
           subText={{ token: 'proFaqDescription' }}
           onClick={async () =>
-            // A copy under protest, not a choice: this mirrors libsession's `url_pro_faq`
-            // (session_protocol.cpp), which the Node binding does NOT surface —
-            // `constants.cpp` builds `LIBSESSION_PRO_URLS` from only `url_pro_roadmap`,
-            // `url_privacy_policy`, `url_terms_of_service`, `url_pro_access_not_found` and
-            // `url_pro_support`, so there is no `faq` field on `ProBackendUrlsType` to read.
-            // Replace this literal with the constant as soon as the binding exports it.
-            showLinkVisitWarningDialog(PRO_FAQ_URL, dispatch)
+            showLinkVisitWarningDialog(LIBSESSION_CONSTANTS.LIBSESSION_PRO_URLS.faq, dispatch)
           }
         />
         <SettingsExternalLinkBasic

--- a/ts/react.d.ts
+++ b/ts/react.d.ts
@@ -135,6 +135,11 @@ declare module 'react' {
     | 'donate';
 
   type ProSettingsSections = 'stats' | 'manage' | 'features';
+  /**
+   * The refund route the non-originating page offered. Its hero copy is the same string in all
+   * three, so the info block is the only thing that says which route the app chose.
+   */
+  type ProRefundRoutes = 'store-policies' | 'platform-account' | 'session-support';
 
   type ProFeatureItems =
     | 'longer-messages'
@@ -323,6 +328,7 @@ declare module 'react' {
     // Pro settings
     | `${ProFeatureItems}-pro-settings-menu-item`
     | `pro-settings-${ProSettingsSections}-header`
+    | `pro-screen-refund-${ProRefundRoutes}`
     // Both the "checking" and the "backend unavailable" messages render into this one slot.
     | 'pro-settings-status-banner'
     // The hero copy, which differs per status. Shared with the non-originating page, whose hero

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -9,6 +9,7 @@ import { UserUtils } from '../../session/utils';
 import { getProMasterKeyHex } from '../../session/utils/User';
 import { updateLocalizedPopupDialog } from './modalDialog';
 import { showLinkVisitWarningDialog } from '../../components/dialog/OpenUrlModal';
+import LIBSESSION_CONSTANTS from '../../session/utils/libsession/libsession_constants';
 import { ProStatus } from '../../session/apis/pro_backend_api/types';
 import { SettingsKey } from '../../data/settings-key';
 import { ProStatusResultType } from '../../session/apis/pro_backend_api/schemas';
@@ -957,7 +958,7 @@ const fetchGetProStatusFromProBackend = createAsyncThunk(
                     dataTestId: 'pro-backend-error-support-button',
                     onClick: () => {
                       showLinkVisitWarningDialog(
-                        'https://sessionapp.zendesk.com/hc/sections/4416517450649-Support',
+                        LIBSESSION_CONSTANTS.LIBSESSION_PRO_URLS.pro_access_not_found,
                         payloadCreator.dispatch
                       );
                     },

--- a/ts/state/ducks/types/defaultFeatureFlags.ts
+++ b/ts/state/ducks/types/defaultFeatureFlags.ts
@@ -1,8 +1,9 @@
 import { isEmpty } from 'lodash';
 import { isTestIntegration, isTestNet } from '../../../shared/env_vars';
-import { ProStatus } from '../../../session/apis/pro_backend_api/types';
+import { ProPaymentProvider, ProStatus } from '../../../session/apis/pro_backend_api/types';
 import {
   MockProAccessExpiryOptions,
+  MockProPlatformRefundWindowOptions,
   MockProProofOptions,
   type SessionBooleanFeatureFlags,
   type SessionDataFeatureFlags,
@@ -11,9 +12,6 @@ import {
 export const defaultProBooleanFeatureFlags = {
   proGroupsAvailable: !isEmpty(process.env.SESSION_PRO_GROUPS),
   useTestProBackend: !isEmpty(process.env.TEST_PRO_BACKEND),
-  mockCurrentUserHasProPlatformRefundExpired: !isEmpty(
-    process.env.SESSION_USER_HAS_PRO_PLATFORM_REFUND_EXPIRED
-  ),
   mockCurrentUserHasProCancelled: !isEmpty(process.env.SESSION_USER_HAS_PRO_CANCELLED),
   mockCurrentUserHasProInGracePeriod: !isEmpty(process.env.SESSION_USER_HAS_PRO_IN_GRACE),
   mockProRecoverButtonAlwaysSucceed: !isEmpty(process.env.SESSION_PRO_RECOVER_ALWAYS_SUCCEED),
@@ -145,6 +143,55 @@ function getMockProProof(): MockProProofOptions | null {
 }
 
 /**
+ * Whether the store's own quick-refund window is still open.
+ *
+ * Unset means "defer to the payment": the window is decided by `platformRefundExpiryTsMs`. That is the
+ * whole point of the flag being tri-state — its predecessor
+ * (`SESSION_USER_HAS_PRO_PLATFORM_REFUND_EXPIRED`, a boolean presence check) forced the window OPEN
+ * whenever it was absent, short-circuiting the payment comparison in every build including release.
+ *
+ * `useactual` is spelled out as well, matching the other Pro mocks, so a config can say "no override"
+ * explicitly rather than by omission.
+ */
+function getMockProPlatformRefundWindow(): MockProPlatformRefundWindowOptions | null {
+  const envVar = process.env.SESSION_PRO_PLATFORM_REFUND_WINDOW?.trim();
+  if (!envVar) {
+    return null;
+  }
+  const known = Object.values(MockProPlatformRefundWindowOptions) as Array<string>;
+  if (known.includes(envVar)) {
+    return envVar as MockProPlatformRefundWindowOptions;
+  }
+  if (envVar === 'useactual') {
+    return null;
+  }
+  return invalidMockEnvVar('SESSION_PRO_PLATFORM_REFUND_WINDOW', envVar, [...known, 'useactual']);
+}
+
+/**
+ * Which store a mocked plan was bought from. Every non-originating Pro page branches on it, and the
+ * refund page uses it to pick between the store-policy, platform-account and Session-support routes.
+ *
+ * Unset resolves the provider to `''`, whose display constants fall back to the slug and whose refund
+ * route is Session support — so a spec meaning "bought on Google Play" has to say so, and cannot get
+ * there by omission.
+ */
+function getMockProPaymentProvider(): ProPaymentProvider | null {
+  const envVar = process.env.SESSION_PRO_PAYMENT_PROVIDER?.trim();
+  if (!envVar) {
+    return null;
+  }
+  const known = Object.values(ProPaymentProvider) as Array<string>;
+  if (known.includes(envVar)) {
+    return envVar;
+  }
+  if (envVar === 'useactual') {
+    return null;
+  }
+  return invalidMockEnvVar('SESSION_PRO_PAYMENT_PROVIDER', envVar, [...known, 'useactual']);
+}
+
+/**
  * Named rather than numeric, because the enum's numbering is an implementation detail that
  * reorders whenever a case is inserted — an environment pinned to `2` would silently start
  * meaning a different duration.
@@ -183,7 +230,8 @@ export const defaultProDataFeatureFlags = {
   mockMessageProFeatures: null,
   mockProCurrentStatus: getMockProCurrentStatus(),
   mockProProof: getMockProProof(),
-  mockProPaymentProvider: null,
+  mockProPlatformRefundWindow: getMockProPlatformRefundWindow(),
+  mockProPaymentProvider: getMockProPaymentProvider(),
   mockProAccessVariant: null,
   mockProAccessExpiry: getMockProAccessExpiry(),
   mockProLongerMessagesSent: null,

--- a/ts/state/ducks/types/releasedFeaturesReduxTypes.ts
+++ b/ts/state/ducks/types/releasedFeaturesReduxTypes.ts
@@ -20,7 +20,6 @@ type SessionBaseBooleanFeatureFlags = {
   debugInputCommands: boolean;
   proGroupsAvailable: boolean;
   canToggleGiphy: boolean;
-  mockCurrentUserHasProPlatformRefundExpired: boolean;
   mockCurrentUserHasProCancelled: boolean;
   mockCurrentUserHasProInGracePeriod: boolean;
   mockProRecoverButtonAlwaysSucceed: boolean;
@@ -86,11 +85,30 @@ export const MockProProofOptions = {
 } as const;
 export type MockProProofOptions = (typeof MockProProofOptions)[keyof typeof MockProProofOptions];
 
+/**
+ * Whether the store's own quick-refund window is still open, which decides between the store-refund
+ * route and the Session-support one.
+ *
+ * `null` means no override: the window is read from the payment's own `platformRefundExpiryTsMs`.
+ *
+ * Tri-state rather than a boolean because this used to be `mockCurrentUserHasProPlatformRefundExpired`,
+ * whose *unset* state forced the window open — it short-circuited the real expiry comparison, in every
+ * build, so a released client never consulted the payment at all. A mock's absence has to mean "defer",
+ * which a two-state flag on an env-presence check cannot express.
+ */
+export const MockProPlatformRefundWindowOptions = {
+  Open: 'open',
+  Closed: 'closed',
+} as const;
+export type MockProPlatformRefundWindowOptions =
+  (typeof MockProPlatformRefundWindowOptions)[keyof typeof MockProPlatformRefundWindowOptions];
+
 export type SessionDataFeatureFlags = {
   useLocalDevNet: string | null;
   mockMessageProFeatures: Array<ProMessageFeature> | null;
   mockProCurrentStatus: ProStatus | null;
   mockProProof: MockProProofOptions | null;
+  mockProPlatformRefundWindow: MockProPlatformRefundWindowOptions | null;
   mockProPaymentProvider: ProPaymentProvider | null;
   mockProAccessVariant: ProAccessVariant | null;
   mockProAccessExpiry: MockProAccessExpiryOptions | null;

--- a/ts/state/selectors/proBackendData.ts
+++ b/ts/state/selectors/proBackendData.ts
@@ -12,6 +12,7 @@ import {
   getDataFeatureFlag,
   getFeatureFlag,
   getFeatureFlagMemo,
+  MockProPlatformRefundWindowOptions,
 } from '../ducks/types/releasedFeaturesReduxTypes';
 import { mockedProExpiryMs, proAutoRenewWithMock } from '../ducks/types/proMocks';
 import { NetworkTime } from '../../util/NetworkTime';
@@ -236,9 +237,7 @@ function processProBackendData({
   const mockVariant = getDataFeatureFlag('mockProAccessVariant');
   const mockPlatform = getDataFeatureFlag('mockProPaymentProvider');
   const mockInGracePeriod = getFeatureFlag('mockCurrentUserHasProInGracePeriod');
-  const mockIsPlatformRefundAvailable = !getFeatureFlag(
-    'mockCurrentUserHasProPlatformRefundExpired'
-  );
+  const mockRefundWindow = getDataFeatureFlag('mockProPlatformRefundWindow');
   const mockExpiry = mockedProExpiryMs();
 
   const isLoading = mockIsLoading || _isLoading;
@@ -277,10 +276,14 @@ function processProBackendData({
         latestAccess?.planCount ?? storedPlanAndProvider?.planCount,
         latestAccess?.planUnit ?? storedPlanAndProvider?.planUnit
       );
-  const isPlatformRefundAvailable =
-    mockIsPlatformRefundAvailable ||
-    (latestAccess?.platformRefundExpiryTsMs && now < latestAccess.platformRefundExpiryTsMs) ||
-    defaultProAccessDetailsSourceData.isPlatformRefundAvailable;
+  // The payment decides this unless a mock says otherwise. The mock used to be a boolean whose unset
+  // state read as "window open", which short-circuited the comparison below in every build — so a
+  // release client never consulted `platformRefundExpiryTsMs` at all, and every subscriber was routed to
+  // the store-refund screen however old the payment was. A null override defers; only an explicit one
+  // wins. No payment means no window, which is `defaultProAccessDetailsSourceData` too.
+  const isPlatformRefundAvailable = mockRefundWindow
+    ? mockRefundWindow === MockProPlatformRefundWindowOptions.Open
+    : !!latestAccess?.platformRefundExpiryTsMs && now < latestAccess.platformRefundExpiryTsMs;
 
   const autoRenew = proAutoRenewWithMock(
     data?.autoRenewing ?? defaultProAccessDetailsSourceData.autoRenew

--- a/ts/test/session/unit/libsession_wrapper/libsession_wrapper_user_profile_test.ts
+++ b/ts/test/session/unit/libsession_wrapper/libsession_wrapper_user_profile_test.ts
@@ -79,9 +79,6 @@ describe('libsession_user_profile', () => {
           // sub-second value would come back floored. Use a second-aligned one to round-trip as-is.
           expiryMs: Math.floor(Date.now() / 1000) * 1000 + 1000,
           revocationTagB64: to_base64(ed25519Seed, base64_variants.ORIGINAL),
-          // Deliberately not v0: the version is required on the way in but is not persisted, so
-          // this must come back as 0. See the expectation below.
-          version: 132,
           signatureHex: to_hex(randombytes_buf(64)),
         },
       };
@@ -100,10 +97,9 @@ describe('libsession_user_profile', () => {
           rotatingPubkeyHex: rotatingPubKeyHex,
           expiryMs: proConfig.proProof.expiryMs,
           revocationTagB64: proConfig.proProof.revocationTagB64,
-          // The stored credential is one opaque bt-encoded value carrying only `e`, `g`, `r` and `s`,
-          // so no version is written and load forces v0 (= 0). A version can't describe itself across
-          // a per-key merge, so a future format takes a new config key instead of an in-dict marker.
-          version: 0,
+          // The stored credential is one opaque bt-encoded value carrying only `e`, `g`, `r` and `s`
+          // -- there is no version to round-trip. A version can't describe itself across a per-key
+          // merge, so a future format takes a new config key instead of an in-dict marker.
           signatureHex: proConfig.proProof.signatureHex,
         },
       };

--- a/ts/test/session/unit/libsession_wrapper/libsession_wrapper_user_profile_test.ts
+++ b/ts/test/session/unit/libsession_wrapper/libsession_wrapper_user_profile_test.ts
@@ -97,9 +97,6 @@ describe('libsession_user_profile', () => {
           rotatingPubkeyHex: rotatingPubKeyHex,
           expiryMs: proConfig.proProof.expiryMs,
           revocationTagB64: proConfig.proProof.revocationTagB64,
-          // The stored credential is one opaque bt-encoded value carrying only `e`, `g`, `r` and `s`
-          // -- there is no version to round-trip. A version can't describe itself across a per-key
-          // merge, so a future format takes a new config key instead of an in-dict marker.
           signatureHex: proConfig.proProof.signatureHex,
         },
       };

--- a/ts/types/message/OutgoingProMessageDetails.ts
+++ b/ts/types/message/OutgoingProMessageDetails.ts
@@ -58,8 +58,7 @@ export class OutgoingProMessageDetails {
       }
       return null;
     }
-    const { expiryMs, revocationTagB64, rotatingPubkeyHex, signatureHex, version } =
-      this.proConfig.proProof;
+    const { expiryMs, revocationTagB64, rotatingPubkeyHex, signatureHex } = this.proConfig.proProof;
 
     return new SignalService.ProMessage({
       profileBitset: bigIntToLong(this.proProfileBitset),
@@ -70,7 +69,6 @@ export class OutgoingProMessageDetails {
         expiryUnixTs: Math.floor(expiryMs / 1000),
         revocationTag: from_base64(revocationTagB64, base64_variants.ORIGINAL),
         rotatingPublicKey: from_hex(rotatingPubkeyHex),
-        version,
         sig: from_hex(signatureHex),
       },
     });


### PR DESCRIPTION
## The bug

`mockCurrentUserHasProPlatformRefundExpired` was a boolean on an env-presence check, and `processProBackendData` read its **negation** as "the refund window is open":

```ts
const mockIsPlatformRefundAvailable = !getFeatureFlag('mockCurrentUserHasProPlatformRefundExpired');

const isPlatformRefundAvailable =
  mockIsPlatformRefundAvailable ||                                                   // `true` when unset
  (latestAccess?.platformRefundExpiryTsMs && now < latestAccess.platformRefundExpiryTsMs) ||
  defaultProAccessDetailsSourceData.isPlatformRefundAvailable;
```

So the *unset* state — every build that sets no mock, release included — put `true` at the head of the `||` chain and short-circuited the comparison behind it. The client never consulted the payment: **every subscriber was routed to the store-refund screen however old their payment was**, and the expiry branch was dead code reachable only by opting *into* the mock.

## The fix

A mock's absence has to mean "defer to the real value", which a two-state flag on a presence check cannot express. `mockProPlatformRefundWindow` replaces it as a tri-state data flag (`open` / `closed` / unset), matching the other Pro mocks:

```ts
const isPlatformRefundAvailable = mockRefundWindow
  ? mockRefundWindow === MockProPlatformRefundWindowOptions.Open
  : !!latestAccess?.platformRefundExpiryTsMs && now < latestAccess.platformRefundExpiryTsMs;
```

Unset now reads the payment's own expiry and only an explicit override wins. Dropping `defaultProAccessDetailsSourceData` from the chain changes nothing on its own — that default is `false`, which is also what "no payment" should mean.

## Also here

- **`mockProPaymentProvider` gains an env reader** (`SESSION_PRO_PAYMENT_PROVIDER`), on the same pattern as the sibling Pro mocks, so the non-originating refund route can be pinned from a config instead of only through the debug dialog. Unset still resolves the provider to `''`, whose route is Session support.
- **The debug dialog** swaps its "Platform Refund Expired" checkbox for the tri-state dropdown.
- **Test ids on the three refund info blocks** (`pro-screen-refund-{store-policies,platform-account,session-support}`). The three routes share their hero copy, so the info block is the only thing on screen that says which route the app picked — without a tag there, a spec cannot tell the fixed behaviour from the broken one. That needed `PanelButtonGroup` to accept a `dataTestId`.

## Verifying

Covered by three specs in the appium suite (`run/test/specs/desktop/pro_refund_routes.spec.ts`), one per route, each asserting the other two routes are absent — so they are each other's negative control rather than three presence checks that would all pass on a client rendering one block for everything.

Those specs need the two env readers above, so they land with the harness change in session-appium and not before this.
