### PR TITLE
feat(attachments): default to stream encryption and write the stream fragment bare

### DIFF
--- a/ts/interactions/avatar-interactions/nts-avatar-interactions.ts
+++ b/ts/interactions/avatar-interactions/nts-avatar-interactions.ts
@@ -1,14 +1,9 @@
-import { randombytes_buf } from 'libsodium-wrappers-sumo';
-
 import { uploadFileToFsWithOnionV4 } from '../../session/apis/file_server_api/FileServerApi';
 import { processNewAttachment } from '../../types/MessageAttachment';
-import { encryptProfile } from '../../util/crypto/profileEncrypter';
 import { processAvatarData } from '../../util/avatar/processAvatarData';
 import { MultiEncryptWrapperActions } from '../../webworker/workers/browser/libsession_worker_interface';
 import { UserUtils } from '../../session/utils';
-import { getFeatureFlag } from '../../state/ducks/types/releasedFeaturesReduxTypes';
 import { SessionProfileSetAvatarDownloadedAny } from '../../models/profile';
-import { fromHexToArray } from '../../session/utils/String';
 import { UserConfigWrapperActions } from '../../webworker/workers/browser/libsession/libsession_worker_userconfig_interface';
 import { ConvoHub } from '../../session/conversations';
 
@@ -29,31 +24,16 @@ export async function uploadAndSetOurAvatarShared({
   // below (resized & converted), not the original one.
   const { avatarFallback, mainAvatarDetails } = await processAvatarData(decryptedAvatarData, true);
 
-  let encryptedData: ArrayBuffer;
-  let encryptionKey: Uint8Array;
-  const deterministicEncryption = getFeatureFlag('useDeterministicEncryption');
   const isAnimated = mainAvatarDetails.isAnimated;
-  if (deterministicEncryption) {
-    const encryptedContent = await MultiEncryptWrapperActions.attachmentEncrypt({
-      allowLarge: false,
-      seed: await UserUtils.getUserEd25519Seed(),
-      data: new Uint8Array(mainAvatarDetails.outputBuffer),
-      domain: 'profilePic',
-    });
-    encryptedData = encryptedContent.encryptedData;
-    encryptionKey = encryptedContent.encryptionKey;
-  } else {
-    // if this is a reupload, reuse the current profile key. Otherwise generate a new one
-    const existingProfileKeyHex = ourConvo.getProfileKeyHex();
-    const profileKey =
-      context === 'reuploadAvatar' && existingProfileKeyHex
-        ? fromHexToArray(existingProfileKeyHex)
-        : randombytes_buf(32);
-    encryptedData = await encryptProfile(mainAvatarDetails.outputBuffer, profileKey);
-    encryptionKey = profileKey;
-  }
+  const encryptedContent = await MultiEncryptWrapperActions.attachmentEncrypt({
+    allowLarge: false,
+    seed: await UserUtils.getUserEd25519Seed(),
+    data: new Uint8Array(mainAvatarDetails.outputBuffer),
+    domain: 'profilePic',
+  });
+  const encryptionKey = encryptedContent.encryptionKey;
 
-  const avatarPointer = await uploadFileToFsWithOnionV4(encryptedData, deterministicEncryption);
+  const avatarPointer = await uploadFileToFsWithOnionV4(encryptedContent.encryptedData);
   if (!avatarPointer) {
     window.log.warn('failed to upload avatar to file server');
     return null;

--- a/ts/session/apis/file_server_api/FileServerApi.ts
+++ b/ts/session/apis/file_server_api/FileServerApi.ts
@@ -14,7 +14,11 @@ import { isReleaseChannel, type ReleaseChannels } from '../../../updater/types';
 import { Storage } from '../../../util/storage';
 import { OnionV4 } from '../../onions/onionv4';
 import { FileFromFileServerDetails } from './types';
-import { queryParamDeterministicEncryption, queryParamServerEd25519Pubkey } from '../../url';
+import {
+  queryParamDeterministicEncryption,
+  queryParamServerEd25519Pubkey,
+  stringifyFragmentParams,
+} from '../../url';
 import { FS, type FILE_SERVER_TARGET_TYPE } from './FileServerTarget';
 import { getFeatureFlag } from '../../../state/ducks/types/releasedFeaturesReduxTypes';
 import { stringify } from '../../../types/sqlSharedTypes';
@@ -33,12 +37,10 @@ function getShortTTLHeadersIfNeeded(): Record<string, string> {
 /**
  * Upload a file to the file server v2 using the onion v4 encoding
  * @param fileContent the data to send
- * @param deterministicEncryption whether the file is deterministically encrypted or not
  * @returns null or the complete URL to share this file
  */
 export const uploadFileToFsWithOnionV4 = async (
-  fileContent: ArrayBuffer,
-  deterministicEncryption: boolean
+  fileContent: ArrayBuffer
 ): Promise<{ fileUrl: string; expiresMs: number } | null> => {
   if (!fileContent || !fileContent.byteLength) {
     return null;
@@ -85,10 +87,8 @@ export const uploadFileToFsWithOnionV4 = async (
   if (target !== 'DEFAULT') {
     urlParams.set(queryParamServerEd25519Pubkey, FS.FILE_SERVERS[target].edPk);
   }
-  if (deterministicEncryption) {
-    urlParams.set(queryParamDeterministicEncryption, '');
-  }
-  const urlParamStr = urlParams.toString();
+  urlParams.set(queryParamDeterministicEncryption, '');
+  const urlParamStr = stringifyFragmentParams(urlParams);
   const fileUrl = `${FS.FILE_SERVERS[target].url}${FILE_ENDPOINT}/${fileId}${urlParamStr ? `#${urlParamStr}` : ''}`;
   const expiresMs = Math.floor(expires * 1000);
   return {

--- a/ts/session/url/index.ts
+++ b/ts/session/url/index.ts
@@ -17,6 +17,23 @@ function parseSearchParamsFromFragment(url: URL) {
 }
 
 /**
+ * Serialises fragment params, writing a valueless key bare rather than with a trailing '='.
+ *
+ * libSession splits the fragment on '&' and compares each part against 'd' with string equality, so
+ * the 'd=' that URLSearchParams.toString() produces is not recognised as the stream-encryption flag
+ * and iOS reads the file as legacy-encrypted. Every fragment we hand to another platform has to go
+ * through here, including the ones rebuilt while adding or stripping the profile key.
+ */
+export function stringifyFragmentParams(searchParams: URLSearchParams) {
+  const parts: Array<string> = [];
+  searchParams.forEach((value, key) => {
+    parts.push(value === '' ? key : `${key}=${encodeURIComponent(value)}`);
+  });
+
+  return parts.join('&');
+}
+
+/**
  * Returns the serverPk/deterministicEncryption/profileKey from the provided url fragment
  * Note:
  * - for the default file server, the serverPk is hardcoded.
@@ -56,7 +73,7 @@ export function addProfileKeyToUrl(url: URL, profileKeyHex: string) {
   }
   const urlCopy = new URL(url.toString());
   searchParams.set(queryParamEncryptionKey, profileKeyHex);
-  urlCopy.hash = searchParams.toString() ?? '';
+  urlCopy.hash = stringifyFragmentParams(searchParams);
 
   return urlCopy;
 }
@@ -70,7 +87,7 @@ function removeProfileKey(url: URL) {
   }
   const urlCopy = new URL(url.toString());
   searchParams.delete(queryParamEncryptionKey);
-  urlCopy.hash = searchParams.toString() ?? '';
+  urlCopy.hash = stringifyFragmentParams(searchParams);
 
   return urlCopy;
 }
@@ -85,7 +102,7 @@ function removeDefaultServerPk(url: URL) {
 
   const urlCopy = new URL(url.toString());
   searchParams.delete(queryParamEncryptionKey);
-  urlCopy.hash = searchParams.toString() ?? '';
+  urlCopy.hash = stringifyFragmentParams(searchParams);
 
   return urlCopy;
 }

--- a/ts/session/utils/Attachments.ts
+++ b/ts/session/utils/Attachments.ts
@@ -1,11 +1,8 @@
-import * as crypto from 'crypto';
 import { isEmpty, isString } from 'lodash';
 import Long from 'long';
 
 import { Attachment } from '../../types/Attachment';
 
-import { encryptAttachment } from '../../util/crypto/attachmentsEncrypter';
-import { addAttachmentPadding } from '../crypto/BufferPadding';
 import {
   AttachmentPointer,
   AttachmentPointerWithUrl,
@@ -15,15 +12,9 @@ import { uploadFileToFsWithOnionV4 } from '../apis/file_server_api/FileServerApi
 import { MultiEncryptWrapperActions } from '../../webworker/workers/browser/libsession_worker_interface';
 import { UserUtils } from '.';
 import { extractLastPathSegment } from '../url';
-import { getFeatureFlag } from '../../state/ducks/types/releasedFeaturesReduxTypes';
 
 type UploadParams = {
   attachment: Attachment;
-
-  /**
-   * Explicit padding is only needed for the legacy encryption, as libsession deterministic encryption already pads the data.
-   */
-  shouldPad?: boolean;
 };
 
 export interface RawPreview {
@@ -39,7 +30,7 @@ export interface RawQuoteAttachment {
 }
 
 async function uploadToFileServer(params: UploadParams): Promise<AttachmentPointerWithUrl> {
-  const { attachment, shouldPad = false } = params;
+  const { attachment } = params;
   if (typeof attachment !== 'object' || attachment == null) {
     throw new Error('Invalid attachment passed.');
   }
@@ -59,38 +50,18 @@ async function uploadToFileServer(params: UploadParams): Promise<AttachmentPoint
     height: attachment.height,
   };
 
-  let attachmentData: ArrayBuffer;
-
-  const deterministicEncryption = getFeatureFlag('useDeterministicEncryption');
-
-  if (deterministicEncryption) {
-    // this throws if the encryption fails
-    window?.log?.debug(
-      'Using deterministic encryption for attachment upload: ',
-      attachment.fileName
-    );
-    const seed = await UserUtils.getUserEd25519Seed();
-    const encryptedContent = await MultiEncryptWrapperActions.attachmentEncrypt({
-      allowLarge: false,
-      seed,
-      data: new Uint8Array(attachment.data),
-      domain: 'attachment',
-    });
-    pointer.key = encryptedContent.encryptionKey;
-    attachmentData = encryptedContent.encryptedData;
-  } else {
-    // this is the legacy attachment encryption
-    pointer.key = new Uint8Array(crypto.randomBytes(64));
-    const iv = new Uint8Array(crypto.randomBytes(16));
-
-    const dataToEncrypt = !shouldPad ? attachment.data : addAttachmentPadding(attachment.data);
-    const data = await encryptAttachment(dataToEncrypt, pointer.key.buffer, iv.buffer);
-    pointer.digest = new Uint8Array(data.digest);
-    attachmentData = data.ciphertext;
-  }
+  // this throws if the encryption fails
+  const seed = await UserUtils.getUserEd25519Seed();
+  const encryptedContent = await MultiEncryptWrapperActions.attachmentEncrypt({
+    allowLarge: false,
+    seed,
+    data: new Uint8Array(attachment.data),
+    domain: 'attachment',
+  });
+  pointer.key = encryptedContent.encryptionKey;
 
   // use file server v2
-  const uploadToV2Result = await uploadFileToFsWithOnionV4(attachmentData, deterministicEncryption);
+  const uploadToV2Result = await uploadFileToFsWithOnionV4(encryptedContent.encryptedData);
   if (uploadToV2Result) {
     const pointerWithUrl: AttachmentPointerWithUrl = {
       ...pointer,
@@ -105,12 +76,7 @@ async function uploadToFileServer(params: UploadParams): Promise<AttachmentPoint
 export async function uploadAttachmentsToFileServer(
   attachments: Array<Attachment>
 ): Promise<Array<AttachmentPointerWithUrl>> {
-  const promises = (attachments || []).map(async attachment =>
-    uploadToFileServer({
-      attachment,
-      shouldPad: true,
-    })
-  );
+  const promises = (attachments || []).map(async attachment => uploadToFileServer({ attachment }));
 
   return Promise.all(promises);
 }

--- a/ts/state/ducks/metaGroups.ts
+++ b/ts/state/ducks/metaGroups.ts
@@ -30,6 +30,7 @@ import { ed25519Str } from '../../session/utils/String';
 import { stringify, toFixedUint8ArrayOfLength } from '../../types/sqlSharedTypes';
 import {
   MetaGroupWrapperActions,
+  MultiEncryptWrapperActions,
   UserGroupsWrapperActions,
 } from '../../webworker/workers/browser/libsession_worker_interface';
 import { StateType } from '../reducer';
@@ -48,7 +49,6 @@ import { tr } from '../../localization/localeTools';
 import { type GroupMemberGetRedux, makeGroupMemberGetRedux } from './types/groupReduxTypes';
 import { uploadFileToFsWithOnionV4 } from '../../session/apis/file_server_api/FileServerApi';
 import { urlToBlob } from '../../types/attachments/VisualAttachment';
-import { encryptProfile } from '../../util/crypto/profileEncrypter';
 import { processNewAttachment } from '../../types/MessageAttachment';
 import type { StoreGroupMessageSubRequest } from '../../session/apis/snode_api/SnodeRequestTypes';
 import { sectionActions } from './section';
@@ -968,18 +968,16 @@ async function handleAvatarChangeFromUI({
     throw new Error('Failed to process avatar');
   }
 
-  // generate a new profile key for this group
-  const profileKey = (await getSodiumRenderer()).randombytes_buf(32);
-  // encrypt the avatar data with the profile key
-  const encryptedData = await encryptProfile(processed.mainAvatarDetails.outputBuffer, profileKey);
+  // the key is derived from the uploader's seed and the content, so it is not ours to generate
+  const encryptedContent = await MultiEncryptWrapperActions.attachmentEncrypt({
+    allowLarge: false,
+    seed: await UserUtils.getUserEd25519Seed(),
+    data: new Uint8Array(processed.mainAvatarDetails.outputBuffer),
+    domain: 'profilePic',
+  });
+  const profileKey = encryptedContent.encryptionKey;
 
-  // Note: currently deterministic encryption is not supported for group's avatars
-  const deterministicEncryption = false;
-
-  const uploadedFileDetails = await uploadFileToFsWithOnionV4(
-    encryptedData,
-    deterministicEncryption
-  );
+  const uploadedFileDetails = await uploadFileToFsWithOnionV4(encryptedContent.encryptedData);
   if (!uploadedFileDetails || !uploadedFileDetails.fileUrl) {
     window?.log?.warn('File upload for groupv2 to file server failed');
     throw new Error('File upload for groupv2 to file server failed');

--- a/ts/state/ducks/types/defaultFeatureFlags.ts
+++ b/ts/state/ducks/types/defaultFeatureFlags.ts
@@ -29,7 +29,6 @@ export const defaultBooleanFeatureFlags = {
   ...defaultProBooleanFeatureFlags,
   replaceLocalizedStringsWithKeys: false,
   useClosedGroupV2QAButtons: !isEmpty(process.env.GROUPV2_QA_BUTTONS),
-  useDeterministicEncryption: !isEmpty(process.env.SESSION_ATTACH_DETERMINISTIC_ENCRYPTION),
   disableOnionRequests: false,
   disableImageProcessor: !isEmpty(process.env.SESSION_DISABLE_IMAGE_PROCESSOR),
   disableLocalAttachmentEncryption: !isEmpty(

--- a/ts/state/ducks/types/releasedFeaturesReduxTypes.ts
+++ b/ts/state/ducks/types/releasedFeaturesReduxTypes.ts
@@ -11,7 +11,6 @@ type SessionBaseBooleanFeatureFlags = {
   disableOnionRequests: boolean;
   disableImageProcessor: boolean;
   disableLocalAttachmentEncryption: boolean;
-  useDeterministicEncryption: boolean;
   useTestNet: boolean;
   useTestProBackend: boolean;
   useClosedGroupV2QAButtons: boolean;

--- a/ts/test/session/unit/crypto/LegacyAttachmentDecrypt_test.ts
+++ b/ts/test/session/unit/crypto/LegacyAttachmentDecrypt_test.ts
@@ -1,0 +1,100 @@
+import { expect } from 'chai';
+
+import { decryptAttachment } from '../../../../util/crypto/attachmentsEncrypter';
+import { getUnpaddedAttachment } from '../../../../session/crypto/BufferPadding';
+
+const hexToBuffer = (hex: string) =>
+  Uint8Array.from(hex.match(/.{2}/g)!.map(b => parseInt(b, 16))).buffer;
+
+/**
+ * Content encrypted the legacy way stays on the file server indefinitely, so this format has to keep
+ * decrypting long after nothing writes it. The vectors were produced externally rather than by a round
+ * trip, so they still describe the wire format now that the encrypting half is gone.
+ */
+describe('legacy attachment decryption', () => {
+  /** 32-byte AES key ‖ 32-byte HMAC key */
+  const key = hexToBuffer('11'.repeat(32) + '22'.repeat(32));
+  /** IV ‖ AES-256-CBC(PKCS7) ‖ HMAC-SHA256(IV ‖ ciphertext), over a 541-byte zero-padded plaintext */
+  const ciphertext = hexToBuffer(
+    '333333333333333333333333333333330ee1ed4f89c70232caed52b8765365ff' +
+      'e904557d3c61038c97bdb5bee3189fc6f53aac97422dc92d8693c0a72b3aa362' +
+      '01d1bd3a6dd6164a09154ae87aa95888066a80449e211fc64a69c04b0f9ddce0' +
+      '2f144fbea3a731ded616d0436b2fd6ec908f89ebf85d15bad69bdaa66827f0b3' +
+      '484b7425d383f7136e3c911881731c043863f49f5ada6f85f8fa456efd08a2db' +
+      '8c7b510cb04a225035db36e21660f5274939dc09639ffd30cc36ac9fc8776761' +
+      '5a93ab017c028a8bdf2dd7ef48c245b846c7cd4942866d77b056a2a59924d426' +
+      '4d1e1d23b8c5ed598f23ada8a905c5579383581203db2c5f60c434551992162f' +
+      'b9f36105a91515c5472105c64f3c111a16c745bbca3e810460319b3124c430ca' +
+      '3d87f4fd9400502cd62d7e782ee5eebf4656f4acd84a9ae964e0f40804dea71d' +
+      '675eb620a2659094b52a3bdf9b36c8ac66ffcbbb129749e5394eabf4b8708249' +
+      '12cf7966797621b0ca073baf66d500d5589649b89d5298855471178c724907d2' +
+      '5e5812ea7cbf4d9fdf19319eeba03b491cf2857a388ef861ea11e83876d43751' +
+      'fbbc80aaf205e5d937e9dcc046f9aaf3ee56b6a627a5a474e1ac5cde5a12e52a' +
+      'fd23fcdadeb591aa06f374bd84edf8a5d61151df711ed8fbded86f0b23c28ef4' +
+      '414b99d422c4bf95f30f1f18b274c42d9e61a48f63a754d100c7bf64fc88f469' +
+      '407560f167919c9d5f10d5a343dff87e753ab281e57073fce95481d2b8c4da0e' +
+      '5f0d13c67d802c1733c232e3d520f38a4f9d5a43c6ce60843288322b883d7d24' +
+      '796efd75c676cb02a5b6148ea737534d'
+  );
+  const digest = hexToBuffer('ee65e6417b452d017a4d8e2ce984883c1f7dc8d920d7551f0e2d2af7606bd9a9');
+  const plaintext = 'legacy attachment payload';
+  const paddedSize = 541;
+
+  it('decrypts to the sender-padded plaintext', async () => {
+    const decrypted = await decryptAttachment(ciphertext, key, digest);
+
+    expect(decrypted.byteLength).to.equal(paddedSize);
+    expect(Buffer.from(decrypted).subarray(0, plaintext.length).toString('utf8')).to.equal(
+      plaintext
+    );
+  });
+
+  it('rejects a tampered ciphertext', async () => {
+    const tampered = ciphertext.slice(0);
+    new Uint8Array(tampered)[20] += 1;
+
+    let threw = false;
+    try {
+      await decryptAttachment(tampered, key, digest);
+    } catch {
+      threw = true;
+    }
+    expect(threw).to.equal(true);
+  });
+
+  it('rejects a mismatched digest', async () => {
+    let threw = false;
+    try {
+      await decryptAttachment(ciphertext, key, hexToBuffer('00'.repeat(32)));
+    } catch {
+      threw = true;
+    }
+    expect(threw).to.equal(true);
+  });
+
+  describe('the size bookkeeping that follows decryption', () => {
+    /**
+     * The receiver trims to the size the sender put on the pointer. Legacy senders pad, so there is
+     * something to trim; libSession strips its own padding, so a stream-decrypted attachment already
+     * matches and must be left alone.
+     */
+    it('trims a legacy attachment back to the advertised size', async () => {
+      const decrypted = await decryptAttachment(ciphertext, key, digest);
+      const trimmed = getUnpaddedAttachment(decrypted, plaintext.length);
+
+      expect(trimmed).to.not.equal(null);
+      expect(trimmed!.byteLength).to.equal(plaintext.length);
+      expect(Buffer.from(trimmed!).toString('utf8')).to.equal(plaintext);
+    });
+
+    it('refuses to trim when the data is already the advertised size', () => {
+      const exact = new ArrayBuffer(plaintext.length);
+      expect(getUnpaddedAttachment(exact, plaintext.length)).to.equal(null);
+    });
+
+    it('refuses to trim when the data is shorter than advertised', () => {
+      const short = new ArrayBuffer(plaintext.length - 1);
+      expect(getUnpaddedAttachment(short, plaintext.length)).to.equal(null);
+    });
+  });
+});

--- a/ts/test/session/unit/url/FileServerUrlFragment_test.ts
+++ b/ts/test/session/unit/url/FileServerUrlFragment_test.ts
@@ -1,0 +1,121 @@
+import { expect } from 'chai';
+
+import {
+  addProfileKeyToUrl,
+  extractDetailsFromUrlFragment,
+  queryParamDeterministicEncryption,
+  queryParamServerEd25519Pubkey,
+  stringifyFragmentParams,
+} from '../../../../session/url';
+
+/**
+ * The fragment is the only thing telling a reader which encryption a file used, and libSession
+ * (so iOS) compares it against 'd' with string equality. URLSearchParams.toString() writes 'd=',
+ * which iOS reads as legacy, so nothing that leaves this client may be serialised with it.
+ */
+describe('file server url fragment', () => {
+  const edPk = '0123456789abcdef0123456789abcdef00000000000000000000000000000000';
+  const profileKey = 'aa'.repeat(32);
+
+  /** Mirrors how uploadFileToFsWithOnionV4 builds the fragment. */
+  function buildFragment({ pubkey }: { pubkey?: string } = {}) {
+    const urlParams = new URLSearchParams();
+    if (pubkey) {
+      urlParams.set(queryParamServerEd25519Pubkey, pubkey);
+    }
+    urlParams.set(queryParamDeterministicEncryption, '');
+    return stringifyFragmentParams(urlParams);
+  }
+
+  /** libSession: `if (fragment == FRAGMENT_STREAM_ENCRYPTION)` over `split(fragment, "&")`. */
+  function libSessionWantsStreamDecryption(url: string) {
+    return new URL(url).hash
+      .slice(1)
+      .split('&')
+      .some(fragment => fragment === 'd');
+  }
+
+  describe('stringifyFragmentParams', () => {
+    it('writes a valueless key bare', () => {
+      expect(buildFragment()).to.equal('d');
+    });
+
+    it('writes a valueless key bare alongside a valued one', () => {
+      expect(buildFragment({ pubkey: edPk })).to.equal(`p=${edPk}&d`);
+    });
+
+    it('writes nothing when there are no params', () => {
+      expect(stringifyFragmentParams(new URLSearchParams())).to.equal('');
+    });
+
+    it('is what URLSearchParams would not have produced', () => {
+      const urlParams = new URLSearchParams();
+      urlParams.set(queryParamDeterministicEncryption, '');
+      expect(urlParams.toString()).to.equal('d=');
+      expect(stringifyFragmentParams(urlParams)).to.equal('d');
+    });
+  });
+
+  describe('what libSession and iOS accept', () => {
+    it('recognises the fragment we write', () => {
+      const fragment = buildFragment();
+      expect(
+        libSessionWantsStreamDecryption(`http://filev2.getsession.org/file/abc123#${fragment}`)
+      ).to.equal(true);
+    });
+
+    it('recognises it beside a server pubkey', () => {
+      const fragment = buildFragment({ pubkey: edPk });
+      expect(
+        libSessionWantsStreamDecryption(`http://example.com/file/abc123#${fragment}`)
+      ).to.equal(true);
+    });
+
+    it('still recognises it after a profile key round trip', () => {
+      /// OutgoingUserProfile rebuilds the fragment to attach and strip the profile key, and that
+      /// rebuild is on the path that hands the avatar pointer to the other platforms.
+      const uploaded = new URL(`http://filev2.getsession.org/file/abc123#${buildFragment()}`);
+      const withKey = addProfileKeyToUrl(uploaded, profileKey);
+
+      expect(libSessionWantsStreamDecryption(withKey.toString())).to.equal(true);
+
+      const { urlWithoutProfileKey, profileKey: readBack } = extractDetailsFromUrlFragment(withKey);
+      expect(readBack).to.equal(profileKey);
+      expect(libSessionWantsStreamDecryption(urlWithoutProfileKey)).to.equal(true);
+    });
+  });
+
+  describe('what we read', () => {
+    it('accepts the bare "d" we and the other platforms write', () => {
+      expect(
+        extractDetailsFromUrlFragment(new URL('http://filev2.getsession.org/file/abc123#d'))
+          .deterministicEncryption
+      ).to.equal(true);
+    });
+
+    it('still accepts the legacy "d=" spelling we used to write', () => {
+      expect(
+        extractDetailsFromUrlFragment(new URL('http://filev2.getsession.org/file/abc123#d='))
+          .deterministicEncryption
+      ).to.equal(true);
+    });
+
+    it('accepts "d" beside a server pubkey in either order', () => {
+      expect(
+        extractDetailsFromUrlFragment(new URL(`http://example.com/file/abc123#d&p=${edPk}`))
+          .deterministicEncryption
+      ).to.equal(true);
+      expect(
+        extractDetailsFromUrlFragment(new URL(`http://example.com/file/abc123#p=${edPk}&d`))
+          .deterministicEncryption
+      ).to.equal(true);
+    });
+
+    it('reads no flag when the fragment is absent', () => {
+      expect(
+        extractDetailsFromUrlFragment(new URL('http://filev2.getsession.org/file/abc123'))
+          .deterministicEncryption
+      ).to.equal(false);
+    });
+  });
+});

--- a/ts/util/crypto/attachmentsEncrypter.ts
+++ b/ts/util/crypto/attachmentsEncrypter.ts
@@ -8,22 +8,12 @@ async function sign(key: any, data: any) {
     });
 }
 
-async function encrypt(key: any, data: any, iv: any) {
-  return crypto.subtle
-    .importKey('raw', key, { name: 'AES-CBC' }, false, ['encrypt'])
-    .then(async secondKey => {
-      return crypto.subtle.encrypt({ name: 'AES-CBC', iv: new Uint8Array(iv) }, secondKey, data);
-    });
-}
 async function decrypt(key: any, data: any, iv: any) {
   return crypto.subtle
     .importKey('raw', key, { name: 'AES-CBC' }, false, ['decrypt'])
     .then(async secondKey => {
       return crypto.subtle.decrypt({ name: 'AES-CBC', iv: new Uint8Array(iv) }, secondKey, data);
     });
-}
-async function calculateMAC(key: any, data: any) {
-  return sign(key, data);
 }
 async function verifyMAC(data: any, key: any, mac: any, length: any) {
   return sign(key, data).then(calculatedMac => {
@@ -57,9 +47,6 @@ async function verifyDigest(data: ArrayBuffer, theirDigest: ArrayBuffer) {
     }
   });
 }
-async function calculateDigest(data: ArrayBuffer) {
-  return crypto.subtle.digest({ name: 'SHA-256' }, data);
-}
 
 export async function decryptAttachment(
   encryptedBin: ArrayBuffer,
@@ -89,41 +76,4 @@ export async function decryptAttachment(
       return verifyDigest(encryptedBin, theirDigest);
     })
     .then(() => decrypt(aesKey, ciphertext, iv));
-}
-
-export async function encryptAttachment(
-  plaintext: ArrayBuffer,
-  keys: ArrayBuffer,
-  iv: ArrayBuffer
-) {
-  if (!(plaintext instanceof ArrayBuffer) && !ArrayBuffer.isView(plaintext)) {
-    throw new TypeError(
-      `\`plaintext\` must be an \`ArrayBuffer\` or \`ArrayBufferView\`; got: ${typeof plaintext}`
-    );
-  }
-
-  if (keys.byteLength !== 64) {
-    throw new Error(`Got invalid length attachment keys: ${keys.byteLength}`);
-  }
-  if (iv.byteLength !== 16) {
-    throw new Error(`Got invalid length attachment iv: ${iv.byteLength}`);
-  }
-  const aesKey = keys.slice(0, 32);
-  const macKey = keys.slice(32, 64);
-
-  return encrypt(aesKey, plaintext, iv).then(async (ciphertext: any) => {
-    const ivAndCiphertext = new Uint8Array(16 + ciphertext.byteLength);
-    ivAndCiphertext.set(new Uint8Array(iv));
-    ivAndCiphertext.set(new Uint8Array(ciphertext), 16);
-
-    return calculateMAC(macKey, ivAndCiphertext.buffer).then(async (mac: any) => {
-      const encryptedBin = new Uint8Array(16 + ciphertext.byteLength + 32);
-      encryptedBin.set(ivAndCiphertext);
-      encryptedBin.set(new Uint8Array(mac), 16 + ciphertext.byteLength);
-      return calculateDigest(encryptedBin.buffer).then(digest => ({
-        ciphertext: encryptedBin.buffer,
-        digest,
-      }));
-    });
-  });
 }

--- a/ts/util/crypto/profileEncrypter.ts
+++ b/ts/util/crypto/profileEncrypter.ts
@@ -1,5 +1,4 @@
 /* eslint-disable more/no-then */
-import { getSodiumRenderer } from '../../session/crypto';
 
 const PROFILE_IV_LENGTH = 12; // bytes
 const PROFILE_KEY_LENGTH = 32; // bytes
@@ -36,32 +35,6 @@ export async function decryptProfile(data: ArrayBuffer, key: ArrayBuffer): Promi
             throw error;
           }
           throw error;
-        })
-    );
-}
-
-async function getRandomBytesFromLength(n: number) {
-  return (await getSodiumRenderer()).randombytes_buf(n);
-}
-
-export async function encryptProfile(data: ArrayBuffer, key: ArrayBuffer): Promise<ArrayBuffer> {
-  const iv = await getRandomBytesFromLength(PROFILE_IV_LENGTH);
-  if (key.byteLength !== PROFILE_KEY_LENGTH) {
-    throw new Error('Got invalid length profile key');
-  }
-  if (iv.byteLength !== PROFILE_IV_LENGTH) {
-    throw new Error('Got invalid length profile iv');
-  }
-  return crypto.subtle
-    .importKey('raw', key, { name: 'AES-GCM' }, false, ['encrypt'])
-    .then(keyForEncryption =>
-      crypto.subtle
-        .encrypt({ name: 'AES-GCM', iv, tagLength: PROFILE_TAG_LENGTH }, keyForEncryption, data)
-        .then(ciphertext => {
-          const ivAndCiphertext = new Uint8Array(PROFILE_IV_LENGTH + ciphertext.byteLength);
-          ivAndCiphertext.set(new Uint8Array(iv));
-          ivAndCiphertext.set(new Uint8Array(ciphertext), PROFILE_IV_LENGTH);
-          return ivAndCiphertext.buffer;
         })
     );
 }


### PR DESCRIPTION
Attachments, our own avatar and group avatars now always use libSession's stream encryption.

### The bug worth reading first

We built the url fragment with `URLSearchParams`, which serialises a valueless key as **`d=`**. libSession compares the fragment against `d` with string equality, so **iOS read every stream-encrypted upload we produced as legacy**: attachments were stored as ciphertext and the download reported success, and avatars failed to decrypt. Android tolerates both spellings and has a regression test for it, so nothing on Android or Desktop ever complained.

Fixing only the uploader would not have been enough. `addProfileKeyToUrl` / `removeProfileKey` rebuild the fragment through the same serialiser, and that rebuild is on the path that hands avatar pointers to the other platforms — a correct `#d` written at upload was normalised straight back to `#d=`. All four sites now go through `stringifyFragmentParams`, which writes a valueless key bare. Reading is unchanged, so the `d=` we used to write is still accepted.

### The rest

- `useDeterministicEncryption` and the legacy branches behind it are gone. Group avatars were separately hardcoded to legacy (`const deterministicEncryption = false`) and now follow the same path.
- The legacy encryptors are deleted. **Legacy decryption stays** — content encrypted the old way sits on the file server indefinitely and there is no migration that removes it.
- `uploadFileToFsWithOnionV4` no longer takes a `deterministicEncryption` flag, and `uploadToFileServer` no longer pads — libSession pads its own input.

### Testing

`tsc` clean; the two new spec files pass under the repo's own mocha and harness (17 cases), rebased on `dev`.

- `LegacyAttachmentDecrypt_test` covers legacy decryption against externally generated vectors plus the size bookkeeping that follows it — legacy content needs trimming to the advertised size, stream-decrypted content already matches and must be left alone.
- `FileServerUrlFragment_test` pins both directions of the fragment, including that the flag survives a profile-key round trip, and asserts against libSession's own matching rule.

Cross-client attachment sending was verified 6/6 by the Appium suite.

Still uncovered: display pictures cross-client, group display pictures, and old content still opening after the change.
