### PR TITLE
fix(pro): stop the sending device counting its own message twice

### DIFF
--- a/ts/session/sending/MessageSentHandler.ts
+++ b/ts/session/sending/MessageSentHandler.ts
@@ -125,6 +125,13 @@ async function handleSwarmMessageSentSuccess({
   const isPrivateSyncMessage = isOurDevice && fetchedMessage.get('sentSync');
   const shouldMarkMessageAsSynced = isPrivateSyncMessage || isClosedGroupMessage;
 
+  fetchedMessage.set({
+    sent_at: sentAtMs,
+    sent: true,
+    errors: undefined,
+  });
+  await fetchedMessage.commit();
+  await fetchedMessage.addProFeaturesToStats();
   // Handle the sync logic here
   if (shouldTriggerSyncMessage && plainTextBuffer) {
     try {
@@ -161,7 +168,6 @@ async function handleSwarmMessageSentSuccess({
   fetchedMessage.set({
     sent_to: sentTo,
     sent: true,
-    sent_at: sentAtMs,
     errors: undefined,
   });
 

--- a/ts/test/session/unit/sending/MessageSentHandlerProStats_test.ts
+++ b/ts/test/session/unit/sending/MessageSentHandlerProStats_test.ts
@@ -1,0 +1,80 @@
+import { expect } from 'chai';
+import Sinon from 'sinon';
+
+import { Data } from '../../../../data/data';
+import type { ConversationModel } from '../../../../models/conversation';
+import { SignalService } from '../../../../protobuf';
+import { MessageSentHandler } from '../../../../session/sending/MessageSentHandler';
+import { UserUtils } from '../../../../session/utils';
+import { TestUtils } from '../../../test-utils';
+
+/**
+ * The composing device must not count its own message twice.
+ *
+ * `dataMessage.ts` counts an outgoing message arriving synced from another of our devices, and argues
+ * it is safe on the device that composed it because "its own copy is dropped as a duplicate above".
+ * That dedup is `WHERE source = $source AND sent_at = $sentAt`, so it can only match once this handler
+ * has PERSISTED the `sent_at` the message went out under.
+ *
+ * The sync copy is dispatched first and `sent_at` is committed after, so between those two points the
+ * stored row still carries its compose-time `sent_at`. A copy returning inside that window does not
+ * match, is stored as a second record, and both records get counted — which is the +2 the Pro stats
+ * spec sees for a single send.
+ */
+describe('handleSwarmMessageSentSuccess / Pro stats double counting', () => {
+  const SENT_AT = 1_700_000_000_000;
+  const COMPOSED_AT = SENT_AT - 250;
+
+  beforeEach(() => {
+    TestUtils.stubWindowLog();
+    Sinon.stub(UserUtils, 'getOurPubKeyStrFromCache').returns(TestUtils.generateFakePubKeyStr());
+    Sinon.stub(UserUtils, 'isUsFromCache').returns(false);
+  });
+
+  afterEach(() => {
+    Sinon.restore();
+  });
+
+  it('commits the sent_at it sent under before dispatching the sync copy', async () => {
+    const message = TestUtils.generateFakeOutgoingPrivateMessage();
+    message.set({ sent_at: COMPOSED_AT });
+    Sinon.stub(message, 'getConversation').returns({
+      updateLastMessage: Sinon.stub(),
+      // `checkForExpiringOutgoingMessage` runs between the sync dispatch and the commit, so the stub
+      // has to survive it for the ordering assertion to be reached at all.
+      isClosedGroup: () => false,
+    } as unknown as ConversationModel);
+
+    const sendSyncMessage = Sinon.stub(message, 'sendSyncMessage').resolves();
+    const commit = Sinon.stub(message, 'commit').resolves('fake-id');
+    Sinon.stub(message, 'addProFeaturesToStats').resolves();
+    Sinon.stub(message, 'updateMessageHash');
+    Sinon.stub(Data, 'getMessageById').resolves(message);
+
+    await MessageSentHandler.handleSwarmMessageSentSuccess({
+      device: TestUtils.generateFakePubKeyStr(),
+      dbMessageIdentifier: message.id,
+      isDestinationClosedGroup: false,
+      // Required for the sync branch: the handler decodes this to re-encrypt for our linked devices.
+      plainTextBuffer: SignalService.Content.encode({
+        dataMessage: { body: 'a message that used a Pro feature' },
+      }).finish(),
+      sentAtMs: SENT_AT,
+      storedAtServerMs: SENT_AT,
+      storedHash: null,
+    });
+
+    // Not an assertion about the bug — a guard, so a setup that stops short of the sync branch fails
+    // loudly rather than passing on an ordering it never exercised.
+    expect(
+      sendSyncMessage.called,
+      'the sync path did not run, so this test asserted nothing'
+    ).to.equal(true);
+
+    expect(
+      commit.calledBefore(sendSyncMessage),
+      'the sync copy went out before sent_at was persisted, so the composing device cannot recognise ' +
+        'its own copy as a duplicate and counts the message twice'
+    ).to.equal(true);
+  });
+});


### PR DESCRIPTION
One over-length message moves `longer-messages` by **2** on a single device. Caught by the QA suite's new Pro stats spec on its first run:

```
baseline:       {badges-sent: 0, longer-messages: 0, pinned-conversations: 0}
after ONE send: {badges-sent: 0, longer-messages: 2, pinned-conversations: 0}
```

### Cause

`dataMessage.ts` counts an outgoing message arriving synced from another of our devices, so a linked device stays level. It argues this is safe on the device that *composed* the message:

> *"Safe from double counting on the device that did compose it, because its own copy is dropped as a duplicate above — and the counted flag lives on the message, so the record created here is a different one and starts uncounted."*

The second clause is the failure mode if the first doesn't hold. That dedup is `WHERE source = $source AND sent_at = $sentAt`. `source` matches — an outgoing message stores our own key (`conversation.ts:1242`) — but `sent_at` only matches once the send path has **persisted** the value it went out under, and it didn't:

| | before |
|---|---|
| 134 | `await sendSyncMessage(contentDecoded, sentAtMs)` — copy dispatched |
| 164 | `sent_at: sentAtMs` set on the model |
| 176 | `commit()` — first persisted here |

Between those points the stored row still carried its **compose-time** `sent_at`. A copy returning inside that window didn't match, wasn't dropped, became a second record — and both records were counted.

The window isn't narrow: the sync send is `await`ed, so a full network round trip completes before `sent_at` is even set. It reproduced on the first run against a local devnet.

### Fix

Set and commit `sent_at` before dispatching the sync copy, so the dedup's assumption is true rather than hopeful.

### Why the existing tests didn't catch it

`MessageProStats_test.ts` passes now and always did. It covers `addProFeaturesToStats` itself — the same instance counted twice, the persisted flag, a synced copy counting on a linked device — and all of that is correct. None of it exercises the **ordering** in `MessageSentHandler`, so the once-only guard never got a chance to see the second record.

The new test asserts `commit` runs before `sendSyncMessage`, verified in both directions:

| handler | result |
|---|---|
| without this change | ✗ *"the sync copy went out before sent_at was persisted…"* |
| with it | ✓ 944 passing |

It also carries an explicit guard that fails if the sync branch didn't run, so a setup that stops short can't pass while asserting nothing — that guard caught two of my own broken attempts while writing it.

### Checks

`prettier --check`, `eslint .` and `tsc --noEmit` clean (the 11 files prettier flags are pre-existing and untouched here).