### PR TITLE
Count the Pro stats on a confirmed send, and on messages sent from a linked device

### DIFF
--- a/ts/models/message.ts
+++ b/ts/models/message.ts
@@ -1593,26 +1593,49 @@ export class MessageModel extends Model<MessageAttributes> {
         proProfileBitset: longOrNumberToBigInt(proDetails.profileBitset),
       });
       await this.commit();
-      const proFeaturesUsed = this.getProFeaturesUsed();
-      await Promise.all(
-        proFeaturesUsed.map(async proFeature => {
-          switch (proFeature) {
-            case ProMessageFeature.PRO_INCREASED_MESSAGE_LENGTH:
-              await Storage.increment(SettingsKey.proLongerMessagesSent);
-              break;
-            case ProMessageFeature.PRO_BADGE:
-              await Storage.increment(SettingsKey.proBadgesSent);
-              break;
-            case ProMessageFeature.PRO_ANIMATED_DISPLAY_PICTURE:
-              // nothing to do for animated display picture
-              break;
-
-            default:
-              assertUnreachable(proFeature, 'Unknown pro feature');
-          }
-        })
-      );
     }
+  }
+
+  /**
+   * Add this message's Pro features to the lifetime stats, once, when a send has succeeded.
+   *
+   * Separate from the bitset written by applyProFeatures because the two answer different questions at
+   * different times. The bitset describes what this message claims and has to be set before it goes on
+   * the wire; the stats count what was actually sent, so they cannot be known until the send comes back.
+   * Incrementing at the earlier point counted a message that never left.
+   *
+   * Guarded by its own flag rather than by the state of the send. One success can be reported more than
+   * once — a 1:1 message reports again for its own sync copy — and `sent` is set by the failure handler
+   * as well, so neither is a usable answer to "has this already been counted".
+   */
+  public async addProFeaturesToStats() {
+    if (this.get('proStatsCounted')) {
+      return;
+    }
+    const proFeaturesUsed = this.getProFeaturesUsed();
+    if (!proFeaturesUsed.length) {
+      return;
+    }
+    await Promise.all(
+      proFeaturesUsed.map(async proFeature => {
+        switch (proFeature) {
+          case ProMessageFeature.PRO_INCREASED_MESSAGE_LENGTH:
+            await Storage.increment(SettingsKey.proLongerMessagesSent);
+            break;
+          case ProMessageFeature.PRO_BADGE:
+            await Storage.increment(SettingsKey.proBadgesSent);
+            break;
+          case ProMessageFeature.PRO_ANIMATED_DISPLAY_PICTURE:
+            // nothing to do for animated display picture
+            break;
+
+          default:
+            assertUnreachable(proFeature, 'Unknown pro feature');
+        }
+      })
+    );
+    this.set({ proStatsCounted: true });
+    await this.commit();
   }
 
   private dispatchMessageUpdate() {

--- a/ts/models/message.ts
+++ b/ts/models/message.ts
@@ -1579,9 +1579,10 @@ export class MessageModel extends Model<MessageAttributes> {
       //  - We already have some bitset set for this message in the DB,
       //  - or the proMessageDetails is empty
       //  - or the proMessageDetails has no bitset set
-      // then,
-      // - we do not need to apply the bitset from the details.
-      // - we also don't need the update the pro stats with this change (as we can assume the change was already counted).
+      // then there is no bitset to apply from the details.
+      //
+      // The stats are not decided here: they are counted from this bitset once a send succeeds, and
+      // guarded there by `proStatsCounted` rather than by this early return.
 
       return;
     }

--- a/ts/models/messageType.ts
+++ b/ts/models/messageType.ts
@@ -162,6 +162,15 @@ type NotSharedMessageAttributes = {
    * This is a string, because bigints cannot be sent over ipc.
    */
   proProfileBitset?: string;
+
+  /**
+   * Set once this message's Pro features have been added to the lifetime stats.
+   *
+   * The stats count messages, not send attempts, so the increment has to happen when a send succeeds
+   * and exactly once however many times that success is reported. `sent` cannot carry that: the failure
+   * handler sets it too, deliberately, and records the failure in `errors` instead.
+   */
+  proStatsCounted?: boolean;
 };
 
 export type MessageAttributes = SharedMessageAttributes & NotSharedMessageAttributes;

--- a/ts/receiver/dataMessage.ts
+++ b/ts/receiver/dataMessage.ts
@@ -345,5 +345,16 @@ async function handleSwarmMessage(
       toRegularMessage(rawDataMessage),
       decodedEnvelope
     );
+
+    // A copy of a message we sent, arriving from one of our other devices, is still a message we sent,
+    // so it counts here as it would have on the device that composed it. This is the only path that
+    // sees it: that device counts on its own send success, which this one never observes.
+    //
+    // Safe from double counting on the device that did compose it, because its own copy is dropped as a
+    // duplicate above, before this runs — and the counted flag lives on the message, so the record
+    // created here is a different one and starts uncounted.
+    if (msgModel.get('type') === 'outgoing') {
+      await msgModel.addProFeaturesToStats();
+    }
   });
 }

