### PR TITLE
Keep a hidden conversation hidden when our own message syncs into it

### DIFF
--- a/ts/receiver/queuedJob.ts
+++ b/ts/receiver/queuedJob.ts
@@ -293,8 +293,15 @@ async function handleRegularMessage(
         : null
     );
 
-    // a new message was received for that conversation. If it was not it should not be hidden anymore
-    await conversation.unhideIfNeeded(false);
+    // A conversation is resurfaced by someone else messaging you. A copy of our own message, synced
+    // from another of our devices, arrives here the same way but is not that — nobody has contacted
+    // us — so a conversation we hid stays hidden.
+    //
+    // Keyed on the sender rather than on the conversation: Note to Self is where our own messages
+    // always land, but they can sync into any conversation, and the question is who sent it.
+    if (!isUsFromCache(decodedEnvelope.getAuthor())) {
+      await conversation.unhideIfNeeded(false);
+    }
   }
 
   // we just received a message from that user so we reset the typing indicator for this convo


### PR DESCRIPTION
A conversation the user has deliberately hidden is un-hidden by our **own** message syncing in from
another device, and `setPriorityFromWrapper` then writes that back to config when `isMe`, so every device
follows.

Note to Self is where it surfaces, but the fix is not Note-to-Self-specific: hide any 1:1, send to it from
another of your devices, and it comes back everywhere.

## The fix

Keyed on the **sender**, matching Android's existing
`senderAddress.address != ctx.currentUserPublicKey`. A conversation-keyed guard would cover the Note to
Self case and miss the general one, which is the reason for preferring the sender.

iOS carries the same fix in session-ios#764. Android already guarded, and was the reference for both.

## Verification

- The Note to Self spec: **3/3 green**, previously 3/3 failing
- Mutation-verified — the guard is load-bearing, not incidentally passing
- 944 unit tests passing

One note for whoever reviews the verification rather than the diff: a grep of the built output for the
new call reported a **false absence**, because babel rewrites calls to member expressions. In built
output a grep hit is evidence and a grep miss is not — the mutation test is what establishes this fix is
doing the work.
