### PR TITLE
fix(pro): drop the pro proof `version` field

### DIFF
--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -369,7 +369,11 @@ message GroupUpdateDeleteMemberContentMessage {
 }
 
 message ProProof {
-  optional uint32 version           = 1;
+  // Numbering starts at 2: field 1 was `version`, dropped because a proof's format is its type
+  // rather than a value it carries -- the format is bound into the signature by the domain prefix
+  // it picks, and a future format arrives as its own message/field.
+  reserved 1;
+  reserved "version";
   optional bytes  revocationTag      = 2;
   optional bytes  rotatingPublicKey = 3;
   optional uint64 expiryUnixTs      = 4; // Epoch timestamp in whole seconds (what the Session Pro backend signs over)

--- a/ts/components/dialog/debug/FeatureFlags.tsx
+++ b/ts/components/dialog/debug/FeatureFlags.tsx
@@ -730,17 +730,12 @@ function ProConfigForm({
   const [genHashInput, setGenHashInput] = useState<string>(
     proConfig?.proProof.revocationTagB64 ?? ''
   );
-  const [versionInput, setVersionInput] = useState<string>(
-    proConfig?.proProof.version.toString() ?? ''
-  );
-
   const removeConfig = useCallback(async () => {
     await UserConfigWrapperActions.removeProConfig();
     setRotatingPrivKeyInput('');
     setExpiryInput('');
     setSigInput('');
     setGenHashInput('');
-    setVersionInput('');
     await forceUpdate();
   }, [forceUpdate]);
 
@@ -762,7 +757,6 @@ function ProConfigForm({
       <DebugInput label="Expiry Timestamp (ms)" value={expiryInput} setValue={setExpiryInput} />
       <DebugInput label="Signature" value={sigInput} setValue={setSigInput} />
       <DebugInput label="Gen Hash" value={genHashInput} setValue={setGenHashInput} />
-      <DebugInput label="Version" value={versionInput} setValue={setVersionInput} />
     </div>
   );
 }

--- a/ts/test/session/unit/libsession_wrapper/libsession_wrapper_user_profile_test.ts
+++ b/ts/test/session/unit/libsession_wrapper/libsession_wrapper_user_profile_test.ts
@@ -79,9 +79,6 @@ describe('libsession_user_profile', () => {
           // sub-second value would come back floored. Use a second-aligned one to round-trip as-is.
           expiryMs: Math.floor(Date.now() / 1000) * 1000 + 1000,
           revocationTagB64: to_base64(ed25519Seed, base64_variants.ORIGINAL),
-          // Deliberately not v0: the version is required on the way in but is not persisted, so
-          // this must come back as 0. See the expectation below.
-          version: 132,
           signatureHex: to_hex(randombytes_buf(64)),
         },
       };
@@ -100,10 +97,9 @@ describe('libsession_user_profile', () => {
           rotatingPubkeyHex: rotatingPubKeyHex,
           expiryMs: proConfig.proProof.expiryMs,
           revocationTagB64: proConfig.proProof.revocationTagB64,
-          // The stored credential is one opaque bt-encoded value carrying only `e`, `g`, `r` and `s`,
-          // so no version is written and load forces v0 (= 0). A version can't describe itself across
-          // a per-key merge, so a future format takes a new config key instead of an in-dict marker.
-          version: 0,
+          // The stored credential is one opaque bt-encoded value carrying only `e`, `g`, `r` and `s`
+          // -- there is no version to round-trip. A version can't describe itself across a per-key
+          // merge, so a future format takes a new config key instead of an in-dict marker.
           signatureHex: proConfig.proProof.signatureHex,
         },
       };

--- a/ts/types/message/OutgoingProMessageDetails.ts
+++ b/ts/types/message/OutgoingProMessageDetails.ts
@@ -58,8 +58,7 @@ export class OutgoingProMessageDetails {
       }
       return null;
     }
-    const { expiryMs, revocationTagB64, rotatingPubkeyHex, signatureHex, version } =
-      this.proConfig.proProof;
+    const { expiryMs, revocationTagB64, rotatingPubkeyHex, signatureHex } = this.proConfig.proProof;
 
     return new SignalService.ProMessage({
       profileBitset: bigIntToLong(this.proProfileBitset),
@@ -70,7 +69,6 @@ export class OutgoingProMessageDetails {
         expiryUnixTs: Math.floor(expiryMs / 1000),
         revocationTag: from_base64(revocationTagB64, base64_variants.ORIGINAL),
         rotatingPublicKey: from_hex(rotatingPubkeyHex),
-        version,
         sig: from_hex(signatureHex),
       },
     });


### PR DESCRIPTION
Propagates an already-merged libsession-util change: `ProProof::version` is gone
(libsession-util PR #130, commit `f0b9ab23` "fix: pro proof has no version field
at all"). `session-pro-backend` has dropped it too (PR #21).

## Why the field went away

A proof's format is bound into the signature by the 16-byte domain prefix it
selects (`ProProof_v0_____`), so a separate version field was redundant — it was
never part of the signed payload. The format is a property of the proof's *type*,
not a value the proof carries, and a future format arrives as its own
message/field rather than as a number inside this one.

## What changed

| File | Change |
|---|---|
| `protos/SignalService.proto` | Retire field 1 in `ProProof` rather than delete the line. Tags 2–5 are untouched, so the wire format of every surviving field is unchanged. |
| `ts/types/message/OutgoingProMessageDetails.ts` | Stop reading `version` off the ProConfig proof when building an outgoing `ProMessage`. |
| `ts/components/dialog/debug/FeatureFlags.tsx` | Drop the read-only "Version" row from the debug Pro Config form (it displayed `proProof.version` and was wired to nothing else). |
| `ts/test/session/unit/libsession_wrapper/libsession_wrapper_user_profile_test.ts` | Drop the `version: 132` input and the `version: 0` round-trip expectation. |

**Tag 1 must never be reused.** Upstream retired it with the explanatory comment
alone; I kept that comment *and* added `reserved 1; reserved "version";`, which is
this file's own established convention (see `Content`, `DataMessage`,
`AttachmentPointer`, `Quote`) and makes the intent unforgeable rather than
advisory. Happy to drop the two `reserved` lines if you'd rather stay byte-for-byte
with upstream.

The generated protobuf artifacts (`ts/protobuf/compiled.js` / `compiled.d.ts`) are
gitignored here, so there is nothing to commit for them — they are produced by
`pnpm build:protobuf`, which I ran locally to typecheck against the new shape. No
generated file was hand-edited.

## `ProStatus` — no change needed

libsession's companion commit adds a `ProStatus::Invalid` case so an unusable proof
degrades to "deliver the message without Pro" instead of discarding the whole
message. Desktop already behaves that way and needs no edit: it never switches
exhaustively over the proof status, it only ever tests
`proStatus === 'ValidOrExpired'` (`ts/receiver/types.ts`, in the constructor and in
`isProProofValidOrExpired`). Anything else already falls through to
`validPro = null`, and the message is delivered as non-Pro.

Worth flagging for the wrapper repo rather than fixing here: `pro.d.ts` declares
`type ProStatus = 'ValidOrExpired' | 'Invalid'`, but the C++ in
`include/pro/types.hpp` actually emits `'ValidOrExpired'`, `'InvalidProBackendSig'`
or `'InvalidUserSig'` — `'Invalid'` is never produced, and two of the three emitted
strings are not in the declared union. Its final `else` also means the new
`ProStatus::Invalid` will arrive mislabelled as `'InvalidUserSig'`. None of that
changes Desktop's behaviour (every one of those strings correctly fails the
`=== 'ValidOrExpired'` test), but the type is a lie and the mislabelling will
mislead anyone reading a log.

## ⚠️ This cannot go green yet

Desktop consumes `libsession_util_nodejs` as a published release **tarball**,
currently **v0.7.0, which predates this removal**. That build still declares
`version: number` on `ProProof`, so CI will fail until libsession releases and the
nodejs wrapper publishes a build containing the removal, and the dependency here is
bumped. Expected — the maintainer decides when to merge.

## Verification actually run

Against the published-shape binding, on `origin/dev` @ `31bf04556`:

- **`tsc --noEmit` baseline on unmodified `origin/dev`: 0 errors.**
- **`tsc --noEmit` with this change: exactly 2 errors**, both in the wrapper test
  and both attributable solely to the stale binding:
  ```
  libsession_wrapper_user_profile_test.ts(77,9): error TS2741: Property 'version' is missing in type
    '{ expiryMs: number; revocationTagB64: string; signatureHex: string; }'
    but required in type 'Omit<ProProof, "rotatingPubkeyHex">'.
  libsession_wrapper_user_profile_test.ts(96,9): error TS2322: ... Property 'version' is missing ...
    but required in type '{ version: number; rotatingPubkeyHex: string; expiryMs: number; signatureHex: string; }'.
  ```
  No other file errors — notably `OutgoingProMessageDetails.ts` is clean, since
  dropping a property from a destructure and an object literal is valid against the
  old type too.
- **eslint on all four changed files: clean (exit 0).** Prettier wanted one
  reformat (the destructure now fits on one line); applied.
- **`mocha` unit suite: 919 passing, 1 failing.** The single failure is the same
  binding staleness, this time at runtime — the v0.7.0 native addon rejects the
  now-absent field:
  ```
  Error: Wrong arguments: expected number: pro_config_from_object.version
  ```

So: **not a clean typecheck and not a clean test run**, and deliberately so — every
failure is the v0.7.0 binding still requiring `version`, and all of them clear when
the dependency is bumped.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