--- a/ts/receiver/opengroup.ts
+++ b/ts/receiver/opengroup.ts
@@ -133,5 +133,18 @@ export const handleOpenGroupMessage = async ({
       toRegularMessage(cleanedDataMessage),
       decodedEnvelope
     );
+
+    // As on the swarm side: a message we sent, reaching us here from another of our devices, is still
+    // one we sent and counts the same.
+    //
+    // The device that composed it does see its own message come back from the server, but not this far.
+    // It is dropped by the deduplication noted above, which compares the sender the server reports
+    // against the one stored locally — and for a blinded room that stored sender is our blinded id, the
+    // same one the server echoes, because the resolution back to our real account id happens after that
+    // comparison. That match is what keeps this from counting twice, and it is a database lookup rather
+    // than anything held in memory, so it survives a restart mid-send.
+    if (msgModel.get('type') === 'outgoing') {
+      await msgModel.addProFeaturesToStats();
+    }
   });
 };

--- a/ts/session/sending/MessageSentHandler.ts
+++ b/ts/session/sending/MessageSentHandler.ts
@@ -36,6 +36,7 @@ async function handlePublicMessageSentSuccess(
       sentSync: true,
     });
     await foundMessage.commit();
+    await foundMessage.addProFeaturesToStats();
     foundMessage.getConversation()?.updateLastMessage();
   } catch (e) {
     window?.log?.error('Error setting public on message');
@@ -173,6 +174,7 @@ async function handleSwarmMessageSentSuccess({
   }
 
   await fetchedMessage.commit();
+  await fetchedMessage.addProFeaturesToStats();
   fetchedMessage.getConversation()?.updateLastMessage();
 }
 

--- a/ts/test/session/unit/models/MessageProStats_test.ts
+++ b/ts/test/session/unit/models/MessageProStats_test.ts
@@ -6,14 +6,16 @@ import type { ConversationModel } from '../../../../models/conversation';
 import { SettingsKey } from '../../../../data/settings-key';
 import { TestUtils } from '../../../test-utils';
 import { UserUtils } from '../../../../session/utils';
+import { OutgoingProMessageDetails } from '../../../../types/message/OutgoingProMessageDetails';
 
 describe('addProFeaturesToStats', () => {
   let increment: Sinon.SinonStub;
+  let saveMessage: Sinon.SinonStub;
 
   beforeEach(() => {
     TestUtils.stubWindowLog();
     Sinon.stub(UserUtils, 'getOurPubKeyStrFromCache').returns(TestUtils.generateFakePubKeyStr());
-    Sinon.stub(Data, 'saveMessage').resolves('fake-id');
+    saveMessage = Sinon.stub(Data, 'saveMessage').resolves('fake-id');
     increment = TestUtils.stubStorage('increment');
   });
 
@@ -60,5 +62,46 @@ describe('addProFeaturesToStats', () => {
     await message.addProFeaturesToStats();
 
     expect(increment.called).to.equal(false);
+  });
+
+  it('does not count while the message is only being composed', async () => {
+    // The regression this exists to hold: the counters used to be incremented here, before the message
+    // was ever sent, so anything that failed to send was counted anyway. Moving them back would pass
+    // every other test in this file.
+    const message = TestUtils.generateFakeOutgoingPrivateMessage();
+    Sinon.stub(message, 'getConversation').returns({
+      updateLastMessage: Sinon.stub(),
+    } as unknown as ConversationModel);
+
+    // toProtobufDetails() is stubbed rather than fed a real proof: this test is about whether composing
+    // touches the counters, and building a valid proof would only add crypto helpers to the setup. The
+    // bitset assertion below is what proves the store actually ran, so the test cannot pass vacuously.
+    const details = new OutgoingProMessageDetails({ proMessageBitset: BigInt(1) });
+    Sinon.stub(details, 'toProtobufDetails').returns({
+      messageBitset: 1,
+      profileBitset: 0,
+    } as unknown as ReturnType<OutgoingProMessageDetails['toProtobufDetails']>);
+
+    await message.applyProFeatures(details);
+
+    expect(
+      message.get('proMessageBitset'),
+      'the bitset must still be stored at compose time'
+    ).to.not.equal(undefined);
+    expect(increment.called, 'composing a message must not touch the stats').to.equal(false);
+  });
+
+  it('persists the counted flag with the message', async () => {
+    // The once-only guard is only worth anything if it survives a restart, so assert it reaches what
+    // gets written rather than only the in-memory model.
+    const message = makeSentProMessage();
+
+    await message.addProFeaturesToStats();
+
+    const saved = saveMessage.lastCall.args[0] as { proStatsCounted?: boolean };
+    expect(
+      saved.proStatsCounted,
+      'proStatsCounted must be part of the persisted attributes'
+    ).to.equal(true);
   });
 });

--- a/ts/test/session/unit/models/MessageProStats_test.ts
+++ b/ts/test/session/unit/models/MessageProStats_test.ts
@@ -1,0 +1,64 @@
+import { expect } from 'chai';
+import Sinon from 'sinon';
+
+import { Data } from '../../../../data/data';
+import type { ConversationModel } from '../../../../models/conversation';
+import { SettingsKey } from '../../../../data/settings-key';
+import { TestUtils } from '../../../test-utils';
+import { UserUtils } from '../../../../session/utils';
+
+describe('addProFeaturesToStats', () => {
+  let increment: Sinon.SinonStub;
+
+  beforeEach(() => {
+    TestUtils.stubWindowLog();
+    Sinon.stub(UserUtils, 'getOurPubKeyStrFromCache').returns(TestUtils.generateFakePubKeyStr());
+    Sinon.stub(Data, 'saveMessage').resolves('fake-id');
+    increment = TestUtils.stubStorage('increment');
+  });
+
+  afterEach(() => {
+    Sinon.restore();
+  });
+
+  function makeSentProMessage() {
+    const message = TestUtils.generateFakeOutgoingPrivateMessage();
+    // The mask for PRO_INCREASED_MESSAGE_LENGTH on a proMessage bitset, per getBitMaskForFeature.
+    message.setProFeaturesUsed({ proMessageBitset: BigInt(1), proProfileBitset: null });
+    Sinon.stub(message, 'getConversation').returns({
+      updateLastMessage: Sinon.stub(),
+    } as unknown as ConversationModel);
+
+    return message;
+  }
+
+  it('counts a message once', async () => {
+    const message = makeSentProMessage();
+
+    await message.addProFeaturesToStats();
+
+    expect(increment.calledOnceWith(SettingsKey.proLongerMessagesSent)).to.equal(true);
+  });
+
+  it('does not count the same message a second time', async () => {
+    const message = makeSentProMessage();
+
+    // A single success can be reported more than once — a 1:1 message reports again for its own sync
+    // copy — so the second report must not add to the stats.
+    await message.addProFeaturesToStats();
+    await message.addProFeaturesToStats();
+
+    expect(increment.callCount).to.equal(1);
+  });
+
+  it('counts nothing for a message that used no Pro features', async () => {
+    const message = TestUtils.generateFakeOutgoingPrivateMessage();
+    Sinon.stub(message, 'getConversation').returns({
+      updateLastMessage: Sinon.stub(),
+    } as unknown as ConversationModel);
+
+    await message.addProFeaturesToStats();
+
+    expect(increment.called).to.equal(false);
+  });
+});

--- a/ts/test/session/unit/models/MessageProStats_test.ts
+++ b/ts/test/session/unit/models/MessageProStats_test.ts
@@ -104,4 +104,22 @@ describe('addProFeaturesToStats', () => {
       'proStatsCounted must be part of the persisted attributes'
     ).to.equal(true);
   });
