### PR TITLE
feat: add flag to disable update prompts

### DIFF
--- a/ts/mains/main_node.ts
+++ b/ts/mains/main_node.ts
@@ -86,6 +86,7 @@ const appInstance = config.util.getEnv('NODE_APP_INSTANCE') || 0;
 import { initAttachmentsChannel } from '../node/attachment_channel';
 
 import * as updater from '../updater/index';
+import { autoUpdateDisabled } from '../updater/auto_update_disabled';
 
 import { ephemeralConfig } from '../node/config/ephemeral_config';
 import { createTemplate } from '../node/menu';
@@ -551,6 +552,11 @@ let isReadyForUpdates = false;
 async function readyForUpdates() {
   console.log('[updater] isReadyForUpdates', isReadyForUpdates);
   if (isReadyForUpdates) {
+    return;
+  }
+
+  if (autoUpdateDisabled(userConfig.get('autoUpdate'))) {
+    console.log('[updater] updates disabled');
     return;
   }
 

--- a/ts/test/session/unit/updater/updater_test.ts
+++ b/ts/test/session/unit/updater/updater_test.ts
@@ -6,6 +6,10 @@ import { expect } from 'chai';
 import { enableLogRedirect } from '../../../test-utils/utils';
 import { DURATION } from '../../../../session/constants';
 import { fetchLatestRelease } from '../../../../session/fetch_latest_release';
+import {
+  autoUpdateDisabled,
+  DISABLE_UPDATE_PROMPT_ARG,
+} from '../../../../updater/auto_update_disabled';
 
 describe('Updater', () => {
   it('package.json target is correct', () => {
@@ -30,5 +34,29 @@ describe('Updater', () => {
 
   it('checks the file server on the same cadence as the update throttle', () => {
     expect(fetchLatestRelease.fetchReleaseFromFileServerInterval).to.equal(30 * DURATION.MINUTES);
+  });
+
+  describe('autoUpdateDisabled', () => {
+    it('defaults to enabled when the user setting is absent', () => {
+      expect(autoUpdateDisabled(undefined, [], false)).to.be.false;
+    });
+
+    it('respects the user setting', () => {
+      expect(autoUpdateDisabled(false, [], false)).to.be.true;
+      expect(autoUpdateDisabled(true, [], false)).to.be.false;
+    });
+
+    it('disables updates for Mac App Store builds', () => {
+      expect(autoUpdateDisabled(true, [], true)).to.be.true;
+    });
+
+    it(`disables updates when ${DISABLE_UPDATE_PROMPT_ARG} is present`, () => {
+      expect(autoUpdateDisabled(true, ['session-desktop', DISABLE_UPDATE_PROMPT_ARG], false)).to.be
+        .true;
+    });
+
+    it('ignores unrelated launch arguments', () => {
+      expect(autoUpdateDisabled(true, ['session-desktop', '--start-in-tray'], false)).to.be.false;
+    });
   });
 });

--- a/ts/updater/auto_update_disabled.ts
+++ b/ts/updater/auto_update_disabled.ts
@@ -1,0 +1,11 @@
+export const DISABLE_UPDATE_PROMPT_ARG = '--disable-update-prompt';
+
+export function autoUpdateDisabled(
+  userSetting: unknown,
+  argv: ReadonlyArray<string> = process.argv,
+  isMacAppStore = process.mas
+): boolean {
+  const autoUpdate = typeof userSetting !== 'boolean' || userSetting;
+
+  return isMacAppStore || argv.includes(DISABLE_UPDATE_PROMPT_ARG) || !autoUpdate;
+}

--- a/ts/updater/index.ts
+++ b/ts/updater/index.ts
@@ -2,9 +2,9 @@ import type { BrowserWindow } from 'electron';
 import { start as startUpdater, stop as stopUpdater } from './updater';
 import type { UserConfig } from '../node/config/user_config';
 import type { LoggerType } from '../util/logger/Logging';
+import { autoUpdateDisabled } from './auto_update_disabled';
 
 let initialized = false;
-let localUserConfig: UserConfig;
 
 export async function start(
   getMainWindow: () => BrowserWindow | null,
@@ -23,9 +23,8 @@ export async function start(
     throw new Error('[updater] start: Must provide logger!');
   }
   initialized = true;
-  localUserConfig = userConfig; // reused below
 
-  if (autoUpdateDisabled()) {
+  if (autoUpdateDisabled(userConfig.get('autoUpdate'))) {
     logger.info('[updater] start: Updates disabled - not starting new version checks');
 
     return;
@@ -39,14 +38,4 @@ export function stop() {
     stopUpdater();
     initialized = false;
   }
-}
-
-function autoUpdateDisabled() {
-  // We need to ensure that if auto update is not present in the user config then we assume it is on by default
-  const userSetting = localUserConfig.get('autoUpdate');
-  const autoUpdate = typeof userSetting !== 'boolean' || userSetting;
-
-  return (
-    process.mas || !autoUpdate // From Electron: Mac App Store build // User setting
-  );
 }


### PR DESCRIPTION
### Contributor checklist:

- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://blog.axosoft.com/golden-rule-of-rebasing-in-git/) on the latest [`dev`](https://github.com/session-foundation/session-desktop/tree/dev) branch
- [x] A `pnpm ready` run passes successfully ([more about tests here](https://github.com/session-foundation/session-desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Fixes #545

Adds a `--disable-update-prompt` launch flag so package maintainers can suppress update prompts without changing the user's saved auto-update preference

The same disable check now gates updater startup and the readiness state used by manual and renderer-triggered checks, so those paths cannot bypass the flag

Tested with:

- `pnpm ready` (949 passing)
