### PR TITLE
Keep the access expiry on a revoked proof, and confirm the account status at once

### DIFF
--- a/ts/session/utils/job_runners/jobs/UpdateProRevocationListJob.ts
+++ b/ts/session/utils/job_runners/jobs/UpdateProRevocationListJob.ts
@@ -150,14 +150,18 @@ class UpdateProRevocationListJob extends PersistedJob<UpdateProRevocationListPer
         // Our own proof is revoked: clear it directly. The renewal loop won't do this for us —
         // renewal_target treats a still-unexpired proof as "not due", so a revoked-but-unexpired
         // proof would otherwise linger in config (and stay attachable, §6.1) until natural expiry.
-        // Also refresh status so the UI reflects the change.
+        //
+        // The status fetch is immediate: what the account is now cannot be known locally — the access
+        // expiry is still the old, future one — and a fetch from before this revocation cannot have
+        // observed it, which is the assumption the routine floor rests on. It also ends the acquire
+        // loop, which libsession runs while the access expiry is still ahead of now.
         window.log.info(
           `UpdateProRevocationListJob: our current revocation tag is revoked. Clearing our pro proof.`
         );
         await UserConfigWrapperActions.removeProConfig();
         await persistProConfigWrite();
         window.inboxStore?.dispatch(
-          proBackendDataActions.refreshGetProStatusFromProBackend({}) as any
+          proBackendDataActions.refreshGetProStatusFromProBackend({ immediate: true }) as any
         );
       }
       // find all the conversations that have a revoked revocation tag and trigger a UI refresh on them

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -108,7 +108,7 @@ export type WithCallerContext = { callerContext?: 'recover' };
  * something any routine trigger may pass, and a floor every caller bypasses is dead code.
  *
  * Sanctioned callers and no others: manual refresh/recover (implied by `callerContext: 'recover'`), the
- * bounded while-open grace poll, and developer/debug paths.
+ * bounded while-open grace poll, a proof revocation, and developer/debug paths.
  */
 export type WithImmediate = { immediate?: boolean };
 
@@ -348,11 +348,23 @@ async function applyProofOutcome(
       }
       break;
     case 'revoked':
-      // Terminal: revocation kills even an unexpired proof (bypasses the downgrade guard). With the
-      // proof gone we must also clear E, or the renewal target (future E, no proof) would spin.
+      // Revocation kills even an unexpired proof, bypassing the downgrade guard. It says the proof is
+      // void; it says nothing about the subscription. A revocation with `revoke_payments` false is a
+      // rotation — the account stays paid and re-provable — and locally that is indistinguishable from
+      // a refund, so the proof goes and the access expiry stays.
+      //
+      // `E` is synced config rather than device-local, so clearing it here would erase from every
+      // device the record that this account ever subscribed, leaving a lapsed subscriber
+      // indistinguishable from someone who never had Pro.
+      //
+      // Immediate rather than floored: the expiry alone cannot describe this state — it is the old,
+      // still-future one either way — so what to display is unknown until the status lands, and a
+      // fetch that ran before the revocation cannot have seen it.
       await UserConfigWrapperActions.removeProConfig();
-      await UserConfigWrapperActions.setProAccessExpiry(null);
       await persistProConfigWrite();
