### PR TITLE
feat(qa): give the four Pro stats cells test ids

### DIFF
--- a/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
+++ b/ts/components/dialog/user-settings/pages/user-pro/ProSettingsPage.tsx
@@ -449,7 +449,7 @@ function ProStats() {
                 iconSize="huge"
                 unicode={LUCIDE_ICONS_UNICODE.MESSAGE_SQUARE}
               />
-              <StatsLabel>
+              <StatsLabel data-testid="pro-stats-longer-messages">
                 {tr('proLongerMessagesSent', {
                   count: proLongerMessagesSent,
                   total: formatProStats(proLongerMessagesSent),
@@ -462,7 +462,7 @@ function ProStats() {
                 iconSize="huge"
                 unicode={LUCIDE_ICONS_UNICODE.PIN}
               />
-              <StatsLabel>
+              <StatsLabel data-testid="pro-stats-pinned-conversations">
                 {tr('proPinnedConversations', {
                   count: proPinnedConversations,
                   total: formatProStats(proPinnedConversations),
@@ -477,7 +477,7 @@ function ProStats() {
                 iconSize="huge"
                 unicode={LUCIDE_ICONS_UNICODE.RECTANGLE_ELLIPSES}
               />
-              <StatsLabel>
+              <StatsLabel data-testid="pro-stats-badges-sent">
                 {tr('proBadgesSent', {
                   count: proBadgesSent,
                   total: formatProStats(proBadgesSent),
@@ -490,7 +490,7 @@ function ProStats() {
                 iconSize="huge"
                 unicode={LUCIDE_ICONS_UNICODE.USERS_ROUND}
               />
-              <StatsLabel disabled={!proGroupsAvailable}>
+              <StatsLabel disabled={!proGroupsAvailable} data-testid="pro-stats-groups-upgraded">
                 {tr('proGroupsUpgraded', {
                   count: proGroupsUpgraded,
                   total: formatProStats(proGroupsUpgraded),

--- a/ts/react.d.ts
+++ b/ts/react.d.ts
@@ -329,6 +329,15 @@ declare module 'react' {
     // renders the same slot; a locator reads the text through the id to tell the states apart.
     | 'pro-settings-description'
 
+    // The four "Your Pro Stats" cells. Named the same as Android and iOS
+    // (`content-descriptions` / `SessionProUI.AccessibilityIdentifier`) so one harness
+    // locator serves every client. Desktop puts the id on the label holding the count
+    // itself rather than on a container, because that is where the text is.
+    | 'pro-stats-longer-messages'
+    | 'pro-stats-pinned-conversations'
+    | 'pro-stats-badges-sent'
+    | 'pro-stats-groups-upgraded'
+
     // timer options
     | DisappearTimeOptionDataTestId
     | DisappearOptionDataTestId


### PR DESCRIPTION
Adds the four `pro-stats-*` test ids to the "Your Pro Stats" matrix.

### The gap

Desktop had only `pro-settings-stats-header` — the header, not the numbers. Nothing under it was addressable, so a Pro stats spec could not be written for Desktop at all. Android and iOS both already declare all four.

### The change

Four entries on `SessionDataTestId`, applied to the `StatsLabel` of each cell:

| cell | id |
|---|---|
| `proLongerMessagesSent` | `pro-stats-longer-messages` |
| `proPinnedConversations` | `pro-stats-pinned-conversations` |
| `proBadgesSent` | `pro-stats-badges-sent` |
| `proGroupsUpgraded` | `pro-stats-groups-upgraded` |

**Same names as Android and iOS** (`content-descriptions` / `SessionProUI.AccessibilityIdentifier`), so one harness locator serves all three. The id goes on the label holding the count rather than on a container — Desktop has no container/text split to work around, unlike Android where the id sits on a `Row` that carries no text.

### Verification

`tsc --noEmit` — **12 errors before my change, 12 after, none introduced.** The pre-existing ones are unrelated to this and include `Property 'version' does not exist on type 'ProProof'` in `FeatureFlags.tsx`, which is fallout from the installed binding moving to 0.7.2 (the Pro proof dropped its `version` field). That one needs fixing separately.

`prettier --check` clean on both files. Not exercised in a running app — it is a test-id-only change with no behaviour.

### Two things found while doing this, not fixed here

- **`groups-upgraded` has no data source on any client.** Android hard-codes 0, iOS's counter has no write site, Desktop assigns `0`. Tagged for symmetry; not something a test should assert yet.
- **The stats tooltip says "usage on this device"**, but `pinned-conversations` is libSession-backed and therefore synced. The tooltip is wrong about that one cell.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>