### PR TITLE
qa: give the pin/unpin context-menu item a test id

### DIFF
--- a/ts/components/menu/ConversationListItemContextMenu.tsx
+++ b/ts/components/menu/ConversationListItemContextMenu.tsx
@@ -143,6 +143,7 @@ export const PinConversationMenuItem = (): JSX.Element | null => {
   const menuText = tr(isPinned ? 'pinUnpin' : 'pin');
   return (
     <MenuItem
+      dataTestId="pin-conversation-menu-item"
       onClick={togglePinConversation}
       iconType={isPinned ? LUCIDE_ICONS_UNICODE.PIN_OFF : LUCIDE_ICONS_UNICODE.PIN}
       isDangerAction={false}

--- a/ts/react.d.ts
+++ b/ts/react.d.ts
@@ -341,6 +341,7 @@ declare module 'react' {
     // itself rather than on a container, because that is where the text is.
     | 'pro-stats-longer-messages'
     | 'pro-stats-pinned-conversations'
+    | 'pin-conversation-menu-item'
     | 'pro-stats-badges-sent'
     | 'pro-stats-groups-upgraded'
 


### PR DESCRIPTION
`PinConversationMenuItem` renders a bare `MenuItem`, so it falls back to the shared `context-menu-item` id that every other item in the conversation-list context menu also uses. A test can find "some context menu item" but not the pin control.

```diff
     <MenuItem
+      dataTestId="pin-conversation-menu-item"
       onClick={togglePinConversation}
```

Plus the id in the `SessionDataTestId` union. `MenuItem` already accepts `dataTestId` and defaults it, so nothing else changes.

### Why

The `pinned-conversations` Pro stat is a live count of currently-pinned threads. Covering it in the QA suite means pinning one, and Desktop was the only platform where a test could not — Android and iOS both expose the control. Without this, the Desktop half of the Pro-stats spec can assert `longer-messages` and `badges-sent` but not the third counter.

Matching by the item's text (`tr('pin')`) was the alternative and is what the QA suite's locator rules exclude: it pins the test to a display string and breaks on any copy change.

### One id, not two

The label toggles between `pin` and `pinUnpin` via `useIsPinned`, but a single id is enough — the resulting state is already assertable through the existing `conversation-item-pinned` icon, so the test does not need the menu item to tell it which direction the toggle will go.

### Scope

Two lines, no behaviour change. Typechecks clean (the only errors in a fresh worktree are the ungenerated protobuf and an unpopulated `ts/localization`, neither related).