### PR TITLE
Make the collapsed message bubble and its Read More button addressable

### DIFF
--- a/ts/components/conversation/message/message-content/MessageBubble.tsx
+++ b/ts/components/conversation/message/message-content/MessageBubble.tsx
@@ -98,11 +98,11 @@ export function MessageBubble({ children }: { children: ReactNode }) {
 
   return (
     <>
-      <StyledMessageBubble ref={msgBubbleRef} $expanded={expanded}>
+      <StyledMessageBubble ref={msgBubbleRef} $expanded={expanded} data-testid="message-bubble">
         {children}
       </StyledMessageBubble>
       {showReadMore && !expanded ? (
-        <ReadMoreButton onClick={onClick} onKeyDown={onKeyDown}>
+        <ReadMoreButton onClick={onClick} onKeyDown={onKeyDown} data-testid="read-more-button">
           {tr('messageBubbleReadMore')}
         </ReadMoreButton>
       ) : null}

--- a/ts/react.d.ts
+++ b/ts/react.d.ts
@@ -357,6 +357,8 @@ declare module 'react' {
     // generic readably message (not control message)
     | 'message-content'
     | 'message-container'
+    | 'message-bubble'
+    | 'read-more-button'
 
     // control message types
     | 'message-request-response-message'


### PR DESCRIPTION
### Description

A long message collapses at 25 lines and offers a Read More button. Neither the button nor the bubble
carried a test id, so an end-to-end test could neither drive that nor observe it — the row is currently
uncovered on Desktop for want of two attributes.

**Two ids rather than one, and the second is the load-bearing part.** The button renders only while the
message is collapsed, so its absence after a click is what says the message expanded. But an assertion
that something is *gone* passes just as well when it was never there — against a button that failed to
render, a mistyped id, or a bubble that never collapsed. The bubble's id is the other half: still
present, button gone, and the expansion is established rather than inferred.

    message-bubble      on StyledMessageBubble
    read-more-button    on ReadMoreButton

Both are declared in `ts/react.d.ts` alongside the existing message testids rather than added as loose
literals.

### Test approach

Inert outside a UI test — two `data-testid` attributes and their type declarations, no behaviour
touched.

The end-to-end spec that consumes them is being written now in session-appium and covers Android and
Desktop. iOS is deliberately excluded and needs no equivalent: there `readMoreButton` is a subview of a
bubble that sets `isAccessibilityElement = true`, which makes the bubble a leaf — an id was added there,
confirmed compiled in, and measured unfindable (20s, 120 attempts). iOS also carries the full message
text in the bubble's accessibility attributes whether or not it is visually collapsed, so a spec reads
the tail without expanding.

One thing worth knowing for anyone writing against these: the threshold is **25 rendered lines**
(`MAX_MESSAGE_MAX_LINES_BEFORE_READ_MORE`), not a character count, so a long single-line paste may not
collapse at all.