+
+  it('counts a copy of our own message synced from another device', async () => {
+    // That copy is a different message record from the one the sending device counted, so it starts
+    // uncounted — which is what lets a linked device stay level rather than the flag suppressing it.
+    const synced = TestUtils.generateFakeOutgoingPrivateMessage();
+    synced.setProFeaturesUsed({ proMessageBitset: BigInt(1), proProfileBitset: null });
+    Sinon.stub(synced, 'getConversation').returns({
+      updateLastMessage: Sinon.stub(),
+    } as unknown as ConversationModel);
+
+    expect(synced.get('proStatsCounted'), 'a freshly received copy must start uncounted').to.equal(
+      undefined
+    );
+
+    await synced.addProFeaturesToStats();
+
+    expect(increment.calledOnceWith(SettingsKey.proLongerMessagesSent)).to.equal(true);
+  });
 });


### PR DESCRIPTION
### Contributor checklist:

- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`dev`](https://github.com/session-foundation/session-desktop/tree/dev) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/session-foundation/session-desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

The Pro stats on the settings screen were counting the wrong things, in three separate ways. Each is
its own commit.

**A message was counted when it was tried, not when it was sent.** The counters were incremented in
`applyProFeatures`, which runs before the message goes out — so a message that failed to send was
counted anyway and the totals ran ahead of what had actually been sent. Only the counting moves, to
the two success handlers; the bitset written at compose time has to stay there, because it describes
what the message claims and travels on the wire.

Counting is guarded by its own persisted flag rather than by the send's state, for two reasons that
are easy to miss on review. A single success is reported more than once — a 1:1 message reports again
for its own sync copy, re-entering the same handler. And `sent` is set by the failure handler too, on
purpose, with the failure recorded in `errors`, so it cannot answer "did this send work". Because the
flag persists with the message, a resend of a message that already counted stays counted once.

**A message sent from another of your devices was not counted at all.** It arrives on the other
devices through the receive path, which never touched the counters — so the same message counted on
one device and not on the rest, and the totals drifted further apart the more devices were in use.
It is now counted from the copy that arrives, gated on it being outgoing.

**Community messages were missed by that same fix,** because they arrive by a different route. Now
handled the same way.

Both of those raise the obvious question of whether the device that composed the message can end up
counting it twice, and the answer is no in both cases, for reasons written into the commits rather
than left implicit. On the swarm side the composing device's own echo is dropped as a duplicate
before reaching the counting call. In a community it is dropped by the poller's deduplication, which
compares the sender the server reports against the one already stored — in a blinded room the stored
sender is our blinded id, the same one the server echoes, because the resolution back to the real
account id happens after that comparison. That is a database lookup rather than an in-memory set, so
it still holds if the app restarts between sending and the message coming back.

### Test approach

Six unit tests in `ts/test/session/unit/models/MessageProStats_test.ts`, covering counting once,
not counting a second time, not counting a message with no Pro features, not counting at compose
time, persisting the flag, and counting a copy synced from another device.

Two of those exist because of a gap found while reviewing the first version of this change: every
test written with it called the new counting method directly, so putting the old increment back
inside `applyProFeatures` left all of them green while the bug was back. One test now drives
`applyProFeatures` and asserts the counters stay untouched while the bitset is still stored, and
another asserts `proStatsCounted` reaches the attributes handed to `saveMessage` — the guard is only
worth anything if it survives a restart, and stubbing the save meant the earlier dedupe test only
ever proved in-memory behaviour.

Full unit suite green (943 passing), `tsc` clean, prettier and eslint clean. Verified on macOS 15.6.
