### PR TITLE
Pro: revocation test hook and incoming-limit fix

### DIFF
--- a/ts/receiver/queuedJob.ts
+++ b/ts/receiver/queuedJob.ts
@@ -229,7 +229,20 @@ async function handleRegularMessage(
 
   handleLinkPreviews(rawDataMessage.body, rawDataMessage.preview, message);
 
-  const maxChars = sendingDeviceConversation.hasValidCurrentProProof()
+  // Sized from the proof THIS message carried, not from what we had stored for its sender. The stored
+  // record is only ever refreshed by a message that also carries a profile block
+  // (buildPrivateProfileChangeFromSwarmDataMessage returns null without one), so sizing from it made the
+  // limit depend on the profile rather than on the proof: a first message from a newly-Pro sender, or any
+  // message sent without a profile, would be cut against a record that had never heard of their proof.
+  // iOS and Android both read the arriving proof here.
+  //
+  // Our own synced messages keep reading our own access instead: that path resolves through our config
+  // rather than a contact record, so it never had the coupling this removes.
+  const senderIsProForThisMessage = sendingDeviceConversation.isMe()
+    ? sendingDeviceConversation.hasValidCurrentProProof()
+    : decodedEnvelope.proProofEntitlesFeaturesNow();
+
+  const maxChars = senderIsProForThisMessage
     ? LIBSESSION_CONSTANTS.MESSAGE_CHARACTER_LIMIT_PRO
     : LIBSESSION_CONSTANTS.MESSAGE_CHARACTER_LIMIT_STANDARD;
 

--- a/ts/receiver/types.ts
+++ b/ts/receiver/types.ts
@@ -1,6 +1,7 @@
 import type { DecodedPro } from 'libsession_util_nodejs';
 import { isNil } from 'lodash';
 import { ProRevocationCache } from '../session/revocation_list/pro_revocation_list';
+import { NetworkTime } from '../util/NetworkTime';
 
 type DecodedProConstructorArgs = {
   id: string;
@@ -101,6 +102,28 @@ export abstract class BaseDecodedEnvelope {
       return false;
     }
     return this.validPro.proProof.expiryMs < timestampMs;
+  }
+
+  /**
+   * Whether the proof this message arrived with entitles the message to Pro features right now.
+   *
+   * The three checks are separate because `validPro` is only the decode verdict — a signature the backend
+   * issued — and says nothing about whether that proof has since expired or been revoked. Reading it alone
+   * would hand Pro features to both.
+   *
+   * Judged at the current instant rather than at `sentAtMs`, matching what the sender's stored record
+   * answers today: a message is sized by whether the proof behind it is usable, not by whether it was
+   * usable when it was written. The per-message feature bitset asks the same question at send time — see
+   * processProDetailsForMsg — and the two instants have never agreed.
+   */
+  public proProofEntitlesFeaturesNow() {
+    if (!this.validPro) {
+      return false;
+    }
+    if (this.isProProofRevoked()) {
+      return false;
+    }
+    return !this.isProProofExpiredAtMs(NetworkTime.now());
   }
 
   /**

--- a/ts/session/utils/job_runners/jobs/UpdateProRevocationListJob.ts
+++ b/ts/session/utils/job_runners/jobs/UpdateProRevocationListJob.ts
@@ -233,11 +233,32 @@ async function queueNewJobIfNeeded() {
 }
 
 /**
+ * Backdate the next-run instant so the startup gate below decides, on its own terms, to poll now.
+ *
+ * The gate is left exactly as it is: this changes what it reads, not what it does, so a spec that relies
+ * on a poll is still exercising the path that ships. Bypassing the gate with a direct fetch would let the
+ * spec pass while the real polling path was broken.
+ *
+ * One-shot. The poll it releases stores a fresh `retry_in` from the backend — 24h against the QA
+ * backend — so the next launch is gated again unless the variable is still set.
+ */
+async function backdateNextRunIfForced() {
+  if (!getFeatureFlag('forceProRevocationRefresh')) {
+    return;
+  }
+  window.log.info(
+    'UpdateProRevocationListJob: SESSION_FORCE_PRO_REVOCATION_REFRESH is set; backdating the next-run instant so the startup gate polls now.'
+  );
+  await updateNextRunAtMs(Date.now() - 1);
+}
+
+/**
  * Run, and await the UpdateProRevocationListJob on startup.
  * Note: this is only run if the nextRunAtMs is unset or is already passed.
  */
 async function runOnStartup() {
   try {
+    await backdateNextRunIfForced();
     const now = Date.now();
     const refreshedNextRunAtMs = await refreshNextRunAtMsIfNeeded();
 

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -412,9 +412,16 @@ async function handleExpiryCTAs(
   const expiredCTADeadlineMs = accessExpiryTsMs + gracePeriodDurationMs + PRO_EXPIRED_CTA_WINDOW_MS;
 
   const proExpiringSoonCTA = !isUndefined(Storage.get(SettingsKey.proExpiringSoonCTA));
+  // Presence, not truth. Each key carries three states: absent means never armed this cycle, `true` armed
+  // and not yet shown, `false` armed and already shown — the CTA writes `false` over its own flag as it
+  // displays. Testing presence is what makes an expiry happen once per Pro cycle rather than once per
+  // status fetch: a shown CTA leaves `false` behind, which reads as armed and blocks the re-arm below.
+  // Reading these as booleans instead would re-raise the same expiry on every launch that confirms a
+  // status.
   const proExpiredCTA = !isUndefined(Storage.get(SettingsKey.proExpiredCTA));
 
-  // Remove the pro expired cta item if the user gets pro again
+  // Removing the key, rather than setting it false, is what ends the cycle: it is the only path back to
+  // "never armed", so a subsequent lapse can raise the CTA again.
   if (status === ProStatus.Active && proExpiredCTA) {
     await Storage.remove(SettingsKey.proExpiredCTA);
   }

--- a/ts/state/ducks/types/defaultFeatureFlags.ts
+++ b/ts/state/ducks/types/defaultFeatureFlags.ts
@@ -54,6 +54,7 @@ export const defaultBooleanFeatureFlags = {
   debugInsecureNodeFetch: !isEmpty(process.env.SESSION_DEBUG_INSECURE_NODE_FETCH),
   debugOnlineState: !isEmpty(process.env.SESSION_DEBUG_ONLINE_STATE),
   debugForceSeedNodeFailure: !isEmpty(process.env.SESSION_DEBUG_FORCE_SEED_NODE_FAILURE),
+  forceProRevocationRefresh: getForceProRevocationRefresh(),
   debugKeyboardShortcuts: !isEmpty(process.env.SESSION_DEBUG_KEYBOARD_SHORTCUTS),
   debugFocusScope: !isEmpty(process.env.SESSION_DEBUG_FOCUS_SCOPE),
   debugFocusTrap: !isEmpty(process.env.SESSION_DEBUG_FOCUS_TRAP),
@@ -175,6 +176,27 @@ function getMockProAccessExpiry(): MockProAccessExpiryOptions | null {
  */
 function getFakeAvatarPickerFile(): string | null {
   return process.env.SESSION_FAKE_AVATAR_PICKER_FILE?.trim() || null;
+}
+
+/**
+ * Force the revocation-list poll on the next launch, by backdating the persisted next-run instant.
+ *
+ * The QA backend serves the production `retry_in` of 24h, so a client that has polled once will not poll
+ * again for a day and no revocation is observable within a test. This does not shorten the interval or
+ * add a second fetch path — it moves the stored instant into the past and lets the existing gate reach
+ * its own conclusion, so a spec exercises the polling path that ships rather than one built beside it.
+ *
+ * `isTestIntegration()` first, so the variable is inert outside a test-integration run however it is set.
+ *
+ * Explicitly `true`/`1` rather than a presence check: `SESSION_...=0` reads as "off" to whoever wrote it,
+ * and a presence check would turn it on.
+ */
+function getForceProRevocationRefresh(): boolean {
+  if (!isTestIntegration()) {
+    return false;
+  }
+  const envVar = process.env.SESSION_FORCE_PRO_REVOCATION_REFRESH?.trim().toLowerCase();
+  return envVar === 'true' || envVar === '1';
 }
 
 export const defaultAvatarPickerColor = '#0000ff'; // defaults to blue

--- a/ts/state/ducks/types/releasedFeaturesReduxTypes.ts
+++ b/ts/state/ducks/types/releasedFeaturesReduxTypes.ts
@@ -30,6 +30,9 @@ type SessionBaseBooleanFeatureFlags = {
   mockProBackendSuccess: boolean;
   fsTTL30s: boolean;
   debugForceSeedNodeFailure: boolean;
+  // Backdates the persisted next-revocation-poll instant at launch so the startup gate polls now. The QA
+  // backend serves the production 24h `retry_in`, which otherwise puts a client's second poll a day out.
+  forceProRevocationRefresh: boolean;
 };
 
 export type SessionDebugBooleanFeatureFlags = {


### PR DESCRIPTION
> **Draft — part of the Pro revocation set, for review alongside session-appium#138.**

Two changes and a doc correction, supporting the Pro revocation specs.

### `SESSION_FORCE_PRO_REVOCATION_REFRESH`

The backend serves a 24h `retry_in`, so a client's second revocation poll is a day after its first and **no revocation behaviour is reachable within a test**. This forces the next poll rather than shortening the interval or adding a fetch path, so a spec exercises the production polling path rather than a parallel one that could pass while the real path was broken.

### Size an incoming message from the proof it carried

The character limit for an incoming message was chosen from the Pro proof stored against its sender's contact record. That record is only refreshed by a message that *also* carries a profile block, so the limit depended on the profile rather than on the proof.

The ordering already happened to be right — the arriving proof is written to the record before the limit is chosen, in the same function — so a first oversized message from a newly-Pro sender is kept today. But it is kept **by luck**: a message without a profile block, or one whose profile timestamp is not newer, would be cut against a record that had never heard of that sender's proof. Reading the proof from the envelope removes the dependency rather than the ordering.

iOS and Android both size from the arriving proof; this was the only client that did not.

Entitlement stays three checks, not one: `validPro` is the decode verdict and says nothing about expiry or revocation, so both are still refused and still judged at the current instant. The observable does not move — which is why this has no spec of its own, and why the first-contact spec that was meant to guard it was dropped (reasons in `COVERAGE-table.md`).

### Doc

Why the CTA flags are read for presence rather than truth.