+      window.inboxStore?.dispatch(
+        proBackendDataActions.refreshGetProStatusFromProBackend({ immediate: true }) as any
+      );
       break;
     default:
       // Unrecognized error_code: fail closed, non-destructively — treat as transient (no write/clear).

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -298,12 +298,16 @@ async function applyProofOutcome(
     // along, and must: otherwise coverage end pairs a fresh expiry with a grace from a different billing
     // period, and an unwritten auto-renewing flag reads as not-renewing.
     //
-    // All three writes belong inside the success branch. On a failure outcome core never fills
-    // `accountAutoRenewing`/`accountGracePeriodMs`, so its struct defaults (`false`/`0`) come through,
-    // indistinguishable from a backend that said "not renewing, no grace" — and both keys are
-    // presence-only, so writing those would erase what a `get_pro_status` fetch had learned.
+    // `accountAutoRenewing` and `accountGracePeriodMs` may only be read on an outcome that carries the
+    // account block — a success or a `subscription_expired`. Every other outcome leaves them at the
+    // struct defaults `false`/`0`, indistinguishable from a backend that said "not renewing, no grace",
+    // and both config keys are presence-only, so writing those defaults erases what a `get_pro_status`
+    // fetch had learned.
     //
-    // `accountExpiryMs` is nullable — absent on `not_subscribed` and `revoked` — hence its guard.
+    // Only the expiry is guarded, because it is the only one whose absence is representable: it arrives
+    // nullable, and the sole way to write "absent" is to clear `E`, which would erase from every device
+    // the record that this account ever subscribed. An absent grace or renewing flag arrives as `0`/
+    // `false`, which core defines as "does not apply" rather than "unknown", so writing it is correct.
     if (response.accountExpiryMs !== null) {
       await UserConfigWrapperActions.setProAccessExpiry(response.accountExpiryMs);
     }
@@ -323,7 +327,8 @@ async function applyProofOutcome(
       // All three together, never the expiry alone. Coverage ends at the expiry plus the grace, and on
       // a lapse or cancellation it is usually the expiry that has NOT moved while the grace and the
       // renewing flag have — so refreshing the expiry by itself would pair it with a grace the backend
-      // has stopped honouring. `parse_pro_proof` fills all three on this slug for that reason.
+      // has stopped honouring. This is one of the two outcomes carrying the account block, which is why
+      // all three are available here.
       //
       // Don't wipe a fresh proof a re-subscribe just landed.
       if (!haveValidProof()) {

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -354,6 +354,16 @@ async function applyProofOutcome(
         await UserConfigWrapperActions.removeProConfig();
         await UserConfigWrapperActions.setProAccessExpiry(null);
         await persistProConfigWrite();
+        // A status fetch binds any payment registered for this key but not yet redeemed, so it can
+        // find a purchase that existed and simply was not bound when the proof was requested — which
+        // is the state a client sits in immediately after paying. Immediate for the same reason as the
+        // rows above: a fetch from before the purchase cannot have seen it.
+        //
+        // Nothing to loop on: the expiry has just been cleared, so the renewal target stays dormant,
+        // and a `never` status writes nothing back.
+        window.inboxStore?.dispatch(
+          proBackendDataActions.refreshGetProStatusFromProBackend({ immediate: true }) as any
+        );
       }
       break;
     case 'revoked':

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -108,7 +108,7 @@ export type WithCallerContext = { callerContext?: 'recover' };
  * something any routine trigger may pass, and a floor every caller bypasses is dead code.
  *
  * Sanctioned callers and no others: manual refresh/recover (implied by `callerContext: 'recover'`), the
- * bounded while-open grace poll, a proof revocation, and developer/debug paths.
+ * bounded while-open grace poll, a proof outcome that ended entitlement, and developer/debug paths.
  */
 export type WithImmediate = { immediate?: boolean };
 
@@ -315,14 +315,15 @@ async function applyProofOutcome(
   // Non-ok: the machine slug (error_code) decides.
   switch (response.errorCode) {
     case 'subscription_expired':
-      // Lapsed, so not entitled. The access expiry is set to the past one this response carries rather
-      // than cleared: it is what the backend last said, and the surfaces that describe the plan are
-      // seeded from it, so an absent expiry states "never subscribed" where a past one states "lapsed".
-      // It is synced config, so the difference reaches every device.
+      // Lapsed, so not entitled. The three account values this response carries are recorded rather
+      // than cleared: they are what the backend last said, and the surfaces describing the plan are
+      // seeded from them, so absent values state "never subscribed" where past ones state "lapsed".
+      // They are synced config, so the difference reaches every device.
       //
-      // The expiry alone, and not the renewing flag or the grace period beside it: core fills those two
-      // only on a successful parse, and their struct defaults would erase what a status fetch had
-      // learned — key `A` is presence-only and a zero `G` reads as no grace.
+      // All three together, never the expiry alone. Coverage ends at the expiry plus the grace, and on
+      // a lapse or cancellation it is usually the expiry that has NOT moved while the grace and the
+      // renewing flag have — so refreshing the expiry by itself would pair it with a grace the backend
+      // has stopped honouring. `parse_pro_proof` fills all three on this slug for that reason.
       //
       // Don't wipe a fresh proof a re-subscribe just landed.
       if (!haveValidProof()) {
@@ -330,15 +331,18 @@ async function applyProofOutcome(
         if (response.accountExpiryMs !== null) {
           await UserConfigWrapperActions.setProAccessExpiry(response.accountExpiryMs);
         }
+        await writeProAutoRenewingToConfig(response.accountAutoRenewing);
+        await UserConfigWrapperActions.setProGracePeriod(response.accountGracePeriodMs);
         await persistProConfigWrite();
         // Entitlement ended, and nothing observes that: the config watch that would refresh our status
         // runs on incoming merges, so a local write reaches no one. The Expired CTA needs a status fetch
-        // to be raised at all — it is written by one — and the clear above leaves the cold-start gate
-        // without a horizon to decide from, so this is the only edge from "we just lapsed" to "find out
-        // what to show". Floored like every routine trigger: when a status fetch has just run, this is
-        // dropped, which is right — that fetch already had the chance to raise it.
+        // to be raised at all — it is written by one — so this is the only edge from "we just lapsed" to
+        // "find out what to show".
+        //
+        // Immediate: a fetch from before this lapse cannot have seen it, which is what the routine floor
+        // assumes when it drops one.
         window.inboxStore?.dispatch(
-          proBackendDataActions.refreshGetProStatusFromProBackend({}) as any
+          proBackendDataActions.refreshGetProStatusFromProBackend({ immediate: true }) as any
         );
       }
       break;

--- a/ts/state/ducks/proBackendData.ts
+++ b/ts/state/ducks/proBackendData.ts
@@ -315,16 +315,21 @@ async function applyProofOutcome(
   // Non-ok: the machine slug (error_code) decides.
   switch (response.errorCode) {
     case 'subscription_expired':
-      // Lapsed, so not entitled — the same conclusion as the two outcomes below, and cleared the same
-      // way. A past expiry left in config has nothing left to compute: every window here is derived
-      // from the access expiry, and a lapse changes the grace period and the renewing flag while
-      // typically leaving the expiry itself alone, so refreshing only the expiry would pair it with a
-      // grace the backend has stopped honouring. Clearing erases the auto-renewing flag and grace period
-      // alongside it instead, leaving absent keys rather than stored zeroes. Don't wipe a fresh proof a
-      // re-subscribe just landed.
+      // Lapsed, so not entitled. The access expiry is set to the past one this response carries rather
+      // than cleared: it is what the backend last said, and the surfaces that describe the plan are
+      // seeded from it, so an absent expiry states "never subscribed" where a past one states "lapsed".
+      // It is synced config, so the difference reaches every device.
+      //
+      // The expiry alone, and not the renewing flag or the grace period beside it: core fills those two
+      // only on a successful parse, and their struct defaults would erase what a status fetch had
+      // learned — key `A` is presence-only and a zero `G` reads as no grace.
+      //
+      // Don't wipe a fresh proof a re-subscribe just landed.
       if (!haveValidProof()) {
         await UserConfigWrapperActions.removeProConfig();
-        await UserConfigWrapperActions.setProAccessExpiry(null);
+        if (response.accountExpiryMs !== null) {
+          await UserConfigWrapperActions.setProAccessExpiry(response.accountExpiryMs);
+        }
         await persistProConfigWrite();
         // Entitlement ended, and nothing observes that: the config watch that would refresh our status
         // runs on incoming merges, so a local write reaches no one. The Expired CTA needs a status fetch


### PR DESCRIPTION
One rule, applied to every `generate_pro_proof` failure, and a fetch afterwards.

| response | config | then |
|---|---|---|
| `revoked` | **keep `E`** (the response carries no expiry) | fetch status, **immediate** |
| `subscription_expired` | **set `E`, `G`, `A`** from the response | fetch status, **immediate** |
| `not_subscribed` | **clear `E`** (no user row exists) | fetch status, **immediate** |

The principle underneath: **`E` reflects what the backend last said. Clear it only when the backend says
there is nothing to say — never as a side effect of a local decision.**

## Why keeping `E` on `revoked` matters

A revocation says this proof is void; it does not say what the subscription is. A revocation with
`revoke_payments=false` is a **rotation** — the account stays paid and re-provable — and no client can tell
that apart from a refund locally. Android already said so in its own comment:

> "`E` is not cleared locally. A revocation says this proof is void, not what the subscription is now — the
> account may be fine and re-provable, or genuinely gone, and only the server knows which."

`E` is also **synced config**, not device-local: a client that clears it pushes that clear to every other
device, erasing the shared record that the user ever subscribed. Both mobile clients seed display status
from `E` plus the proof, so clearing it makes "lapsed subscriber" indistinguishable from "never subscribed".
That shipped on iOS as a refunded subscriber being offered "Recover Pro Access" and "Upgrade to" instead of
"Renew".

## Why the trio travels together

Verified in libsession's parser (`src/pro_backend.cpp`, `parse_pro_proof`) — all three fields are populated
inside the FAILURE branch when the slug is `subscription_expired`, with the comment:

> "They must travel together: coverage ends at `account_expiry + grace`, and an expiry has typically NOT
> changed on this failure (it is a lapse/cancellation) while the grace and flag have — refreshing only the
> expiry would leave a stale grace claiming coverage the backend has stopped honouring."

The backend sends all three unconditionally on that slug, so "absent" cannot arise from a current backend.

## Why immediate, not floored

Neither `E` choice gives a correct display on its own: after a refund `E` is still the OLD, FUTURE expiry, so
keeping it seeds "active" just as clearing it seeds "never". Only the status fetch fixes it — the backend
keeps the user row and writes `expiry_at = now`, returning `user_status: "expired"` with a real PAST
`expiry_ts`, which every client mirrors into `E`.

A floored fetch is dropped whenever a status fetch ran inside the floor, which is the normal case because
launch fetches. **Measured on iOS: adding a FLOORED fetch changed nothing — 5 runs out of 5 still wrong.**

That mirrored past `E` is also what TERMINATES the acquire loop: libsession's `pro_renewal_target` acquires
only while `access && *access > now`. Flooring the terminator is the wrong place to economise.

## Verification

Desktop 8/8 revocation specs. Android 15/15 revocation plus the wider `ProApi` surface, and 12/12 pin specs.
iOS pin 13/14 across two builds, refund 5/5, recipient 3/3.

`subscription_expired` has **no spec on any platform** — the slug only fires once
`expiry + grace + RENEWAL_LATENCY_ALLOWANCE` has passed, that allowance is a hard-coded hour, and
`/dev/add_payment` validates `duration` positive. Nothing can reach it in a test. Recorded as a blocked row
in the coverage table; a dev expire hook would make it reachable in seconds.
